### PR TITLE
fix(deploy): guard EC2 enrichment workers with Docker Compose profiles

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,21 +60,20 @@ jobs:
             CURR=$(git rev-parse HEAD)
             API_CHANGED=false
             WEB_CHANGED=false
-            WORKER_CHANGED=false
 
             if [ -n "$PREV" ]; then
               DIFF_FILES=$(git diff --name-only "$PREV" "$CURR" || true)
               echo "$DIFF_FILES" | grep -q '^services/api/' && API_CHANGED=true || true
               echo "$DIFF_FILES" | grep -q '^services/web/' && WEB_CHANGED=true || true
-              echo "$DIFF_FILES" | grep -qE '^services/drive-(stt|ocr|caption)-worker/' && WORKER_CHANGED=true || true
-              echo "$DIFF_FILES" | grep -qE '^(docker-compose\.yml|\.env\.example)' && API_CHANGED=true && WEB_CHANGED=true && WORKER_CHANGED=true || true
+
+              echo "$DIFF_FILES" | grep -qE '^(docker-compose\.yml|\.env\.example)' && API_CHANGED=true && WEB_CHANGED=true || true
             else
               API_CHANGED=true
               WEB_CHANGED=true
-              WORKER_CHANGED=true
+
             fi
 
-            echo "API changed: $API_CHANGED | Web changed: $WEB_CHANGED | Worker changed: $WORKER_CHANGED"
+            echo "API changed: $API_CHANGED | Web changed: $WEB_CHANGED"
 
             # ---- Build changed services ----
             if [ "$API_CHANGED" = true ]; then
@@ -111,16 +110,8 @@ jobs:
               sleep 5
             fi
 
-            # WARNING (2026-02-26): Enrichment workers (STT, OCR, Caption) have migrated to Aircloud+ GPU.
-            # This block rebuilds and restarts EC2 CPU enrichment containers, creating DUAL SQS consumers
-            # that compete with Aircloud+ workers. This is the #1 priority fix in housekeeping PR2.
-            # PR2 will remove this block entirely. Until then, deploys may cause brief message duplication.
-            if [ "$WORKER_CHANGED" = true ] || [ "$API_CHANGED" = true ]; then
-              echo "--- rebuilding and restarting enrichment workers ---"
-              docker compose build drive-stt-worker drive-ocr-worker drive-caption-worker
-              docker compose up -d --no-deps --force-recreate drive-stt-worker drive-ocr-worker drive-caption-worker
-              sleep 5
-            fi
+            # Enrichment workers (STT, OCR, Caption) run on Aircloud+ GPU since 2026-02-26.
+            # EC2 no longer builds or restarts them. See docs/housekeeping/01_cleanup_plan.md.
 
             # ---- Health checks (retry loop — Next.js cold start can take 30s+) ----
             echo "--- health checks ---"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,7 @@ services:
   # DEPRECATED (2026-02-26): face-worker is dead code — never ran in production.
   # Kept for reference only. Removal planned in PR4 (housekeeping).
   face-worker:
+    profiles: ["face-dev"]
     build:
       context: ./services/worker
       dockerfile: Dockerfile
@@ -265,8 +266,9 @@ services:
   # DEPRECATED (2026-02-26): OCR enrichment worker migrated to Aircloud+ GPU.
   # This CPU service definition is kept for local dev only.
   # Staging/prod uses ghcr.io/jlee-heimdex/heimdex-ocr-worker-gpu:latest on Aircloud+.
-  # PR2 will add 'profiles: [local-enrichment]' to prevent accidental startup.
+  # Guarded by profiles: ["ec2-legacy"] — requires --profile ec2-legacy to start.
   drive-ocr-worker:
+    profiles: ["ec2-legacy"]
     build:
       context: .
       dockerfile: services/drive-ocr-worker/Dockerfile
@@ -312,6 +314,7 @@ services:
   # Caption worker no longer uses HTTP-based llama backend (CAPTION_ENGINE=qwen2vl on Aircloud+).
   # Kept for local dev fallback only. Removal planned in PR2/PR4.
   llama-caption-server:
+    profiles: ["llama-caption"]
     build:
       context: ./services/llama-caption-server
       dockerfile: Dockerfile
@@ -345,8 +348,9 @@ services:
   # This CPU service definition is kept for local dev only.
   # Staging/prod uses ghcr.io/jlee-heimdex/heimdex-caption-worker-gpu:latest on Aircloud+.
   # Model: Qwen/Qwen2-VL-2B-Instruct (GPU) vs OpenGVLab/InternVL2-1B (CPU, below).
-  # PR2 will add 'profiles: [local-enrichment]' to prevent accidental startup.
+  # Guarded by profiles: ["ec2-legacy"] — requires --profile ec2-legacy to start.
   drive-caption-worker:
+    profiles: ["ec2-legacy"]
     build:
       context: .
       dockerfile: services/drive-caption-worker/Dockerfile
@@ -401,8 +405,9 @@ services:
   # This CPU service definition is kept for local dev only.
   # Staging/prod uses ghcr.io/jlee-heimdex/heimdex-stt-worker-gpu:latest on Aircloud+.
   # Model: turbo/cuda/float16 (GPU) vs small/cpu/int8 (CPU, below).
-  # PR2 will add 'profiles: [local-enrichment]' to prevent accidental startup.
+  # Guarded by profiles: ["ec2-legacy"] — requires --profile ec2-legacy to start.
   drive-stt-worker:
+    profiles: ["ec2-legacy"]
     build:
       context: .
       dockerfile: services/drive-stt-worker/Dockerfile
@@ -450,8 +455,9 @@ services:
 
   # NOTE (2026-02-26): elasticmq is for LOCAL DEV SQS simulation only.
   # Staging/prod uses real AWS SQS (ap-northeast-2). Not needed on EC2.
-  # EC2 still runs this container — removal planned in PR2.
+  # Guarded by profiles: ["local-dev"] — requires --profile local-dev to start.
   elasticmq:
+    profiles: ["local-dev"]
     image: softwaremill/elasticmq-native:latest
     container_name: heimdex-elasticmq
     mem_limit: 256m


### PR DESCRIPTION
## Summary

**Critical safety fix**: Prevents dual SQS consumer conflict between EC2 and Aircloud+ GPU workers.

Stacks on #3 (`docs/housekeeping-gpu-migration`).

## Problem

Every push to `main` triggered `deploy-staging.yml`, which rebuilt and restarted EC2 enrichment worker containers (STT, OCR, Caption). Since these workers migrated to Aircloud+ GPU, this creates **dual SQS consumers** competing for the same messages — causing duplicate processing and wasted compute.

## Solution

### deploy-staging.yml
- **Removed** `WORKER_CHANGED` detection logic (no longer needed)
- **Removed** enrichment worker build/restart block entirely
- Deploy now only manages: API, Web, and core infra (postgres, opensearch, etc.)

### docker-compose.yml — Profile Guards
Services are guarded by Docker Compose profiles so `docker compose up -d` only starts essential services:

| Service | Profile | Reason |
|---------|---------|--------|
| `drive-stt-worker` | `ec2-legacy` | Migrated to Aircloud+ GPU |
| `drive-ocr-worker` | `ec2-legacy` | Migrated to Aircloud+ GPU |
| `drive-caption-worker` | `ec2-legacy` | Migrated to Aircloud+ GPU |
| `face-worker` | `face-dev` | Dead code (sleep infinity) |
| `llama-caption-server` | `llama-caption` | Replaced by Qwen2-VL on Aircloud+ |
| `elasticmq` | `local-dev` | Only for local SQS simulation |

**Default services** (no profile needed): postgres, opensearch, minio, api, web, drive-worker

### heimdex-media-pipelines deploy-staging.yml
- Updated to only restart `drive-worker` (the one service that stays on EC2 and mounts pipelines)
- Removed enrichment worker restart loop

## Verification

- [x] `docker compose config` validates
- [x] `docker compose config --services` → postgres, opensearch, minio, api, web, drive-worker
- [x] `docker compose --profile ec2-legacy config --services` → adds 3 enrichment workers
- [x] `docker compose --profile local-dev config --services` → adds elasticmq
- [x] All 4 profiles together → all 12 services
- [x] `make check-coupling` passes
- [ ] `make test` — requires running containers (CI will verify)

## Post-Merge Manual Steps (EC2)

```bash
ssh -i ~/.ssh/heimdex-staging.pem ec2-user@3.34.75.63
cd /opt/heimdex/dev-heimdex-for-livecommerce
# After deploy runs, verify enrichment workers are NOT running:
docker ps --format '{{.Names}}' | grep -E 'stt|ocr|caption-worker'
# Expected: no output

# Also stop and remove stale containers manually:
docker compose stop llama-caption-server elasticmq face-worker 2>/dev/null || true
docker compose rm -f llama-caption-server elasticmq face-worker 2>/dev/null || true
```

## Also needs (separate repo)

`heimdex-media-pipelines/.github/workflows/deploy-staging.yml` was updated locally to only restart `drive-worker`. This change needs to be committed to the pipelines repo separately.