### PR TITLE
feat(analytics): add color search analytics (BQ + GA4)

### DIFF
--- a/services/api/app/modules/search/router.py
+++ b/services/api/app/modules/search/router.py
@@ -80,6 +80,10 @@ def _build_metadata(request: SearchRequest) -> dict[str, Any]:
         meta["person_cluster_ids"] = request.filters.person_cluster_ids
     if request.include_ocr is not None:
         meta["include_ocr"] = request.include_ocr
+    if request.color_family:
+        meta["color_family"] = request.color_family
+    elif request.color_hex:
+        meta["color_hex"] = request.color_hex
     return meta
 
 

--- a/services/web/src/app/layout.tsx
+++ b/services/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Providers } from "./providers";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { SceneBasketProvider } from "@/features/basket/useSceneBasket";
 import { BasketPanel } from "@/features/basket/BasketPanel";
+import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import "./globals.css";
 
 export const dynamic = "force-dynamic";
@@ -20,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-gray-50 text-gray-900 antialiased">
+        <GoogleAnalytics />
         <Providers>
           <SceneBasketProvider>
             <AppLayout>{children}</AppLayout>

--- a/services/web/src/components/GoogleAnalytics.tsx
+++ b/services/web/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Script from "next/script";
+import { GA_MEASUREMENT_ID } from "@/lib/analytics/gtag";
+
+/**
+ * Loads the GA4 gtag.js snippet.
+ * Renders nothing when NEXT_PUBLIC_GA_MEASUREMENT_ID is not set.
+ */
+export function GoogleAnalytics() {
+  if (!GA_MEASUREMENT_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', {
+            page_path: window.location.pathname,
+          });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/services/web/src/components/dashboard/DashboardContent.tsx
+++ b/services/web/src/components/dashboard/DashboardContent.tsx
@@ -18,6 +18,7 @@ import { DateRangeCalendar, isSameDay, isInRange, formatDateKr } from "@/compone
 import { OpenInDriveButton } from "@/components/OpenInDriveButton";
 import { useImageSelectionContext } from "@/features/images/ImageSelectionContext";
 import { parseSlashCommand, getSlashCommandSuggestions } from "@/lib/slash-commands";
+import { trackColorSearch, trackSearchPageView, trackSearchResultClick } from "@/lib/analytics/gtag";
 import { useOrgSettings } from "@/lib/orgSettings";
 import { getThumbnailAspectClass, getDashboardGridClass, type ThumbnailAspectRatio } from "@/lib/thumbnailUtils";
 import {
@@ -967,7 +968,13 @@ export default function DashboardContent({
             {!hideGroupByToggle && <GroupByToggle value={groupBy} onChange={setGroupBy} />}
             {contentType === "image" && (
               <div className="ml-1">
-                <ColorPicker value={colorFamily} onChange={setColorFamily} />
+                <ColorPicker
+                value={colorFamily}
+                onChange={(family) => {
+                  setColorFamily(family);
+                  if (family) trackColorSearch(family, !!query.trim());
+                }}
+              />
               </div>
             )}
             {!hideContentTypeToggle && (
@@ -1194,7 +1201,22 @@ export default function DashboardContent({
         {/* Results grid */}
         {!isLoading && hasResults && (
           <>
-            <div className={cn("mt-6 grid gap-5", getDashboardGridClass(aspectRatio))}>
+            <div
+              className={cn("mt-6 grid gap-5", getDashboardGridClass(aspectRatio))}
+              onClick={(e) => {
+                if (!isSearchMode) return;
+                const link = (e.target as HTMLElement).closest("a[href]") as HTMLAnchorElement | null;
+                if (!link) return;
+                const children = Array.from(e.currentTarget.children);
+                const idx = children.findIndex(child => child.contains(link));
+                if (idx < 0) return;
+                const videoId = link.pathname.split("/").pop() ?? "";
+                trackSearchResultClick({
+                  pageNumber: currentPage, position: idx + 1,
+                  colorFamily, query: activeQuery, videoId,
+                });
+              }}
+            >
               {isSearchMode
                 ? searchResponse?.result_type === "video"
                   ? (paginatedResults as VideoResult[]).map((video) => (
@@ -1212,13 +1234,20 @@ export default function DashboardContent({
               <Pagination
                 currentPage={currentPage}
                 totalPages={totalPages}
-                onPageChange={setCurrentPage}
+                onPageChange={(page) => {
+                  setCurrentPage(page);
+                  trackSearchPageView({ pageNumber: page, colorFamily, query: activeQuery });
+                }}
               />
             ) : hasMore ? (
               <div className="mt-8 flex justify-center">
                 <button
                   type="button"
-                  onClick={loadMore}
+                  onClick={() => {
+                    loadMore();
+                    const nextPage = Math.ceil(videos.length / PAGE_SIZE) + 1;
+                    trackSearchPageView({ pageNumber: nextPage, colorFamily, query: activeQuery });
+                  }}
                   disabled={isLoadingMore}
                   className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
                 >

--- a/services/web/src/lib/analytics/gtag.ts
+++ b/services/web/src/lib/analytics/gtag.ts
@@ -1,0 +1,71 @@
+/**
+ * GA4 (gtag.js) helper — thin wrapper over window.gtag().
+ *
+ * Measurement ID is read from NEXT_PUBLIC_GA_MEASUREMENT_ID.
+ * When the env var is empty the helpers become no-ops,
+ * so the rest of the codebase can call them unconditionally.
+ */
+
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? "";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+    dataLayer?: any[];
+  }
+}
+
+function gtag(...args: any[]) {
+  if (typeof window === "undefined" || !window.gtag) return;
+  window.gtag(...args);
+}
+
+// ---------------------------------------------------------------------------
+// Page view (auto-tracked by gtag.js, but exposed for SPA route changes)
+// ---------------------------------------------------------------------------
+export function pageview(url: string) {
+  gtag("config", GA_MEASUREMENT_ID, { page_path: url });
+}
+
+// ---------------------------------------------------------------------------
+// Color search events
+// ---------------------------------------------------------------------------
+
+/** Fired when user selects a color family chip. */
+export function trackColorSearch(colorFamily: string, hasQuery: boolean) {
+  gtag("event", "color_search", {
+    color_family: colorFamily,
+    has_query: String(hasQuery),
+  });
+}
+
+/** Fired when user navigates to a new page of search results (pagination / "더보기"). */
+export function trackSearchPageView(params: {
+  pageNumber: number;
+  colorFamily?: string;
+  query?: string;
+}) {
+  gtag("event", "search_page_view", {
+    page_number: params.pageNumber,
+    color_family: params.colorFamily ?? "",
+    query: params.query ?? "",
+  });
+}
+
+/** Fired when user clicks a search result. */
+export function trackSearchResultClick(params: {
+  pageNumber: number;
+  position: number;
+  colorFamily?: string;
+  query?: string;
+  videoId?: string;
+}) {
+  gtag("event", "search_result_click", {
+    page_number: params.pageNumber,
+    position: params.position,
+    color_family: params.colorFamily ?? "",
+    query: params.query ?? "",
+    video_id: params.videoId ?? "",
+  });
+}


### PR DESCRIPTION
  ## Summary
  - `_build_metadata()`에 color_family/color_hex 추가하여 BQ 색상 검색 이벤트 수집
  - GA4 gtag 인프라 추가 (GoogleAnalytics 컴포넌트 + gtag.ts 헬퍼)
  - color_search, search_page_view, search_result_click 이벤트 코드 추가
  - BQ 스키마 문서: t_search_filter_usage 수정 + 신규 6개 테이블
  - Looker 가이드 문서: Page 4 수정 + Page 7 Color Search Analysis

  ## 추후  작업 필요
  - [ ] GA4 속성 생성 + Measurement ID 발급
  - [ ] staging/production에 `NEXT_PUBLIC_GA_MEASUREMENT_ID` 환경변수 설정 후 web 리빌드
  - [ ] GA4 → BQ Export 활성화 > 박지석
  - [ ] BQ Scheduled Query 6개 등록 (SQL은 SEARCH_ANALYTICS_BQ_SCHEMA.md 참고) > 박지석

  ## 참고
  - GA4 Measurement ID 미설정 시 모든 이벤트 코드는 no-op (기존 동작 영향 없음)
  - DashboardContent DOM 구조 변경 없음 (그리드 onClick 이벤트 위임만 추가)