### PR TITLE
chore: remove deprecated poll interval fields from settings and config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,7 +242,7 @@ services:
       - DRIVE_PROXY_BUFSIZE=${DRIVE_PROXY_BUFSIZE:-5000k}
       - DRIVE_ENRICHMENT_ENABLED=${DRIVE_ENRICHMENT_ENABLED:-false}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      # SQS consumer configuration (Phase 2)
+      # SQS configuration
       - SQS_CONSUMER_ENABLED=${SQS_CONSUMER_ENABLED:-false}
       - SQS_ENDPOINT_URL=${SQS_ENDPOINT_URL:-}
       - SQS_REGION=${SQS_REGION:-ap-northeast-2}
@@ -290,7 +290,7 @@ services:
       - DRIVE_OCR_MAX_FRAMES_PER_SCENE=${DRIVE_OCR_MAX_FRAMES_PER_SCENE:-10}
       - DRIVE_OCR_MAX_FRAMES_PER_VIDEO=${DRIVE_OCR_MAX_FRAMES_PER_VIDEO:-300}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      # SQS consumer configuration (Phase 2)
+      # SQS configuration
       - SQS_CONSUMER_ENABLED=${SQS_CONSUMER_ENABLED:-false}
       - SQS_ENDPOINT_URL=${SQS_ENDPOINT_URL:-}
       - SQS_REGION=${SQS_REGION:-ap-northeast-2}
@@ -376,7 +376,7 @@ services:
       - HF_HOME=/data/huggingface
       - OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
       - MKL_NUM_THREADS=${MKL_NUM_THREADS:-2}
-      # SQS consumer configuration (Phase 2)
+      # SQS configuration
       - SQS_CONSUMER_ENABLED=${SQS_CONSUMER_ENABLED:-false}
       - SQS_ENDPOINT_URL=${SQS_ENDPOINT_URL:-}
       - SQS_REGION=${SQS_REGION:-ap-northeast-2}
@@ -429,7 +429,7 @@ services:
       - DRIVE_STT_CONCURRENCY=${DRIVE_STT_CONCURRENCY:-1}
       - DRIVE_STT_MAX_AUDIO_SECONDS=${DRIVE_STT_MAX_AUDIO_SECONDS:-3600}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      # SQS consumer configuration (Phase 2)
+      # SQS configuration
       - SQS_CONSUMER_ENABLED=${SQS_CONSUMER_ENABLED:-false}
       - SQS_ENDPOINT_URL=${SQS_ENDPOINT_URL:-}
       - SQS_REGION=${SQS_REGION:-ap-northeast-2}

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -133,7 +133,6 @@ class Settings(BaseSettings):
 
     # --- OCR enrichment worker ---
     drive_ocr_enabled: bool = False
-    drive_ocr_poll_interval_seconds: int = 30
     drive_ocr_concurrency: int = 1
     drive_ocr_max_frames_per_scene: int = 10
     drive_ocr_max_frames_per_video: int = 300
@@ -143,13 +142,11 @@ class Settings(BaseSettings):
     drive_stt_model: str = "turbo"
     drive_stt_language: str = "ko"
     drive_stt_backend: str = "faster-whisper"
-    drive_stt_poll_interval_seconds: int = 30
     drive_stt_concurrency: int = 1
     drive_stt_max_audio_seconds: int = 21600
 
     # --- Caption enrichment worker ---
     scene_caption_enabled: bool = False
-    drive_caption_poll_interval_seconds: int = 30
     drive_caption_concurrency: int = 1
     drive_caption_model: str = "Qwen/Qwen2-VL-2B-Instruct"
     caption_engine: str = "qwen2vl"  # "qwen2vl", "internvl2", "florence2", or "llama_http"
@@ -157,7 +154,7 @@ class Settings(BaseSettings):
     llama_caption_api_key: str = ""
 
 
-    # --- SQS (dormant — Phase 0) ---
+    # --- SQS (Phase 3 complete — enrichment workers are mandatory SQS consumers) ---
     sqs_enabled: bool = False
     sqs_endpoint_url: str = ""
     sqs_region: str = "ap-northeast-2"

--- a/services/worker_sdk/src/heimdex_worker_sdk/settings.py
+++ b/services/worker_sdk/src/heimdex_worker_sdk/settings.py
@@ -54,7 +54,6 @@ class WorkerSettings(BaseSettings):
 
     # --- Caption enrichment ---
     scene_caption_enabled: bool = False
-    drive_caption_poll_interval_seconds: int = 30  # DEPRECATED (Phase 3): enrichment workers use SQS only
     drive_caption_concurrency: int = 1
     drive_caption_model: str = "Qwen/Qwen2-VL-2B-Instruct"
     caption_engine: str = "qwen2vl"  # "qwen2vl", "internvl2", "florence2", or "llama_http"
@@ -66,19 +65,17 @@ class WorkerSettings(BaseSettings):
     drive_stt_model: str = "turbo"
     drive_stt_language: str = "ko"
     drive_stt_backend: str = "faster-whisper"
-    drive_stt_poll_interval_seconds: int = 30  # DEPRECATED (Phase 3): enrichment workers use SQS only
     drive_stt_concurrency: int = 1
     drive_stt_max_audio_seconds: int = 21600  # 6 hours; faster-whisper handles long audio natively
 
     # --- OCR enrichment ---
     drive_ocr_enabled: bool = False
-    drive_ocr_poll_interval_seconds: int = 30  # DEPRECATED (Phase 3): enrichment workers use SQS only
     drive_ocr_concurrency: int = 1
     drive_ocr_max_frames_per_scene: int = 10
     drive_ocr_max_frames_per_video: int = 300
 
 
-    # --- SQS (Phase 0 producer / Phase 2 consumer / Phase 3 mandatory for enrichment) ---
+    # --- SQS (Phase 3 complete — enrichment workers are mandatory SQS consumers) ---
     sqs_enabled: bool = False
     sqs_consumer_enabled: bool = False
     sqs_endpoint_url: str = ""


### PR DESCRIPTION
## Summary

Final housekeeping cleanup. Removes the deprecated poll interval field declarations from Python settings classes.

Stacks on #5 (`chore/remove-deprecated-poll-intervals`).

## What changed

### `services/worker_sdk/src/heimdex_worker_sdk/settings.py`
Removed 3 field declarations:
- `drive_caption_poll_interval_seconds: int = 30`
- `drive_stt_poll_interval_seconds: int = 30`
- `drive_ocr_poll_interval_seconds: int = 30`

### `services/api/app/config.py`
Removed same 3 field declarations from the API's `Settings` class.

### `docker-compose.yml`
Updated 4 stale `# SQS consumer configuration (Phase 2)` comments to `# SQS configuration` (SQS migration is Phase 3 complete).

## Why safe

- **PR3** already removed the docker-compose env var passthroughs
- **PR3** already removed the test assertions for these fields
- No runtime code references these fields (verified via grep)
- `drive_worker_poll_interval_seconds` is **kept** — drive-worker still uses it

## Verification

- [x] `docker compose config` validates
- [x] `make check-coupling` passes
- [x] LSP diagnostics clean on both settings.py and config.py
- [x] No grep matches for deprecated fields in service code
- [ ] `make test` — requires running containers (CI will verify)

## Full PR Stack

| PR | Title | Status |
|----|-------|--------|
| #3 | docs: housekeeping audit and deprecation notices | Ready |
| #4 | fix: guard EC2 enrichment workers with profiles | Ready |
| #5 | chore: remove deprecated poll intervals + apscheduler | Ready |
| **#6** | **chore: remove poll interval fields from settings** | **This PR** |