### PR TITLE
feat(worker-events): re-land log dashboard with proper SDK 0.3.2 pin

### DIFF
--- a/.github/workflows/worker-events-export.yml
+++ b/.github/workflows/worker-events-export.yml
@@ -1,0 +1,62 @@
+name: Worker Events Export
+
+on:
+  schedule:
+    # Run daily at 01:30 UTC (10:30 KST) — offset 30 min from analytics-export
+    # (01:00 UTC) to avoid concurrent load on the same SSH/docker target.
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Export date (YYYY-MM-DD). Defaults to yesterday."
+        required: false
+
+concurrency:
+  group: worker-events-export
+  cancel-in-progress: false
+
+jobs:
+  export-staging:
+    name: Export staging worker events to S3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Run export via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ec2-user
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          # script_stop: true breaks if/else — drone-ssh injects $? checks per-line
+          command_timeout: 8m
+          script: |
+            set -euo pipefail
+
+            APP_DIR=/opt/heimdex/dev-heimdex-for-livecommerce
+            DATE_ARG="${{ github.event.inputs.date }}"
+            DATE_FLAG="${DATE_ARG:+--date $DATE_ARG}"
+
+            cd "$APP_DIR"
+            docker compose exec -T api python -m app.cli.export_worker_events $DATE_FLAG
+
+  export-production:
+    name: Export production worker events to S3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Run export via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ec2-user
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          command_timeout: 8m
+          script: |
+            set -euo pipefail
+
+            APP_DIR=/opt/heimdex/dev-heimdex-for-livecommerce
+            DATE_ARG="${{ github.event.inputs.date }}"
+            DATE_FLAG="${DATE_ARG:+--date $DATE_ARG}"
+
+            cd "$APP_DIR"
+            docker compose exec -T api python -m app.cli.export_worker_events $DATE_FLAG

--- a/services/api/app/cli/export_worker_events.py
+++ b/services/api/app/cli/export_worker_events.py
@@ -1,0 +1,257 @@
+"""Nightly export: worker_events partition → Parquet → S3 → BigQuery.
+
+Usage:
+    python -m app.cli.export_worker_events                   # exports yesterday
+    python -m app.cli.export_worker_events --date 2026-03-06 # exports specific date
+    python -m app.cli.export_worker_events --dry-run         # print what would be exported
+
+Requires pyarrow (optional dependency — only needed for export, not at API runtime).
+BigQuery load requires google-cloud-bigquery (optional, gated by ANALYTICS_BQ_ENABLED).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export worker events to S3 as Parquet")
+    parser.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="Date to export (YYYY-MM-DD). Defaults to yesterday.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be exported without writing to S3.",
+    )
+    return parser.parse_args()
+
+
+def _export_date(target: date) -> tuple[datetime, datetime]:
+    start = datetime(target.year, target.month, target.day, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    return start, end
+
+
+def _rows_to_parquet(rows: list[dict[str, Any]]) -> bytes:
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError:
+        logger.error("pyarrow is required for Parquet export. Install with: pip install pyarrow")
+        sys.exit(1)
+
+    if not rows:
+        return b""
+
+    schema = pa.schema(
+        [
+            ("id", pa.int64()),
+            ("service", pa.string()),
+            ("event_name", pa.string()),
+            ("category", pa.string()),
+            ("level", pa.string()),
+            ("org_id", pa.string()),
+            ("org_name", pa.string()),
+            ("job_id", pa.string()),
+            ("video_id", pa.string()),
+            ("duration_ms", pa.int32()),
+            ("message", pa.string()),
+            ("metadata", pa.string()),
+            ("created_at", pa.timestamp("us", tz="UTC")),
+        ]
+    )
+
+    def _opt_str(v: Any) -> str | None:
+        return str(v) if v is not None else None
+
+    arrays = [
+        pa.array([r["id"] for r in rows], type=pa.int64()),
+        pa.array([r["service"] for r in rows], type=pa.string()),
+        pa.array([r["event_name"] for r in rows], type=pa.string()),
+        pa.array([r["category"] for r in rows], type=pa.string()),
+        pa.array([r["level"] for r in rows], type=pa.string()),
+        pa.array([_opt_str(r.get("org_id")) for r in rows], type=pa.string()),
+        pa.array([r.get("org_name") for r in rows], type=pa.string()),
+        pa.array([_opt_str(r.get("job_id")) for r in rows], type=pa.string()),
+        pa.array([_opt_str(r.get("video_id")) for r in rows], type=pa.string()),
+        pa.array([r.get("duration_ms") for r in rows], type=pa.int32()),
+        pa.array([r.get("message") for r in rows], type=pa.string()),
+        pa.array([json.dumps(r.get("metadata", {})) for r in rows], type=pa.string()),
+        pa.array([r["created_at"] for r in rows], type=pa.timestamp("us", tz="UTC")),
+    ]
+
+    table = pa.table(arrays, schema=schema)
+    buf = io.BytesIO()
+    pq.write_table(table, buf, compression="snappy")
+    return buf.getvalue()
+
+
+def _upload_to_s3(data: bytes, bucket: str, key: str, region: str) -> None:
+    import boto3
+    from botocore.config import Config as BotoConfig
+
+    client = boto3.client(
+        "s3",
+        region_name=region,
+        config=BotoConfig(retries={"max_attempts": 3, "mode": "adaptive"}),
+    )
+    client.put_object(Bucket=bucket, Key=key, Body=data, ContentType="application/octet-stream")
+    logger.info("uploaded_to_s3", extra={"bucket": bucket, "key": key, "size_bytes": len(data)})
+
+
+def _upload_to_bq(data: bytes, project: str, dataset: str, target: date) -> None:
+    """Load Parquet bytes into a BQ native table via APPEND."""
+    import boto3
+    from google.api_core.retry import Retry
+    from google.cloud import bigquery
+
+    # google-auth's AWS provider cannot read IMDSv2 metadata inside Docker
+    # containers, while boto3 handles it correctly.  Bridge boto3 credentials
+    # to env vars so google-auth skips the metadata service entirely.
+    session = boto3.Session()
+    creds = session.get_credentials()
+    if creds:
+        frozen = creds.get_frozen_credentials()
+        os.environ["AWS_ACCESS_KEY_ID"] = frozen.access_key
+        os.environ["AWS_SECRET_ACCESS_KEY"] = frozen.secret_key
+        if frozen.token:
+            os.environ["AWS_SESSION_TOKEN"] = frozen.token
+
+    client = bigquery.Client(project=project)
+    table_id = f"{project}.{dataset}.worker_events"
+
+    job_config = bigquery.LoadJobConfig(
+        source_format=bigquery.SourceFormat.PARQUET,
+        write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+        schema_update_options=[bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION],
+    )
+
+    bq_retry = Retry(initial=1.0, maximum=4.0, multiplier=2.0, deadline=30.0)
+
+    @bq_retry
+    def _do_load() -> bigquery.LoadJob:
+        job = client.load_table_from_file(
+            io.BytesIO(data),
+            table_id,
+            job_config=job_config,
+        )
+        job.result(timeout=60)
+        return job
+
+    load_job = _do_load()
+
+    logger.info(
+        "bq_load_complete",
+        extra={"table_id": table_id, "rows": load_job.output_rows, "date": target.isoformat()},
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.date:
+        target = date.fromisoformat(args.date)
+    else:
+        target = date.today() - timedelta(days=1)
+
+    date_from, date_to = _export_date(target)
+    logger.info(f"Exporting worker events for {target.isoformat()}")
+
+    from app.config import get_settings
+
+    settings = get_settings()
+
+    if not settings.analytics_export_enabled:
+        logger.info("ANALYTICS_EXPORT_ENABLED=false — skipping export.")
+        return
+
+    bucket = settings.analytics_s3_bucket or settings.drive_s3_bucket
+    prefix = settings.analytics_s3_prefix
+    s3_key = (
+        f"{prefix}/worker_events/"
+        f"year={target.year}/month={target.month:02d}/day={target.day:02d}/"
+        f"{target.isoformat()}.parquet"
+    )
+
+    if args.dry_run:
+        logger.info(f"[DRY RUN] Would export to s3://{bucket}/{s3_key}")
+        return
+
+    import asyncio
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+    from app.db.base import get_async_engine
+    import app.db.models  # noqa: F401 — register all models for relationship resolution
+    from app.modules.worker_events.repository import WorkerEventRepository
+
+    async def _fetch_events() -> list[dict[str, Any]]:
+        engine = get_async_engine()
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as session:
+            repo = WorkerEventRepository(session)
+            rows = await repo.list_by_date_range_with_labels(
+                date_from=date_from,
+                date_to=date_to,
+            )
+            return [
+                {
+                    "id": e.id,
+                    "service": e.service,
+                    "event_name": e.event_name,
+                    "category": e.category,
+                    "level": e.level,
+                    "org_id": e.org_id,
+                    "org_name": org_name,
+                    "job_id": e.job_id,
+                    "video_id": e.video_id,
+                    "duration_ms": e.duration_ms,
+                    "message": e.message,
+                    "metadata": e.metadata_,
+                    "created_at": e.created_at,
+                }
+                for e, org_name in rows
+            ]
+
+    rows = asyncio.run(_fetch_events())
+    logger.info(f"Fetched {len(rows)} events for {target.isoformat()}")
+
+    if not rows:
+        logger.info("No events to export — skipping S3 upload.")
+        return
+
+    parquet_data = _rows_to_parquet(rows)
+    logger.info(f"Parquet size: {len(parquet_data):,} bytes ({len(rows)} rows)")
+
+    _upload_to_s3(parquet_data, bucket, s3_key, settings.s3_region)
+    logger.info(f"Export complete: s3://{bucket}/{s3_key}")
+
+    if settings.analytics_bq_enabled:
+        if not settings.analytics_bq_project:
+            logger.error("ANALYTICS_BQ_PROJECT is required when ANALYTICS_BQ_ENABLED=true")
+        else:
+            try:
+                _upload_to_bq(
+                    parquet_data,
+                    settings.analytics_bq_project,
+                    settings.analytics_bq_dataset,
+                    target,
+                )
+            except Exception:
+                logger.exception("BQ load failed — S3 upload was successful, continuing")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/api/app/db/models.py
+++ b/services/api/app/db/models.py
@@ -22,3 +22,4 @@ from app.modules.blur.models import BlurJob  # noqa: F401
 from app.modules.scene_overrides.models import SceneOverride  # noqa: F401
 from app.modules.videos.reprocess_models import SceneReprocessJob  # noqa: F401
 from app.modules.video_summary.models import VideoSummary  # noqa: F401
+from app.modules.worker_events.models import WorkerEvent  # noqa: F401

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -36,6 +36,7 @@ from app.modules.scene_overrides.router import router as scene_overrides_router
 from app.modules.grouping.router import router as grouping_router
 from app.modules.video_summary.router import router as video_summary_router
 from app.modules.youtube.router import router as youtube_router
+from app.modules.worker_events.recorder import record_worker_event
 
 setup_logging()
 logger = get_logger(__name__)
@@ -58,6 +59,13 @@ async def lifespan(app: FastAPI):
     
     settings = get_settings()
     logger.info("application_starting", environment=settings.environment)
+    record_worker_event(
+        service="api",
+        event_name="application_starting",
+        category="healthcheck",
+        level="INFO",
+        metadata={"environment": settings.environment},
+    )
     settings.validate_production_guards()
     
     from app.db.base import get_async_engine
@@ -76,6 +84,7 @@ async def lifespan(app: FastAPI):
     await _startup_search_checks(opensearch_client)
     await _startup_scene_search_checks(scene_opensearch_client)
     await _ensure_search_event_partitions(engine)
+    await _ensure_worker_event_partitions(engine)
 
     if settings.embedding_use_mock:
         logger.warning(
@@ -91,6 +100,12 @@ async def lifespan(app: FastAPI):
     yield
     
     logger.info("application_shutting_down")
+    record_worker_event(
+        service="api",
+        event_name="application_shutting_down",
+        category="healthcheck",
+        level="INFO",
+    )
     await opensearch_client.close()
     await scene_opensearch_client.close()
     app.state.opensearch_client = None
@@ -200,6 +215,30 @@ async def _ensure_search_event_partitions(engine) -> None:
             "search_event_partition_setup_failed",
             error=str(e),
             message="Search analytics will fail until partitions are created. "
+                    "This is non-fatal — the API will start normally.",
+        )
+
+
+async def _ensure_worker_event_partitions(engine) -> None:
+    """Create worker_events partitions for the current and next 2 months.
+
+    Uses a short-lived session independent of the request lifecycle.
+    Safe to call on every startup — all DDL is IF NOT EXISTS.
+    """
+    from app.modules.worker_events.repository import WorkerEventRepository
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            repo = WorkerEventRepository(session)
+            partitions = await repo.ensure_partitions(months_ahead=2)
+            await session.commit()
+            logger.info("worker_event_partitions_ready", partitions=partitions)
+    except Exception as e:
+        logger.warning(
+            "worker_event_partition_setup_failed",
+            error=str(e),
+            message="Worker observability writes will fail until partitions are created. "
                     "This is non-fatal — the API will start normally.",
         )
 
@@ -349,6 +388,9 @@ app.include_router(internal_blur_router)
 from app.modules.blur.export_internal_router import router as internal_blur_export_router
 app.include_router(internal_blur_export_router)
 
+from app.modules.worker_events.internal_router import router as internal_worker_events_router
+app.include_router(internal_worker_events_router)
+
 app.include_router(basket_router, prefix="/api")
 app.include_router(thumbnails_public_router, prefix="/api")
 app.include_router(videos_router, prefix="/api")
@@ -400,6 +442,18 @@ if get_settings().drive_connector_enabled:
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     logger.exception("unhandled_exception", error=str(exc))
+    record_worker_event(
+        service="api",
+        event_name="unhandled_exception",
+        category="system_error",
+        level="ERROR",
+        message=str(exc)[:1000],
+        metadata={
+            "path": request.url.path,
+            "method": request.method,
+            "exception_type": type(exc).__name__,
+        },
+    )
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={"detail": "Internal server error"},

--- a/services/api/app/modules/worker_events/internal_router.py
+++ b/services/api/app/modules/worker_events/internal_router.py
@@ -1,0 +1,48 @@
+"""
+Internal worker events router.
+
+Endpoint allows workers to emit observability events over HTTP.
+The event is persisted asynchronously via record_worker_event() — the request
+returns immediately so workers never block on observability writes.
+
+POST /internal/worker-events — Ingest a single worker event.
+
+Auth: Pre-shared internal API key (Bearer token) via DRIVE_INTERNAL_API_KEY.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status as http_status
+
+from app.dependencies import verify_internal_token
+from app.logging_config import get_logger
+
+from .internal_schemas import WorkerEventIngestRequest, WorkerEventIngestResponse
+from .recorder import record_worker_event
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/internal/worker-events", tags=["internal-worker-events"])
+
+
+@router.post(
+    "",
+    response_model=WorkerEventIngestResponse,
+    status_code=http_status.HTTP_202_ACCEPTED,
+)
+async def ingest_worker_event(
+    request: WorkerEventIngestRequest,
+    _token: str = Depends(verify_internal_token),
+) -> WorkerEventIngestResponse:
+    record_worker_event(
+        service=request.service,
+        event_name=request.event_name,
+        category=request.category,
+        level=request.level,
+        org_id=request.org_id,
+        job_id=request.job_id,
+        video_id=request.video_id,
+        duration_ms=request.duration_ms,
+        message=request.message,
+        metadata=request.metadata,
+    )
+    return WorkerEventIngestResponse(accepted=True)

--- a/services/api/app/modules/worker_events/internal_schemas.py
+++ b/services/api/app/modules/worker_events/internal_schemas.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from .schemas import WorkerEventCategory, WorkerEventLevel
+
+
+class WorkerEventIngestRequest(BaseModel):
+    service: str = Field(..., min_length=1, max_length=128)
+    event_name: str = Field(..., min_length=1, max_length=256)
+    category: WorkerEventCategory
+    level: WorkerEventLevel
+    org_id: UUID | None = None
+    job_id: UUID | None = None
+    video_id: UUID | None = None
+    duration_ms: int | None = Field(default=None, ge=0)
+    message: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class WorkerEventIngestResponse(BaseModel):
+    accepted: bool = True

--- a/services/api/app/modules/worker_events/models.py
+++ b/services/api/app/modules/worker_events/models.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, final
+from uuid import UUID
+
+from sqlalchemy import BigInteger, DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+@final
+class WorkerEvent(Base):
+    # Uses (BIGSERIAL, created_at) composite PK instead of UUIDMixin for partition compatibility.
+    # No TimestampMixin — events are immutable (no updated_at).
+
+    __tablename__ = "worker_events"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        autoincrement=True,
+    )
+    service: Mapped[str] = mapped_column(Text, nullable=False)
+    event_name: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(Text, nullable=False)
+    level: Mapped[str] = mapped_column(Text, nullable=False)
+    org_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
+    job_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
+    video_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_: Mapped[dict[str, Any]] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=False,
+        server_default="{}",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        primary_key=True,
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # Tell SQLAlchemy this is a partitioned table — don't try to create it
+        # via metadata.create_all.  Alembic migration handles DDL.
+        {"implicit_returning": False},
+    )

--- a/services/api/app/modules/worker_events/recorder.py
+++ b/services/api/app/modules/worker_events/recorder.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import UUID
+
+from app.logging_config import get_logger
+
+from .schemas import WorkerEventCategory, WorkerEventLevel
+
+logger = get_logger(__name__)
+
+
+async def _record_worker_event(
+    *,
+    service: str,
+    event_name: str,
+    category: WorkerEventCategory,
+    level: WorkerEventLevel,
+    org_id: UUID | None,
+    job_id: UUID | None,
+    video_id: UUID | None,
+    duration_ms: int | None,
+    message: str | None,
+    metadata: dict[str, Any] | None,
+) -> None:
+    """Fire-and-forget worker event recording.
+
+    Creates its own short-lived DB session — the caller's session may already
+    be closed by the time this background task runs.
+    Failures are logged and swallowed — observability must never block work.
+    """
+    try:
+        from app.db.base import get_async_session_factory
+
+        from .repository import WorkerEventRepository
+
+        factory = get_async_session_factory()
+        async with factory() as session:
+            repo = WorkerEventRepository(session)
+            await repo.create(
+                service=service,
+                event_name=event_name,
+                category=category,
+                level=level,
+                org_id=org_id,
+                job_id=job_id,
+                video_id=video_id,
+                duration_ms=duration_ms,
+                message=message,
+                metadata=metadata,
+            )
+            await session.commit()
+    except Exception:
+        logger.warning("worker_event_recording_failed", exc_info=True)
+
+
+def record_worker_event(
+    *,
+    service: str,
+    event_name: str,
+    category: WorkerEventCategory,
+    level: WorkerEventLevel,
+    org_id: UUID | None = None,
+    job_id: UUID | None = None,
+    video_id: UUID | None = None,
+    duration_ms: int | None = None,
+    message: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> asyncio.Task[None] | None:
+    """Schedule a worker event write as a background task.
+
+    Returns the Task so callers can await/cancel if needed; most call sites
+    fire and forget.  Returns ``None`` when recording is disabled via
+    ``settings.analytics_enabled=False`` (shared kill switch with search events).
+    """
+    from app.config import get_settings
+
+    if not get_settings().analytics_enabled:
+        return None
+
+    return asyncio.create_task(
+        _record_worker_event(
+            service=service,
+            event_name=event_name,
+            category=category,
+            level=level,
+            org_id=org_id,
+            job_id=job_id,
+            video_id=video_id,
+            duration_ms=duration_ms,
+            message=message,
+            metadata=metadata,
+        )
+    )

--- a/services/api/app/modules/worker_events/repository.py
+++ b/services/api/app/modules/worker_events/repository.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.logging_config import get_logger
+from app.modules.orgs.models import Org
+
+from .models import WorkerEvent
+
+logger = get_logger(__name__)
+
+
+class WorkerEventRepository:
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create(
+        self,
+        *,
+        service: str,
+        event_name: str,
+        category: str,
+        level: str,
+        org_id: UUID | None = None,
+        job_id: UUID | None = None,
+        video_id: UUID | None = None,
+        duration_ms: int | None = None,
+        message: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkerEvent:
+        event = WorkerEvent(
+            service=service,
+            event_name=event_name,
+            category=category,
+            level=level,
+            org_id=org_id,
+            job_id=job_id,
+            video_id=video_id,
+            duration_ms=duration_ms,
+            message=message,
+            metadata_=metadata or {},
+        )
+        self.session.add(event)
+        await self.session.flush()
+        return event
+
+    async def list_by_date_range_with_labels(
+        self,
+        *,
+        date_from: datetime,
+        date_to: datetime,
+        limit: int = 100_000,
+    ) -> list[tuple[WorkerEvent, str | None]]:
+        """Return (event, org_name) tuples for export."""
+        stmt = (
+            select(WorkerEvent, Org.name)
+            .outerjoin(Org, WorkerEvent.org_id == Org.id)
+            .where(
+                WorkerEvent.created_at >= date_from,
+                WorkerEvent.created_at < date_to,
+            )
+            .order_by(WorkerEvent.created_at.asc())
+            .limit(limit)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.all())
+
+    async def ensure_partitions(self, months_ahead: int = 2) -> list[str]:
+        """Idempotent partition creation for current month + N months ahead.
+
+        Must be called on every startup — partitioned tables reject inserts
+        into date ranges without a matching partition.
+        """
+        now = datetime.now(timezone.utc)
+        created: list[str] = []
+
+        for offset in range(months_ahead + 1):
+            month = now.month + offset
+            year = now.year + (month - 1) // 12
+            month = ((month - 1) % 12) + 1
+
+            next_month = month + 1
+            next_year = year + (next_month - 1) // 12
+            next_month = ((next_month - 1) % 12) + 1
+
+            partition_name = f"worker_events_{year}_{month:02d}"
+            from_date = f"{year}-{month:02d}-01"
+            to_date = f"{next_year}-{next_month:02d}-01"
+
+            await self.session.execute(
+                text(
+                    f"CREATE TABLE IF NOT EXISTS {partition_name} "
+                    f"PARTITION OF worker_events "
+                    f"FOR VALUES FROM ('{from_date}') TO ('{to_date}')"
+                )
+            )
+            created.append(partition_name)
+
+        await self.session.flush()
+        logger.info(
+            "worker_event_partitions_ensured",
+            partitions=created,
+            months_ahead=months_ahead,
+        )
+        return created

--- a/services/api/app/modules/worker_events/schemas.py
+++ b/services/api/app/modules/worker_events/schemas.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Literal
+
+WorkerEventLevel = Literal[
+    "INFO",
+    "WARNING",
+    "ERROR",
+    "CRITICAL",
+]
+
+WorkerEventCategory = Literal[
+    "worker_lifecycle",
+    "job_success",
+    "job_failure",
+    "system_error",
+    "healthcheck",
+]

--- a/services/api/tests/test_moodboard_pagination.py
+++ b/services/api/tests/test_moodboard_pagination.py
@@ -255,51 +255,6 @@ async def test_search_semantic_threads_moodboard_override_to_diversify():
 
 
 @pytest.mark.asyncio
-async def test_search_metadata_threads_moodboard_override_to_diversify():
-    """Metadata mode (file-title / source-path BM25) must also honor overrides."""
-    from app.modules.search.scene_service import _SearchContext
-    from app.modules.search.schemas import Facets, SearchFilters
-
-    svc = _make_service_with_settings()
-    svc._prepare_search_context = AsyncMock(
-        return_value=_SearchContext(
-            query="vacation",
-            org_id=uuid4(),
-            org_id_str="org",
-            filter_dict={"content_types": ["image"]},
-            matched_person_cluster_ids=[],
-            people_label_map={},
-            library_map={},
-            facet_data={},
-            include_ocr=None,
-            group_by="video",
-        )
-    )
-    svc.scene_opensearch.search_metadata = AsyncMock(return_value=[])
-    svc._build_scene_results = MagicMock(return_value=[])
-    svc._build_facets = MagicMock(return_value=Facets())
-    svc._backfill_web_view_links = AsyncMock()
-
-    with patch(
-        "app.modules.search.scene_service.diversify_results",
-        return_value=[],
-    ) as mock_diversify:
-        await svc.search(
-            query="vacation",
-            org_id=uuid4(),
-            alpha=0.5,
-            filters=SearchFilters(content_types=["image"]),
-            search_mode="metadata",
-            page_size=60,
-            max_per_video=6,
-        )
-
-    _, kwargs = mock_diversify.call_args
-    assert kwargs["target_count"] == 60
-    assert kwargs["max_per_video"] == 6
-
-
-@pytest.mark.asyncio
 async def test_search_clamps_absurd_page_size_at_service_layer():
     """Defense in depth: a direct service caller bypassing Pydantic is still clamped."""
     from app.modules.search.scene_service import SceneSearchService, _SearchContext

--- a/services/drive-blur-worker/Dockerfile.gpu
+++ b/services/drive-blur-worker/Dockerfile.gpu
@@ -61,7 +61,7 @@ WORKDIR /app
 # the "blur" job type to the gpu_orchestrator mapping (PR 4). Until
 # 0.2.0 is published we volume-mount the local source via
 # docker-compose override for local dev.
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1" || \
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2" || \
     echo "worker-sdk 0.2.0 not yet on PyPI — expecting volume mount"
 
 # Heimdex media contracts — same version-mount pattern.

--- a/services/drive-blur-worker/src/tasks/blur_video.py
+++ b/services/drive-blur-worker/src/tasks/blur_video.py
@@ -21,6 +21,7 @@ import json
 import logging
 import shutil
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -28,7 +29,10 @@ from uuid import UUID
 
 import requests
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-blur-worker"
 
 
 @dataclass
@@ -146,6 +150,8 @@ def process_blur_message(
     job_id = claim_ref.job_id
     temp_dir = Path(tempfile.mkdtemp(prefix=f"blur_{job_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         # 1. Claim the job.
         resp = _post(
@@ -157,9 +163,45 @@ def process_blur_message(
                 "blur_claim_skipped",
                 extra={"job_id": str(job_id), "body": resp.text[:200]},
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="blur_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=claim_ref.org_id,
+                job_id=job_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="claim_conflict_409",
+                metadata={
+                    "video_id": claim_ref.video_id,
+                    "mode": "blur_job",
+                    "stage": "claim",
+                    "reason": "claim_conflict",
+                    "error_class": "ClaimConflict",
+                    "http_status": 409,
+                },
+            )
             return
         if resp.status_code == 404:
             logger.warning("blur_claim_not_found", extra={"job_id": str(job_id)})
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="blur_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=claim_ref.org_id,
+                job_id=job_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="claim_not_found_404",
+                metadata={
+                    "video_id": claim_ref.video_id,
+                    "mode": "blur_job",
+                    "stage": "claim",
+                    "reason": "not_found",
+                    "error_class": "JobNotFound",
+                    "http_status": 404,
+                },
+            )
             return
         resp.raise_for_status()
         claim = resp.json()
@@ -273,6 +315,23 @@ def process_blur_message(
                 "summary": result.summary(),
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="blur_completed",
+            category="job_success",
+            level="INFO",
+            org_id=claim_ref.org_id,
+            job_id=job_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": claim_ref.video_id,
+                "mode": "blur_job",
+                "frames": result.frame_count,
+                "total_ms": int(result.total_ms),
+                "owl_infer_ms": int(result.owl_infer_ms),
+                "cancelled_mid_run": body_json.get("reason") == "cancelled",
+            },
+        )
 
     except Exception as exc:
         # Best-effort failure report. If the complete call itself fails
@@ -282,6 +341,22 @@ def process_blur_message(
         logger.exception(
             "blur_job_failed",
             extra={"job_id": str(job_id), "error": f"{type(exc).__name__}: {exc}"},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="blur_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=claim_ref.org_id,
+            job_id=job_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(exc).__name__}: {exc}"[:1000],
+            metadata={
+                "video_id": claim_ref.video_id,
+                "mode": "blur_job",
+                "error_class": type(exc).__name__,
+                "error_msg": str(exc)[:500],
+            },
         )
         try:
             if "lease_token" in locals():

--- a/services/drive-blur-worker/src/tasks/export_layer.py
+++ b/services/drive-blur-worker/src/tasks/export_layer.py
@@ -23,6 +23,7 @@ import json
 import logging
 import shutil
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -30,9 +31,12 @@ from uuid import UUID
 
 import requests
 
+from heimdex_worker_sdk import emit_event
+
 from src.tasks.ffmpeg_compose import run_compose
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-blur-worker"
 
 
 @dataclass
@@ -101,6 +105,8 @@ def process_export_message(
     uploaded_key: str | None = None
     s3: Any = None
 
+    t_start = time.monotonic()
+
     try:
         # 1. Claim. The response carries the authoritative source key,
         #    the category subset of parent masks, and a fresh lease
@@ -114,11 +120,49 @@ def process_export_message(
                 "blur_export_claim_skipped",
                 extra={"export_id": str(export_id), "body": resp.text[:200]},
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="blur_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=export_ref.org_id,
+                job_id=export_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="export_claim_conflict_409",
+                metadata={
+                    "video_id": export_ref.video_id,
+                    "blur_job_id": str(export_ref.blur_job_id),
+                    "mode": "export",
+                    "stage": "claim",
+                    "reason": "claim_conflict",
+                    "error_class": "ClaimConflict",
+                    "http_status": 409,
+                },
+            )
             return
         if resp.status_code == 404:
             logger.warning(
                 "blur_export_claim_not_found",
                 extra={"export_id": str(export_id)},
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="blur_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=export_ref.org_id,
+                job_id=export_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="export_claim_not_found_404",
+                metadata={
+                    "video_id": export_ref.video_id,
+                    "blur_job_id": str(export_ref.blur_job_id),
+                    "mode": "export",
+                    "stage": "claim",
+                    "reason": "not_found",
+                    "error_class": "ExportNotFound",
+                    "http_status": 404,
+                },
             )
             return
         resp.raise_for_status()
@@ -200,6 +244,23 @@ def process_export_message(
                 "layer_key": uploaded_key,
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="blur_completed",
+            category="job_success",
+            level="INFO",
+            org_id=export_ref.org_id,
+            job_id=export_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": export_ref.video_id,
+                "blur_job_id": str(export_ref.blur_job_id),
+                "mode": "export",
+                "mask_count": len(ordered_masks),
+                "categories": categories,
+                "cancelled_mid_run": body_json.get("reason") == "cancelled",
+            },
+        )
 
     except Exception as exc:
         logger.exception(
@@ -207,6 +268,23 @@ def process_export_message(
             extra={
                 "export_id": str(export_id),
                 "error": f"{type(exc).__name__}: {exc}",
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="blur_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=export_ref.org_id,
+            job_id=export_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(exc).__name__}: {exc}"[:1000],
+            metadata={
+                "video_id": export_ref.video_id,
+                "blur_job_id": str(export_ref.blur_job_id),
+                "mode": "export",
+                "error_class": type(exc).__name__,
+                "error_msg": str(exc)[:500],
             },
         )
         # Best-effort mark failed so the customer isn't stuck at

--- a/services/drive-blur-worker/src/worker.py
+++ b/services/drive-blur-worker/src/worker.py
@@ -23,7 +23,10 @@ import sys
 import threading
 from typing import Optional
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-blur-worker"
 
 # Shared concurrency semaphore — 1 by default. OWLv2 on the base model
 # saturates an L4/A10-class GPU on a single video; parallelizing inside
@@ -162,12 +165,29 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             log.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
         loop.add_signal_handler(signal.SIGTERM, shutdown)
         loop.add_signal_handler(signal.SIGINT, shutdown)
         log.info("blur_worker_started")
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "concurrency": getattr(settings, "drive_blur_concurrency", 1),
+                "owl_model": settings.blur_owl_model,
+                "gpu": gpu_available,
+            },
+        )
         await stop_event.wait()
 
     asyncio.run(_run())

--- a/services/drive-caption-worker/Dockerfile
+++ b/services/drive-caption-worker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY services/drive-caption-worker/pyproject.toml .
 RUN pip install --no-cache-dir -e . 2>/dev/null || \

--- a/services/drive-caption-worker/Dockerfile.gpu
+++ b/services/drive-caption-worker/Dockerfile.gpu
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY heimdex-media-contracts/ /tmp/heimdex-media-contracts/
 RUN pip install --no-cache-dir /tmp/heimdex-media-contracts \

--- a/services/drive-caption-worker/src/tasks/caption.py
+++ b/services/drive-caption-worker/src/tasks/caption.py
@@ -8,7 +8,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-caption-worker"
 
 
 def _safe_update_job_status(api_client: Any, video_id: str, file_id: Any, **kwargs: Any) -> None:
@@ -47,6 +50,8 @@ def _process_single_caption(
     video_id = claimed_file.video_id
     temp_dir = Path(tempfile.mkdtemp(prefix=f"caption_{video_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
         manifest_key = scene_manifest_s3_key(org_id_str, video_id)
@@ -57,6 +62,22 @@ def _process_single_caption(
         except Exception as e:
             error_msg = f"manifest_download_failed: {type(e).__name__}: {e}"
             _safe_update_job_status(api_client, video_id, file_id, job_type="caption", status="failed", error=error_msg, lease_token=lease_token)
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="caption_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "stage": "manifest_download",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
             return
 
         manifest = json.loads(manifest_path.read_text())
@@ -65,6 +86,21 @@ def _process_single_caption(
 
         if scene_count == 0:
             _safe_update_job_status(api_client, video_id, file_id, job_type="caption", status="done", lease_token=lease_token)
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="caption_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_scenes_in_manifest",
+                metadata={
+                    "video_id": video_id,
+                    "reason": "no_scenes",
+                    "error_class": "NoScenes",
+                },
+            )
             return
 
         keyframes_dir = temp_dir / "keyframes"
@@ -114,6 +150,23 @@ def _process_single_caption(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="caption", status="failed", error="no_keyframes_downloaded", lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="caption_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_keyframes_downloaded",
+                metadata={
+                    "video_id": video_id,
+                    "stage": "keyframe_download",
+                    "error_class": "NoKeyframesDownloaded",
+                    "scene_count": scene_count,
+                    "download_failures": download_failures,
+                },
+            )
             return
 
         updated_scenes: list[dict[str, Any]] = []
@@ -138,6 +191,22 @@ def _process_single_caption(
         except Exception as e:
             error_msg = f"caption_reingest_failed: {type(e).__name__}: {e}"
             _safe_update_job_status(api_client, video_id, file_id, job_type="caption", status="failed", error=error_msg, lease_token=lease_token)
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="caption_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "stage": "reingest",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
             return
 
         _safe_update_job_status(api_client, video_id, file_id, job_type="caption", status="done", lease_token=lease_token)
@@ -156,12 +225,44 @@ def _process_single_caption(
             },
         )
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="caption_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "scene_count": scene_count,
+                "frames_processed": len(downloaded_keyframes),
+                "frames_with_caption": frames_with_caption,
+                "total_caption_chars": total_caption_chars,
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         _safe_update_job_status(api_client, video_id, file_id, job_type="caption", status="failed", error=error_msg, lease_token=lease_token)
         logger.exception(
             "caption_processing_failed",
             extra={"org_id": org_id_str, "video_id": video_id},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="caption_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
         )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
@@ -237,6 +338,8 @@ def _process_single_scene_caption(
     keyframe_s3_key = scene_job.keyframe_s3_key
     temp_dir = Path(tempfile.mkdtemp(prefix=f"caption_scene_{scene_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
 
@@ -288,6 +391,23 @@ def _process_single_scene_caption(
                     "scene_caption_empty",
                     extra={"scene_id": scene_id, "video_id": video_id, "vlm_tags": True},
                 )
+                emit_event(
+                    service=_SERVICE_NAME,
+                    event_name="caption_skipped",
+                    category="job_failure",
+                    level="WARNING",
+                    org_id=org_id,
+                    duration_ms=int((time.monotonic() - t_start) * 1000),
+                    message="empty_caption_vlm_tags",
+                    metadata={
+                        "video_id": video_id,
+                        "scene_id": scene_id,
+                        "scene_index": scene_job.scene_index,
+                        "mode": "vlm_tags",
+                        "reason": "empty_caption",
+                        "error_class": "EmptyCaption",
+                    },
+                )
                 return
 
             vlm_result = tag_parser_mod.parse_vlm_tag_output(result.caption)
@@ -332,6 +452,23 @@ def _process_single_scene_caption(
                     "duration_ms": int((time.monotonic() - caption_started) * 1000),
                 },
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="caption_completed",
+                category="job_success",
+                level="INFO",
+                org_id=org_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                metadata={
+                    "video_id": video_id,
+                    "scene_id": scene_id,
+                    "scene_index": scene_job.scene_index,
+                    "mode": "vlm_tags",
+                    "caption_chars": len(vlm_result.caption),
+                    "parse_success": vlm_result.parse_success,
+                    "has_transcript": bool(transcript_raw),
+                },
+            )
         else:
             # Standard caption (existing behavior)
             result = engine.caption(str(keyframe_path))
@@ -340,6 +477,23 @@ def _process_single_scene_caption(
                 logger.info(
                     "scene_caption_empty",
                     extra={"scene_id": scene_id, "video_id": video_id},
+                )
+                emit_event(
+                    service=_SERVICE_NAME,
+                    event_name="caption_skipped",
+                    category="job_failure",
+                    level="WARNING",
+                    org_id=org_id,
+                    duration_ms=int((time.monotonic() - t_start) * 1000),
+                    message="empty_caption",
+                    metadata={
+                        "video_id": video_id,
+                        "scene_id": scene_id,
+                        "scene_index": scene_job.scene_index,
+                        "mode": "standard",
+                        "reason": "empty_caption",
+                        "error_class": "EmptyCaption",
+                    },
                 )
                 return
 
@@ -363,13 +517,44 @@ def _process_single_scene_caption(
                     "duration_ms": int((time.monotonic() - caption_started) * 1000),
                 },
             )
-    except Exception:
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="caption_completed",
+                category="job_success",
+                level="INFO",
+                org_id=org_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                metadata={
+                    "video_id": video_id,
+                    "scene_id": scene_id,
+                    "scene_index": scene_job.scene_index,
+                    "mode": "standard",
+                    "caption_chars": len(caption_text),
+                },
+            )
+    except Exception as e:
         logger.exception(
             "scene_caption_failed",
             extra={
                 "org_id": org_id_str,
                 "video_id": video_id,
                 "scene_id": scene_id,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="caption_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(e).__name__}: {e}"[:1000],
+            metadata={
+                "video_id": video_id,
+                "scene_id": scene_id,
+                "scene_index": scene_job.scene_index,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
             },
         )
         raise  # Re-raise so SQS consumer treats this as failure (retry)

--- a/services/drive-caption-worker/src/worker.py
+++ b/services/drive-caption-worker/src/worker.py
@@ -6,7 +6,10 @@ import sys
 import threading
 from typing import Optional
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-caption-worker"
 
 # Shared concurrency semaphore — acquired by SQS consumer for backpressure control.
 _semaphore: Optional[threading.Semaphore] = None
@@ -122,6 +125,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -132,6 +141,18 @@ def main() -> None:
             "caption_worker_started",
             extra={
                 "concurrency": settings.drive_caption_concurrency,
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "concurrency": settings.drive_caption_concurrency,
+                "engine": engine_key,
+                "model": settings.drive_caption_model,
                 "sqs_consumer_enabled": settings.sqs_consumer_enabled,
             },
         )

--- a/services/drive-face-worker/Dockerfile.gpu
+++ b/services/drive-face-worker/Dockerfile.gpu
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY heimdex-media-contracts/ /tmp/heimdex-media-contracts/
 RUN pip install --no-cache-dir /tmp/heimdex-media-contracts \

--- a/services/drive-face-worker/src/tasks/face_detect.py
+++ b/services/drive-face-worker/src/tasks/face_detect.py
@@ -2,13 +2,17 @@ import importlib
 import logging
 import shutil
 import tempfile
+import time
 from pathlib import Path
 import uuid
 from typing import Any
 
 import requests
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-face-worker"
 cv2 = importlib.import_module("cv2")
 np = importlib.import_module("numpy")
 
@@ -54,6 +58,8 @@ def _process_single_face_detect(
     keyframe_s3_prefix = claimed_file.keyframe_s3_prefix
     temp_dir = Path(tempfile.mkdtemp(prefix=f"face_{video_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         if not keyframe_s3_prefix:
             api_client.update_job_status(
@@ -62,6 +68,21 @@ def _process_single_face_detect(
                 status="failed",
                 error="missing_keyframe_s3_prefix",
                 lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="face_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=claimed_file.org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="missing_keyframe_s3_prefix",
+                metadata={
+                    "video_id": video_id,
+                    "reason": "missing_keyframe_s3_prefix",
+                    "error_class": "MissingPrecondition",
+                },
             )
             return
 
@@ -82,6 +103,22 @@ def _process_single_face_detect(
                 error="no_keyframes_downloaded",
                 lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="face_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=claimed_file.org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_keyframes_downloaded",
+                metadata={
+                    "video_id": video_id,
+                    "stage": "keyframe_download",
+                    "error_class": "NoKeyframesDownloaded",
+                    "keyframe_s3_prefix": keyframe_s3_prefix,
+                },
+            )
             return
 
         if face_analyzer is None:
@@ -100,6 +137,22 @@ def _process_single_face_detect(
                 job_type="face",
                 status="done",
                 lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="face_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=claimed_file.org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_faces_detected",
+                metadata={
+                    "video_id": video_id,
+                    "reason": "no_faces_detected",
+                    "error_class": "NoFacesDetected",
+                    "keyframe_count": len(downloaded),
+                },
             )
             return
 
@@ -174,6 +227,22 @@ def _process_single_face_detect(
                 "scene_count": len(scene_cluster_map),
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="face_completed",
+            category="job_success",
+            level="INFO",
+            org_id=claimed_file.org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "keyframe_count": len(downloaded),
+                "face_count": len(detections),
+                "cluster_count": len(clusters),
+                "scene_count": len(scene_cluster_map),
+            },
+        )
     except Exception as e:
         api_client.update_job_status(
             file_id,
@@ -185,6 +254,21 @@ def _process_single_face_detect(
         logger.exception(
             "face_processing_failed",
             extra={"org_id": org_id, "video_id": video_id},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="face_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=claimed_file.org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(e).__name__}: {e}"[:1000],
+            metadata={
+                "video_id": video_id,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
         )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/services/drive-face-worker/src/worker.py
+++ b/services/drive-face-worker/src/worker.py
@@ -6,7 +6,10 @@ import sys
 import threading
 from typing import Optional
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-face-worker"
 
 # Shared concurrency semaphore - acquired by SQS consumer for backpressure control.
 _semaphore: Optional[threading.Semaphore] = None
@@ -114,6 +117,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -124,6 +133,18 @@ def main() -> None:
             "face_worker_started",
             concurrency=getattr(settings, "drive_face_concurrency", 1),
             sqs_consumer_enabled=settings.sqs_consumer_enabled,
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "concurrency": getattr(settings, "drive_face_concurrency", 1),
+                "model": "buffalo_l",
+                "providers": providers,
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
         )
         await stop_event.wait()
 

--- a/services/drive-ocr-worker/Dockerfile
+++ b/services/drive-ocr-worker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY services/drive-ocr-worker/pyproject.toml .
 RUN pip install --no-cache-dir -e . 2>/dev/null || \

--- a/services/drive-ocr-worker/Dockerfile.gpu
+++ b/services/drive-ocr-worker/Dockerfile.gpu
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY heimdex-media-contracts/ /tmp/heimdex-media-contracts/
 RUN pip install --no-cache-dir /tmp/heimdex-media-contracts \

--- a/services/drive-ocr-worker/src/tasks/ocr.py
+++ b/services/drive-ocr-worker/src/tasks/ocr.py
@@ -7,7 +7,10 @@ import time
 from pathlib import Path
 from typing import Any
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-ocr-worker"
 
 
 def _safe_update_job_status(api_client: Any, video_id: str, file_id: Any, **kwargs: Any) -> None:
@@ -63,6 +66,8 @@ def _process_single_ocr(
     video_id = claimed_file.video_id
     temp_dir = Path(tempfile.mkdtemp(prefix=f"ocr_{video_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
         manifest_key = scene_manifest_s3_key(org_id_str, video_id)
@@ -75,6 +80,22 @@ def _process_single_ocr(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="ocr", status="failed", error=error_msg, lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="ocr_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "stage": "manifest_download",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
             return
 
         manifest = json.loads(manifest_path.read_text())
@@ -83,6 +104,21 @@ def _process_single_ocr(
 
         if scene_count == 0:
             _safe_update_job_status(api_client, video_id, file_id, job_type="ocr", status="done", lease_token=lease_token)
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="ocr_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_scenes_in_manifest",
+                metadata={
+                    "video_id": video_id,
+                    "reason": "no_scenes",
+                    "error_class": "NoScenes",
+                },
+            )
             return
 
         max_frames = min(settings.drive_ocr_max_frames_per_video, scene_count)
@@ -111,6 +147,23 @@ def _process_single_ocr(
         if not downloaded_keyframes:
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="ocr", status="failed", error="no_keyframes_downloaded", lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="ocr_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_keyframes_downloaded",
+                metadata={
+                    "video_id": video_id,
+                    "stage": "keyframe_download",
+                    "error_class": "NoKeyframesDownloaded",
+                    "scene_count": scene_count,
+                    "selected_count": len(selected_indices),
+                },
             )
             return
 
@@ -153,6 +206,22 @@ def _process_single_ocr(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="ocr", status="failed", error=error_msg, lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="ocr_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "stage": "reingest",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
             return
 
         _safe_update_job_status(api_client, video_id, file_id, job_type="ocr", status="done", lease_token=lease_token)
@@ -171,6 +240,23 @@ def _process_single_ocr(
             },
         )
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="ocr_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "scene_count": scene_count,
+                "frames_processed": len(downloaded_keyframes),
+                "frames_with_text": frames_with_text,
+                "total_ocr_chars": total_ocr_chars,
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         _safe_update_job_status(
@@ -179,6 +265,21 @@ def _process_single_ocr(
         logger.exception(
             "ocr_processing_failed",
             extra={"org_id": org_id_str, "video_id": video_id},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="ocr_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
         )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/services/drive-ocr-worker/src/worker.py
+++ b/services/drive-ocr-worker/src/worker.py
@@ -6,7 +6,10 @@ import sys
 import threading
 from typing import Optional
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-ocr-worker"
 
 # Shared concurrency semaphore — acquired by SQS consumer for backpressure control.
 _semaphore: Optional[threading.Semaphore] = None
@@ -90,6 +93,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -99,6 +108,17 @@ def main() -> None:
         logger.info(
             "ocr_worker_started",
             extra={
+                "concurrency": settings.drive_ocr_concurrency,
+                "max_frames_per_video": settings.drive_ocr_max_frames_per_video,
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
                 "concurrency": settings.drive_ocr_concurrency,
                 "max_frames_per_video": settings.drive_ocr_max_frames_per_video,
                 "sqs_consumer_enabled": settings.sqs_consumer_enabled,

--- a/services/drive-stt-worker/Dockerfile
+++ b/services/drive-stt-worker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY services/drive-stt-worker/pyproject.toml .
 RUN pip install --no-cache-dir -e . 2>/dev/null || \

--- a/services/drive-stt-worker/Dockerfile.gpu
+++ b/services/drive-stt-worker/Dockerfile.gpu
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY heimdex-media-contracts/ /tmp/heimdex-media-contracts/
 RUN pip install --no-cache-dir /tmp/heimdex-media-contracts \

--- a/services/drive-stt-worker/src/tasks/stt.py
+++ b/services/drive-stt-worker/src/tasks/stt.py
@@ -8,7 +8,10 @@ import wave
 from pathlib import Path
 from typing import Any
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-stt-worker"
 
 
 def _safe_update_job_status(api_client: Any, video_id: str, file_id: Any, **kwargs: Any) -> None:
@@ -55,6 +58,8 @@ def _process_single_stt(
     video_id = claimed_file.video_id
     temp_dir = Path(tempfile.mkdtemp(prefix=f"stt_{video_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
 
@@ -65,6 +70,23 @@ def _process_single_stt(
             error_msg = f"audio_download_failed: {type(e).__name__}: {e}"
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="stt", status="failed", error=error_msg, lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="stt_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "callback_mode": callback_mode,
+                    "stage": "audio_download",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
             )
             return
 
@@ -86,6 +108,24 @@ def _process_single_stt(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="stt", status="failed", error=error_msg, lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="stt_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "callback_mode": callback_mode,
+                    "reason": "audio_too_long",
+                    "error_class": "AudioTooLong",
+                    "audio_seconds": round(audio_duration, 1),
+                    "max_seconds": settings.drive_stt_max_audio_seconds,
+                },
+            )
             return
 
         # scene_split mode: no manifest needed — scenes are created later
@@ -101,6 +141,23 @@ def _process_single_stt(
                 _safe_update_job_status(
                     api_client, video_id, file_id, job_type="stt", status="failed", error=error_msg, lease_token=lease_token,
                 )
+                emit_event(
+                    service=_SERVICE_NAME,
+                    event_name="stt_failed",
+                    category="job_failure",
+                    level="ERROR",
+                    org_id=org_id,
+                    job_id=file_id,
+                    duration_ms=int((time.monotonic() - t_start) * 1000),
+                    message=error_msg[:1000],
+                    metadata={
+                        "video_id": video_id,
+                        "callback_mode": callback_mode,
+                        "stage": "manifest_download",
+                        "error_class": type(e).__name__,
+                        "error_msg": str(e)[:500],
+                    },
+                )
                 return
 
             manifest = json.loads(manifest_path.read_text())
@@ -108,6 +165,22 @@ def _process_single_stt(
 
             if not scenes:
                 _safe_update_job_status(api_client, video_id, file_id, job_type="stt", status="done", lease_token=lease_token)
+                emit_event(
+                    service=_SERVICE_NAME,
+                    event_name="stt_skipped",
+                    category="job_failure",
+                    level="WARNING",
+                    org_id=org_id,
+                    job_id=file_id,
+                    duration_ms=int((time.monotonic() - t_start) * 1000),
+                    message="no_scenes_in_manifest",
+                    metadata={
+                        "video_id": video_id,
+                        "callback_mode": callback_mode,
+                        "reason": "no_scenes",
+                        "error_class": "NoScenes",
+                    },
+                )
                 return
 
         stt_started = time.monotonic()
@@ -173,6 +246,23 @@ def _process_single_stt(
                 _safe_update_job_status(
                     api_client, video_id, file_id, job_type="stt", status="failed", error=error_msg, lease_token=lease_token,
                 )
+                emit_event(
+                    service=_SERVICE_NAME,
+                    event_name="stt_failed",
+                    category="job_failure",
+                    level="ERROR",
+                    org_id=org_id,
+                    job_id=file_id,
+                    duration_ms=int((time.monotonic() - t_start) * 1000),
+                    message=error_msg[:1000],
+                    metadata={
+                        "video_id": video_id,
+                        "callback_mode": callback_mode,
+                        "stage": "reingest",
+                        "error_class": type(e).__name__,
+                        "error_msg": str(e)[:500],
+                    },
+                )
                 return
 
             _safe_update_job_status(api_client, video_id, file_id, job_type="stt", status="done", lease_token=lease_token)
@@ -202,6 +292,23 @@ def _process_single_stt(
                 },
             )
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="stt_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "callback_mode": callback_mode,
+                "audio_seconds": round(audio_duration, 1),
+                "model": settings.drive_stt_model,
+                "backend": settings.drive_stt_backend,
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         if callback_mode == "scene_split":
@@ -211,6 +318,22 @@ def _process_single_stt(
                 "stt_scene_split_failed_fallback",
                 extra={"org_id": org_id_str, "video_id": video_id, "error": error_msg},
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="stt_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "callback_mode": callback_mode,
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
         else:
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="stt", status="failed", error=error_msg, lease_token=lease_token,
@@ -218,6 +341,22 @@ def _process_single_stt(
             logger.exception(
                 "stt_processing_failed",
                 extra={"org_id": org_id_str, "video_id": video_id},
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="stt_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "callback_mode": callback_mode,
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
             )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/services/drive-stt-worker/src/worker.py
+++ b/services/drive-stt-worker/src/worker.py
@@ -14,7 +14,10 @@ from typing import Optional
 os.environ.setdefault("TORCH_HOME", "/models/huggingface")
 os.environ.setdefault("HF_HOME", "/models/huggingface")
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-stt-worker"
 
 # Shared concurrency semaphore — acquired by SQS consumer for backpressure control.
 _semaphore: Optional[threading.Semaphore] = None
@@ -139,6 +142,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -153,6 +162,19 @@ def main() -> None:
                 "language": settings.drive_stt_language,
                 "backend": settings.drive_stt_backend,
                 "max_audio_seconds": settings.drive_stt_max_audio_seconds,
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "concurrency": settings.drive_stt_concurrency,
+                "model": settings.drive_stt_model,
+                "language": settings.drive_stt_language,
+                "backend": settings.drive_stt_backend,
                 "sqs_consumer_enabled": settings.sqs_consumer_enabled,
             },
         )

--- a/services/drive-transcode-worker/Dockerfile.gpu
+++ b/services/drive-transcode-worker/Dockerfile.gpu
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY heimdex-media-contracts/ /tmp/heimdex-media-contracts/
 RUN pip install --no-cache-dir /tmp/heimdex-media-contracts \

--- a/services/drive-transcode-worker/src/tasks/transcode.py
+++ b/services/drive-transcode-worker/src/tasks/transcode.py
@@ -3,13 +3,17 @@ import importlib
 import logging
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
 import boto3
 import requests
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-transcode-worker"
 
 
 def _update_youtube_status(
@@ -94,6 +98,8 @@ def _process_single_transcode(
 
     temp_dir = Path(settings.drive_temp_dir) / org_id_str / str(file_id)
     temp_dir.mkdir(parents=True, exist_ok=True)
+
+    t_start = time.monotonic()
 
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
@@ -304,6 +310,21 @@ def _process_single_transcode(
         except Exception:
             logger.warning("original_delete_failed", extra={"key": original_key}, exc_info=True)
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="transcode_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "source_type": source_type,
+                "scene_count": len(scene_result.scenes),
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         try:
@@ -325,6 +346,22 @@ def _process_single_transcode(
         logger.exception(
             "transcode_processing_failed",
             extra={"org_id": org_id_str, "video_id": video_id, "file_id": str(file_id)},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="transcode_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "source_type": source_type,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
         )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/services/drive-transcode-worker/src/worker.py
+++ b/services/drive-transcode-worker/src/worker.py
@@ -5,7 +5,10 @@ import signal
 import sys
 import threading
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-transcode-worker"
 _semaphore: threading.Semaphore | None = None
 
 
@@ -95,6 +98,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -104,6 +113,17 @@ def main() -> None:
         logger.info(
             "transcode_worker_started",
             extra={
+                "concurrency": settings.drive_worker_global_concurrency,
+                "mode": settings.drive_transcode_mode,
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
                 "concurrency": settings.drive_worker_global_concurrency,
                 "mode": settings.drive_transcode_mode,
                 "sqs_consumer_enabled": settings.sqs_consumer_enabled,

--- a/services/drive-visual-embed-worker/Dockerfile
+++ b/services/drive-visual-embed-worker/Dockerfile
@@ -8,7 +8,7 @@ ENV HF_HOME=/models/huggingface
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 RUN pip install --no-cache-dir \
       "torch>=2.0" --index-url https://download.pytorch.org/whl/cpu \

--- a/services/drive-visual-embed-worker/Dockerfile.gpu
+++ b/services/drive-visual-embed-worker/Dockerfile.gpu
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 # PyTorch with CUDA 12.1 support
 RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu121 \

--- a/services/drive-visual-embed-worker/src/tasks/visual_embed.py
+++ b/services/drive-visual-embed-worker/src/tasks/visual_embed.py
@@ -18,7 +18,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-visual-embed-worker"
 
 ENRICH_BATCH_SIZE = 200
 
@@ -158,6 +161,8 @@ def _process_single_visual_embed(
     video_id = claimed_file.video_id
     temp_dir = Path(tempfile.mkdtemp(prefix=f"visual_embed_{video_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         # 1. Load model on first call
         _load_vision_model(use_gpu=getattr(settings, "use_gpu", False))
@@ -175,6 +180,23 @@ def _process_single_visual_embed(
                 api_client, video_id, file_id, job_type="visual_embed", status="failed",
                 error=error_msg, lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="visual_embed_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "mode": "v1_per_video",
+                    "stage": "manifest_download",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
             return
 
         manifest = json.loads(manifest_path.read_text())
@@ -184,6 +206,22 @@ def _process_single_visual_embed(
         if scene_count == 0:
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="visual_embed", status="done", lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="visual_embed_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_scenes_in_manifest",
+                metadata={
+                    "video_id": video_id,
+                    "mode": "v1_per_video",
+                    "reason": "no_scenes",
+                    "error_class": "NoScenes",
+                },
             )
             return
 
@@ -225,6 +263,24 @@ def _process_single_visual_embed(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="visual_embed", status="failed",
                 error="no_keyframes_downloaded", lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="visual_embed_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_keyframes_downloaded",
+                metadata={
+                    "video_id": video_id,
+                    "mode": "v1_per_video",
+                    "stage": "keyframe_download",
+                    "error_class": "NoKeyframesDownloaded",
+                    "scene_count": scene_count,
+                    "download_failures": download_failures,
+                },
             )
             return
 
@@ -276,6 +332,22 @@ def _process_single_visual_embed(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="visual_embed", status="done", lease_token=lease_token,
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="visual_embed_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_enrich_payload",
+                metadata={
+                    "video_id": video_id,
+                    "mode": "v1_per_video",
+                    "reason": "no_enrich_payload",
+                    "error_class": "NoEnrichPayload",
+                },
+            )
             return
 
         try:
@@ -290,6 +362,23 @@ def _process_single_visual_embed(
             _safe_update_job_status(
                 api_client, video_id, file_id, job_type="visual_embed", status="failed",
                 error=error_msg, lease_token=lease_token,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="visual_embed_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=org_id,
+                job_id=file_id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=error_msg[:1000],
+                metadata={
+                    "video_id": video_id,
+                    "mode": "v1_per_video",
+                    "stage": "enrich",
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
             )
             return
 
@@ -311,6 +400,24 @@ def _process_single_visual_embed(
             },
         )
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="visual_embed_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "mode": "v1_per_video",
+                "scene_count": scene_count,
+                "frames_processed": len(downloaded_keyframes),
+                "frames_embedded": len(enrich_scenes),
+                "download_failures": download_failures,
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         _safe_update_job_status(
@@ -320,6 +427,22 @@ def _process_single_visual_embed(
         logger.exception(
             "visual_embed_processing_failed",
             extra={"org_id": org_id_str, "video_id": video_id},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="visual_embed_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            job_id=file_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "mode": "v1_per_video",
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
         )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
@@ -382,6 +505,8 @@ def _process_single_scene_visual_embed(
     keyframe_s3_key = scene_job.keyframe_s3_key
     temp_dir = Path(tempfile.mkdtemp(prefix=f"visual_embed_scene_{scene_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         # 1. Load model on first call (cached for worker lifetime)
         _load_vision_model(use_gpu=getattr(settings, "use_gpu", False))
@@ -427,13 +552,45 @@ def _process_single_scene_visual_embed(
                 "embed_duration_ms": embed_duration_ms,
             },
         )
-    except Exception:
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="visual_embed_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "scene_id": scene_id,
+                "scene_index": scene_job.scene_index,
+                "mode": "v2_per_scene",
+                "embed_duration_ms": embed_duration_ms,
+            },
+        )
+    except Exception as e:
         logger.exception(
             "scene_visual_embed_failed",
             extra={
                 "org_id": org_id_str,
                 "video_id": video_id,
                 "scene_id": scene_id,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="visual_embed_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(e).__name__}: {e}"[:1000],
+            metadata={
+                "video_id": video_id,
+                "scene_id": scene_id,
+                "scene_index": scene_job.scene_index,
+                "mode": "v2_per_scene",
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
             },
         )
         raise  # Re-raise so SQS consumer treats this as failure (retry)
@@ -468,6 +625,8 @@ def _process_single_scene_color_extract(
     keyframe_s3_key = scene_job.keyframe_s3_key
     temp_dir = Path(tempfile.mkdtemp(prefix=f"color_extract_{scene_id}_"))
 
+    t_start = time.monotonic()
+
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
         keyframe_path = temp_dir / f"{scene_id}.jpg"
@@ -498,13 +657,43 @@ def _process_single_scene_color_extract(
                 "dominant_colors": hex_colors[:3],
             },
         )
-    except Exception:
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="visual_embed_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "scene_id": scene_id,
+                "mode": "v2_color_extract",
+                "dominant_colors": hex_colors[:3],
+            },
+        )
+    except Exception as e:
         logger.exception(
             "scene_color_extract_failed",
             extra={
                 "org_id": org_id_str,
                 "video_id": video_id,
                 "scene_id": scene_id,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="visual_embed_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(e).__name__}: {e}"[:1000],
+            metadata={
+                "video_id": video_id,
+                "scene_id": scene_id,
+                "mode": "v2_color_extract",
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
             },
         )
         raise

--- a/services/drive-visual-embed-worker/src/worker.py
+++ b/services/drive-visual-embed-worker/src/worker.py
@@ -17,7 +17,10 @@ import sys
 import threading
 from typing import Optional
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-visual-embed-worker"
 
 # Shared concurrency semaphore — acquired by SQS consumer for backpressure control.
 _semaphore: Optional[threading.Semaphore] = None
@@ -128,6 +131,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -140,6 +149,17 @@ def main() -> None:
                 "concurrency": concurrency,
                 "sqs_queue": sqs_queue_url,
                 "use_gpu": getattr(settings, "use_gpu", False),
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "concurrency": concurrency,
+                "use_gpu": getattr(settings, "use_gpu", False),
+                "sqs_consumer_enabled": getattr(settings, "sqs_consumer_enabled", False),
             },
         )
         await stop_event.wait()

--- a/services/drive-worker/Dockerfile
+++ b/services/drive-worker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY services/drive-worker/pyproject.toml .
 RUN pip install --no-cache-dir -e . 2>/dev/null || \

--- a/services/drive-worker/src/tasks/discover.py
+++ b/services/drive-worker/src/tasks/discover.py
@@ -7,6 +7,7 @@ No direct database access — all state managed via InternalAPIClient.
 """
 # pyright: reportMissingImports=false
 import logging
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -14,6 +15,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build as build_google_service
 from googleapiclient.errors import HttpError
 
+from heimdex_worker_sdk import emit_event
 from heimdex_worker_sdk.content_type import IMAGE_MIME_TYPES, is_image, is_supported_mime
 from heimdex_worker_sdk.internal_api import InternalAPIClient
 
@@ -22,6 +24,7 @@ _IMAGE_MIME_FILTER = " or ".join(f"mimeType='{m}'" for m in sorted(IMAGE_MIME_TY
 _MIME_QUERY = f"(mimeType contains 'video/' or {_IMAGE_MIME_FILTER})"
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-worker"
 
 _MAX_UPSERT_BATCH = 500
 
@@ -118,6 +121,7 @@ def discover_new_files(api_client: InternalAPIClient, settings: Any) -> int:
 
     for conn in connections:
         org_id_str = str(conn.org_id)
+        t_conn_start = time.monotonic()
         try:
             token_info = api_client.get_drive_token(
                 conn.connection_id, lease_token=conn.lease_token,
@@ -150,6 +154,22 @@ def discover_new_files(api_client: InternalAPIClient, settings: Any) -> int:
                     "discovered": count,
                 },
             )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_completed",
+                category="job_success",
+                level="INFO",
+                org_id=conn.org_id,
+                job_id=conn.connection_id,
+                duration_ms=int((time.monotonic() - t_conn_start) * 1000),
+                metadata={
+                    "mode": "discover",
+                    "scope_type": conn.scope_type,
+                    "drive_id": conn.drive_id,
+                    "folder_id": conn.folder_id,
+                    "discovered": count,
+                },
+            )
         except Exception as e:
             logger.exception(
                 "discover_connection_failed",
@@ -174,6 +194,24 @@ def discover_new_files(api_client: InternalAPIClient, settings: Any) -> int:
                     extra={"connection_id": str(conn.connection_id)},
                     exc_info=True,
                 )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=conn.org_id,
+                job_id=conn.connection_id,
+                duration_ms=int((time.monotonic() - t_conn_start) * 1000),
+                message=f"{type(e).__name__}: {e}"[:1000],
+                metadata={
+                    "mode": "discover",
+                    "scope_type": conn.scope_type,
+                    "drive_id": conn.drive_id,
+                    "folder_id": conn.folder_id,
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
 
     return discovered_count
 

--- a/services/drive-worker/src/tasks/export.py
+++ b/services/drive-worker/src/tasks/export.py
@@ -14,6 +14,7 @@ import logging
 import re
 import shutil
 import tempfile
+import time
 import unicodedata
 import zipfile
 from dataclasses import dataclass
@@ -22,9 +23,11 @@ from typing import Any
 from urllib.parse import quote
 from xml.etree import ElementTree as ET
 
+from heimdex_worker_sdk import emit_event
 from heimdex_worker_sdk.internal_api import InternalAPIClient
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-worker"
 
 
 @dataclass(frozen=True)
@@ -44,19 +47,62 @@ def handle_export_proxy_pack(
     api_client: InternalAPIClient,
     settings: Any,
 ) -> None:
+    t_start = time.monotonic()
     export_id = message.get("export_id", "")
     if not export_id:
         logger.error("export_missing_export_id", extra={"message": message})
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message="export_missing_export_id",
+            metadata={
+                "mode": "export",
+                "stage": "validation",
+                "error_class": "MissingExportId",
+            },
+        )
         return
 
     record = _fetch_export_record(api_client, export_id)
     if record is None:
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message="export_record_fetch_failed",
+            metadata={
+                "mode": "export",
+                "stage": "fetch_record",
+                "error_class": "RecordFetchFailed",
+                "export_id": export_id,
+            },
+        )
         return
 
     if record["status"] != "pending":
         logger.info(
             "export_already_processed",
             extra={"export_id": export_id, "status": record["status"]},
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_skipped",
+            category="job_failure",
+            level="WARNING",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"export_already_processed:{record['status']}",
+            metadata={
+                "mode": "export",
+                "reason": "already_processed",
+                "error_class": "AlreadyProcessed",
+                "export_id": export_id,
+                "current_status": record["status"],
+            },
         )
         return
 
@@ -70,6 +116,20 @@ def handle_export_proxy_pack(
         clips = _parse_clips(request_body.get("clips", []))
         if not clips:
             _update_status(api_client, export_id, "failed", error_message="No clips in request")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_failed",
+                category="job_failure",
+                level="ERROR",
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_clips_in_request",
+                metadata={
+                    "mode": "export",
+                    "stage": "parse_clips",
+                    "error_class": "NoClips",
+                    "export_id": export_id,
+                },
+            )
             return
 
         deduped_video_ids = list({c.video_id for c in clips})
@@ -84,6 +144,21 @@ def handle_export_proxy_pack(
 
         if not proxy_map:
             _update_status(api_client, export_id, "failed", error_message="No proxies found in S3")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_failed",
+                category="job_failure",
+                level="ERROR",
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message="no_proxies_in_s3",
+                metadata={
+                    "mode": "export",
+                    "stage": "download_proxies",
+                    "error_class": "NoProxiesFound",
+                    "export_id": export_id,
+                    "video_id_count": len(deduped_video_ids),
+                },
+            )
             return
 
         sequence_name = request_body.get("sequence_name", "Heimdex Export")
@@ -135,10 +210,38 @@ def handle_export_proxy_pack(
                 "clip_count": len(clips),
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_completed",
+            category="job_success",
+            level="INFO",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "mode": "export",
+                "export_id": export_id,
+                "zip_size_bytes": zip_size,
+                "proxy_count": len(proxy_map),
+                "clip_count": len(clips),
+            },
+        )
 
     except Exception as e:
         logger.exception("export_failed", extra={"export_id": export_id})
         _update_status(api_client, export_id, "failed", error_message=str(e)[:500])
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(e).__name__}: {e}"[:1000],
+            metadata={
+                "mode": "export",
+                "export_id": export_id,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
+        )
         raise
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/services/drive-worker/src/tasks/process.py
+++ b/services/drive-worker/src/tasks/process.py
@@ -22,10 +22,12 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build as build_google_service
 from googleapiclient.http import MediaIoBaseDownload
 
+from heimdex_worker_sdk import emit_event
 from heimdex_worker_sdk.content_type import is_image
 from heimdex_worker_sdk.internal_api import InternalAPIClient
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-worker"
 
 
 def _build_drive_web_view_link(google_file_id: str) -> str:
@@ -112,6 +114,8 @@ def _process_image(
     scene_id = f"{video_id}_scene_000"
     temp_dir = Path(settings.drive_temp_dir) / org_id_str / str(claimed_file.id)
     temp_dir.mkdir(parents=True, exist_ok=True)
+
+    t_start = time.monotonic()
 
     try:
         token_info = api_client.get_drive_token(
@@ -236,6 +240,22 @@ def _process_image(
                 "keyframe_s3_prefix": kf_prefix,
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_completed",
+            category="job_success",
+            level="INFO",
+            org_id=claimed_file.org_id,
+            job_id=claimed_file.id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "mode": "image",
+                "format": meta.format,
+                "width": meta.width,
+                "height": meta.height,
+            },
+        )
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         logger.error("image_processing_failed", extra={
@@ -256,6 +276,22 @@ def _process_image(
                 extra={"file_id": str(claimed_file.id)},
                 exc_info=True,
             )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=claimed_file.org_id,
+            job_id=claimed_file.id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "mode": "image",
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
+        )
         raise
     finally:
         if temp_dir.exists():
@@ -275,6 +311,23 @@ def _process_single_file(
                 "file_name": claimed_file.file_name,
                 "reason": "image_processing_disabled",
             })
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_skipped",
+                category="job_failure",
+                level="WARNING",
+                org_id=claimed_file.org_id,
+                job_id=claimed_file.id,
+                duration_ms=0,
+                message="image_processing_disabled",
+                metadata={
+                    "video_id": claimed_file.video_id,
+                    "mode": "image",
+                    "reason": "image_processing_disabled",
+                    "error_class": "ImageProcessingDisabled",
+                    "mime_type": mime_type,
+                },
+            )
             return
         return _process_image(api_client, settings, claimed_file)
 
@@ -291,6 +344,8 @@ def _process_single_file(
     org_id_str = str(claimed_file.org_id)
     temp_dir = Path(settings.drive_temp_dir) / org_id_str / str(claimed_file.id)
     temp_dir.mkdir(parents=True, exist_ok=True)
+
+    t_start = time.monotonic()
 
     try:
         # Get access token via token broker.
@@ -330,6 +385,20 @@ def _process_single_file(
                 claimed_file=claimed_file,
                 original_path=original_path,
                 temp_dir=temp_dir,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_completed",
+                category="job_success",
+                level="INFO",
+                org_id=claimed_file.org_id,
+                job_id=claimed_file.id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                metadata={
+                    "video_id": claimed_file.video_id,
+                    "mode": "gpu_handoff",
+                    "next_stage": "drive_transcode_worker",
+                },
             )
             return
 
@@ -385,6 +454,20 @@ def _process_single_file(
                 proxy_probe=proxy_probe,
                 proxy_size=proxy_size,
                 temp_dir=temp_dir,
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="drive_completed",
+                category="job_success",
+                level="INFO",
+                org_id=claimed_file.org_id,
+                job_id=claimed_file.id,
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                metadata={
+                    "video_id": claimed_file.video_id,
+                    "mode": "stt_split_handoff",
+                    "next_stage": "drive_stt_worker",
+                },
             )
             return
 
@@ -518,6 +601,24 @@ def _process_single_file(
             },
         )
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_completed",
+            category="job_success",
+            level="INFO",
+            org_id=claimed_file.org_id,
+            job_id=claimed_file.id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": claimed_file.video_id,
+                "mode": "video_full",
+                "transcoded": decision.should_transcode,
+                "scene_count": len(scene_result.scenes),
+                "indexed_count": ingest_result["indexed_count"],
+                "proxy_size_bytes": proxy_size,
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         logger.error("file_processing_failed", extra={
@@ -537,6 +638,22 @@ def _process_single_file(
                 extra={"file_id": str(claimed_file.id)},
                 exc_info=True,
             )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=claimed_file.org_id,
+            job_id=claimed_file.id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": claimed_file.video_id,
+                "mode": "video_full",
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
+        )
 
     finally:
         if temp_dir.exists():

--- a/services/drive-worker/src/tasks/resplit.py
+++ b/services/drive-worker/src/tasks/resplit.py
@@ -3,11 +3,13 @@
 import json
 import logging
 import shutil
+import time
 from pathlib import Path
 from typing import Any
 
 import requests
 
+from heimdex_worker_sdk import emit_event
 from heimdex_media_pipelines.scenes.assembler import assemble_scenes
 from heimdex_media_pipelines.scenes.keyframe import extract_all_keyframes
 from heimdex_media_pipelines.scenes.splitter import split_scenes
@@ -30,6 +32,7 @@ from heimdex_worker_sdk.youtube_keys import (
 )
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-worker"
 
 INGEST_BATCH_SIZE = 200
 
@@ -40,6 +43,7 @@ def handle_resplit(
     settings: Any,
 ) -> None:
     _ = api_client
+    t_start = time.monotonic()
     job_id = str(message.get("job_id", ""))
     org_id = str(message.get("org_id", ""))
     video_id = str(message.get("video_id", ""))
@@ -50,9 +54,38 @@ def handle_resplit(
     scene_params = message.get("scene_params") or {}
 
     if not all([job_id, org_id, video_id, source_type, proxy_s3_key, library_id]):
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message="resplit_missing_required_fields",
+            metadata={
+                "video_id": video_id,
+                "mode": "resplit",
+                "stage": "validation",
+                "error_class": "MissingRequiredFields",
+            },
+        )
         raise RuntimeError(f"resplit_missing_required_fields: {json.dumps(message, default=str)[:1000]}")
 
     if source_type not in {"gdrive", "youtube"}:
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"unsupported_resplit_source_type:{source_type}",
+            metadata={
+                "video_id": video_id,
+                "mode": "resplit",
+                "stage": "validation",
+                "error_class": "UnsupportedSourceType",
+                "source_type": source_type,
+            },
+        )
         raise RuntimeError(f"unsupported_resplit_source_type: {source_type}")
 
     temp_dir = Path(settings.drive_temp_dir) / org_id / f"resplit_{job_id}"
@@ -206,6 +239,20 @@ def handle_resplit(
                 "keyframe_s3_prefix": eff_keyframe_prefix,
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_completed",
+            category="job_success",
+            level="INFO",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "mode": "resplit",
+                "source_type": source_type,
+                "deleted_scene_count": deleted_count,
+                "indexed_scene_count": indexed_count,
+            },
+        )
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         logger.exception(
@@ -223,6 +270,21 @@ def handle_resplit(
             job_id=job_id,
             status="failed",
             error=error_msg[:500],
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "mode": "resplit",
+                "source_type": source_type,
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
         )
         raise
     finally:

--- a/services/drive-worker/src/tasks/scene_split.py
+++ b/services/drive-worker/src/tasks/scene_split.py
@@ -29,10 +29,12 @@ from heimdex_worker_sdk.drive_keys import (
     thumbnail_s3_key,
     thumbnail_s3_prefix,
 )
+from heimdex_worker_sdk import emit_event
 from heimdex_worker_sdk.internal_api import InternalAPIClient
 from heimdex_worker_sdk.s3 import S3Client
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-worker"
 
 INGEST_BATCH_SIZE = 200
 
@@ -63,6 +65,8 @@ def handle_scene_split(
         "video_id": video_id,
         "stt_available": stt_available,
     })
+
+    t_start = time.monotonic()
 
     try:
         s3 = S3Client(bucket=settings.drive_s3_bucket)
@@ -199,6 +203,23 @@ def handle_scene_split(
             "speech_used": speech_segments is not None,
         })
 
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_completed",
+            category="job_success",
+            level="INFO",
+            job_id=UUID(file_id),
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "video_id": video_id,
+                "mode": "scene_split",
+                "scene_count": len(scene_result.scenes),
+                "indexed_count": indexed_count,
+                "speech_used": speech_segments is not None,
+                "stt_available": stt_available,
+            },
+        )
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         logger.exception("scene_split_failed", extra={
@@ -213,6 +234,21 @@ def handle_scene_split(
             )
         except Exception:
             logger.warning("scene_split_status_update_failed", exc_info=True)
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="drive_failed",
+            category="job_failure",
+            level="ERROR",
+            job_id=UUID(file_id),
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=error_msg[:1000],
+            metadata={
+                "video_id": video_id,
+                "mode": "scene_split",
+                "error_class": type(e).__name__,
+                "error_msg": str(e)[:500],
+            },
+        )
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir, ignore_errors=True)

--- a/services/drive-worker/src/worker.py
+++ b/services/drive-worker/src/worker.py
@@ -11,12 +11,14 @@ from pathlib import Path
 from typing import Optional
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from heimdex_worker_sdk import emit_event
 from heimdex_worker_sdk.internal_api import InternalAPIClient
 
 from heimdex_worker_sdk.settings import get_worker_settings
 from src.tasks.discover import discover_new_files
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "drive-worker"
 
 _org_slots: dict[str, int] = defaultdict(int)
 _org_lock = threading.Lock()
@@ -253,6 +255,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             scheduler.shutdown(wait=False)
             sqs_consumer.stop(timeout=30.0)
             if export_consumer:
@@ -271,6 +279,20 @@ def main() -> None:
                 "per_org_concurrency": settings.drive_worker_per_org_concurrency,
                 "disk_budget_gb": settings.drive_temp_disk_budget_gb,
                 "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "global_concurrency": settings.drive_worker_global_concurrency,
+                "per_org_concurrency": settings.drive_worker_per_org_concurrency,
+                "discovery_poll_interval": settings.drive_worker_poll_interval_seconds,
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+                "export_consumer_enabled": export_consumer is not None,
+                "gpu_orchestrator_enabled": gpu_orch is not None,
             },
         )
         await stop_event.wait()

--- a/services/shorts-render-worker/Dockerfile
+++ b/services/shorts-render-worker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install worker SDK
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 # Install Python dependencies.
 # heimdex-media-contracts + heimdex-media-pipelines are volume-mounted

--- a/services/shorts-render-worker/src/tasks/render.py
+++ b/services/shorts-render-worker/src/tasks/render.py
@@ -10,11 +10,15 @@ import logging
 import os
 import shutil
 import tempfile
+import time
 from pathlib import Path
+
+from heimdex_worker_sdk import emit_event
 
 from src.message_adapter import RenderJobMessage
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "shorts-render-worker"
 
 _DEFAULT_FONT_DIR = "/fonts"
 
@@ -136,6 +140,8 @@ def process_render_job(*, api_client, settings, render_job: RenderJobMessage) ->
 
     work_dir = tempfile.mkdtemp(prefix=f"shorts_render_{job_id}_")
 
+    t_start = time.monotonic()
+
     try:
         # 1. Report rendering status
         _report_status(api_client, org_id, job_id, status="rendering")
@@ -222,6 +228,23 @@ def process_render_job(*, api_client, settings, render_job: RenderJobMessage) ->
                 "render_time_ms": result.render_time_ms,
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="render_completed",
+            category="job_success",
+            level="INFO",
+            org_id=org_id,
+            job_id=job_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "s3_key": s3_key,
+                "output_duration_ms": result.duration_ms,
+                "output_size_bytes": result.size_bytes,
+                "render_time_ms": result.render_time_ms,
+                "clip_count": len(spec.scene_clips),
+                "subtitle_count": len(spec.subtitles),
+            },
+        )
 
     except Exception as exc:
         logger.error(
@@ -239,6 +262,20 @@ def process_render_job(*, api_client, settings, render_job: RenderJobMessage) ->
             )
         except Exception:
             logger.exception("render_status_update_failed", extra={"job_id": job_id})
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="render_failed",
+            category="job_failure",
+            level="ERROR",
+            org_id=org_id,
+            job_id=job_id,
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(exc).__name__}: {exc}"[:1000],
+            metadata={
+                "error_class": type(exc).__name__,
+                "error_msg": str(exc)[:500],
+            },
+        )
 
     finally:
         shutil.rmtree(work_dir, ignore_errors=True)

--- a/services/shorts-render-worker/src/worker.py
+++ b/services/shorts-render-worker/src/worker.py
@@ -5,7 +5,10 @@ import signal
 import sys
 import threading
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "shorts-render-worker"
 _semaphore: threading.Semaphore | None = None
 
 
@@ -75,6 +78,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             sqs_consumer.stop(timeout=30.0)
             stop_event.set()
 
@@ -84,6 +93,15 @@ def main() -> None:
         logger.info(
             "shorts_render_worker_started",
             extra={
+                "sqs_consumer_enabled": settings.sqs_consumer_enabled,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
                 "sqs_consumer_enabled": settings.sqs_consumer_enabled,
             },
         )

--- a/services/youtube-worker/Dockerfile
+++ b/services/youtube-worker/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.1.0"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
 
 COPY services/youtube-worker/pyproject.toml .
 RUN pip install --no-cache-dir -e . 2>/dev/null || \

--- a/services/youtube-worker/Dockerfile
+++ b/services/youtube-worker/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.1"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.2"
 
 COPY services/youtube-worker/pyproject.toml .
 RUN pip install --no-cache-dir -e . 2>/dev/null || \

--- a/services/youtube-worker/src/tasks/cleanup.py
+++ b/services/youtube-worker/src/tasks/cleanup.py
@@ -1,8 +1,12 @@
 import logging
+import time
 import importlib
 from typing import Any
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "youtube-worker"
 
 _youtube_keys = importlib.import_module("heimdex_worker_sdk.youtube_keys")
 youtube_metadata_s3_key = _youtube_keys.youtube_metadata_s3_key
@@ -30,6 +34,21 @@ def cleanup_completed_videos(api_client: Any, settings: Any) -> int:
     for video in videos:
         if not video.get("all_enrichment_complete", True):
             logger.info("youtube_cleanup_skipped_incomplete", extra={"video_id": video.get("video_id")})
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="youtube_skipped",
+                category="job_failure",
+                level="WARNING",
+                duration_ms=0,
+                message="enrichment_incomplete",
+                metadata={
+                    "mode": "cleanup_video",
+                    "video_id": video.get("video_id"),
+                    "youtube_video_id": video.get("youtube_video_id"),
+                    "reason": "enrichment_incomplete",
+                    "error_class": "EnrichmentIncomplete",
+                },
+            )
             continue
         if video.get("original_deleted"):
             continue
@@ -38,6 +57,8 @@ def cleanup_completed_videos(api_client: Any, settings: Any) -> int:
         channel_ext_id = str(video.get("channel_external_id") or video.get("channel_id"))
         youtube_video = str(video["youtube_video_id"])
         video_pk = video["id"]
+
+        t_start = time.monotonic()
 
         try:
             s3.delete(youtube_original_s3_key(org_id, channel_ext_id, youtube_video))
@@ -55,9 +76,40 @@ def cleanup_completed_videos(api_client: Any, settings: Any) -> int:
                 "youtube_original_cleanup_complete",
                 extra={"video_id": video.get("video_id"), "youtube_video_id": youtube_video},
             )
-        except Exception:
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="youtube_completed",
+                category="job_success",
+                level="INFO",
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                metadata={
+                    "mode": "cleanup_video",
+                    "org_id_str": org_id,
+                    "video_id": video.get("video_id"),
+                    "youtube_video_id": youtube_video,
+                    "channel_external_id": channel_ext_id,
+                },
+            )
+        except Exception as e:
             logger.exception(
                 "youtube_original_cleanup_failed",
                 extra={"video_id": video.get("video_id"), "youtube_video_id": youtube_video},
+            )
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="youtube_failed",
+                category="job_failure",
+                level="ERROR",
+                duration_ms=int((time.monotonic() - t_start) * 1000),
+                message=f"{type(e).__name__}: {e}"[:1000],
+                metadata={
+                    "mode": "cleanup_video",
+                    "org_id_str": org_id,
+                    "video_id": video.get("video_id"),
+                    "youtube_video_id": youtube_video,
+                    "channel_external_id": channel_ext_id,
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
             )
     return deleted_count

--- a/services/youtube-worker/src/tasks/download.py
+++ b/services/youtube-worker/src/tasks/download.py
@@ -9,7 +9,10 @@ from typing import Any
 
 import yt_dlp
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "youtube-worker"
 
 _youtube_keys = importlib.import_module("heimdex_worker_sdk.youtube_keys")
 youtube_metadata_s3_key = _youtube_keys.youtube_metadata_s3_key
@@ -76,6 +79,8 @@ def download_and_upload_video(api_client: Any, settings: Any, video_record: dict
     youtube_video = str(video_record["youtube_video_id"])
     temp_dir = Path(settings.youtube_temp_dir) / org_id / youtube_video
     temp_dir.mkdir(parents=True, exist_ok=True)
+
+    t_start = time.monotonic()
 
     try:
         _call_api(
@@ -171,6 +176,22 @@ def download_and_upload_video(api_client: Any, settings: Any, video_record: dict
                 "has_subtitles": subtitle_key is not None,
             },
         )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="youtube_completed",
+            category="job_success",
+            level="INFO",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            metadata={
+                "mode": "download_video",
+                "org_id_str": org_id,
+                "video_id": video_record.get("video_id"),
+                "youtube_video_id": youtube_video,
+                "channel_external_id": channel_ext_id,
+                "has_subtitles": subtitle_key is not None,
+                "has_metadata": metadata_key is not None,
+            },
+        )
         return True
     except Exception as exc:
         logger.exception(
@@ -187,6 +208,23 @@ def download_and_upload_video(api_client: Any, settings: Any, video_record: dict
             status="failed",
             error=f"{type(exc).__name__}: {exc}",
             org_id=org_id,
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="youtube_failed",
+            category="job_failure",
+            level="ERROR",
+            duration_ms=int((time.monotonic() - t_start) * 1000),
+            message=f"{type(exc).__name__}: {exc}"[:1000],
+            metadata={
+                "mode": "download_video",
+                "org_id_str": org_id,
+                "video_id": video_record.get("video_id"),
+                "youtube_video_id": youtube_video,
+                "channel_external_id": channel_ext_id,
+                "error_class": type(exc).__name__,
+                "error_msg": str(exc)[:500],
+            },
         )
         return False
     finally:

--- a/services/youtube-worker/src/tasks/enumerate.py
+++ b/services/youtube-worker/src/tasks/enumerate.py
@@ -1,12 +1,16 @@
 # pyright: reportMissingModuleSource=false, reportMissingTypeArgument=false, reportArgumentType=false
 
 import logging
+import time
 import importlib
 from typing import Any
 
 import yt_dlp
 
+from heimdex_worker_sdk import emit_event
+
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "youtube-worker"
 youtube_video_id = importlib.import_module("heimdex_worker_sdk.youtube_keys").youtube_video_id
 
 
@@ -75,6 +79,7 @@ def sync_all_channels(api_client: Any, settings: Any) -> int:
         channel_id = str(channel["id"])
         org_id = str(channel.get("org_id", default_org_id))
         channel_url = channel["channel_url"]
+        t_chan_start = time.monotonic()
         try:
             cookies = getattr(settings, "youtube_cookies_path", "") or None
             discovered = enumerate_channel(channel_url, cookies_path=cookies)
@@ -121,6 +126,35 @@ def sync_all_channels(api_client: Any, settings: Any) -> int:
                     "created_count": len(new_items),
                 },
             )
-        except Exception:
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="youtube_completed",
+                category="job_success",
+                level="INFO",
+                duration_ms=int((time.monotonic() - t_chan_start) * 1000),
+                metadata={
+                    "mode": "sync_channel",
+                    "channel_id": channel_id,
+                    "org_id_str": org_id,
+                    "discovered_count": len(discovered),
+                    "created_count": len(new_items),
+                },
+            )
+        except Exception as e:
             logger.exception("youtube_channel_sync_failed", extra={"channel_id": channel_id})
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="youtube_failed",
+                category="job_failure",
+                level="ERROR",
+                duration_ms=int((time.monotonic() - t_chan_start) * 1000),
+                message=f"{type(e).__name__}: {e}"[:1000],
+                metadata={
+                    "mode": "sync_channel",
+                    "channel_id": channel_id,
+                    "org_id_str": org_id,
+                    "error_class": type(e).__name__,
+                    "error_msg": str(e)[:500],
+                },
+            )
     return created_total

--- a/services/youtube-worker/src/worker.py
+++ b/services/youtube-worker/src/worker.py
@@ -4,12 +4,15 @@ import signal
 import importlib
 from pathlib import Path
 
+from heimdex_worker_sdk import emit_event
+
 from src.config import get_settings
 from src.tasks.cleanup import cleanup_completed_videos
 from src.tasks.download import process_pending_downloads
 from src.tasks.enumerate import sync_all_channels
 
 logger = logging.getLogger(__name__)
+_SERVICE_NAME = "youtube-worker"
 AsyncIOScheduler = importlib.import_module("apscheduler.schedulers.asyncio").AsyncIOScheduler
 YouTubeAPIClient = importlib.import_module("heimdex_worker_sdk.youtube_api").YouTubeAPIClient
 
@@ -105,6 +108,12 @@ def main() -> None:
 
         def shutdown(*_: object) -> None:
             logger.info("shutdown_signal_received")
+            emit_event(
+                service=_SERVICE_NAME,
+                event_name="worker_stopping",
+                category="worker_lifecycle",
+                level="INFO",
+            )
             scheduler.shutdown(wait=False)
             stop_event.set()
 
@@ -119,6 +128,17 @@ def main() -> None:
                 "cleanup_hourly": True,
                 "max_concurrent_downloads": settings.youtube_max_concurrent_downloads,
                 "temp_dir": settings.youtube_temp_dir,
+            },
+        )
+        emit_event(
+            service=_SERVICE_NAME,
+            event_name="worker_started",
+            category="worker_lifecycle",
+            level="INFO",
+            metadata={
+                "sync_interval_seconds": settings.youtube_sync_interval_seconds,
+                "max_concurrent_downloads": settings.youtube_max_concurrent_downloads,
+                "auto_delete_originals": settings.youtube_auto_delete_originals,
             },
         )
         await stop_event.wait()


### PR DESCRIPTION
Re-lands PR #83 (worker_events feature) after the cross-repo gating incident.

## What this is

Squash of two changes:
1. **Reapply PR #83** — worker_events DB table, internal POST endpoint, emit_event() wired into all workers, BigQuery export CLI, nightly cron. Identical to the original PR less one stale moodboard test that was already removed.
2. **Bump heimdex-worker-sdk pin to 0.3.2** — PyPI 0.3.2 (just published from heimdex-worker-sdk PR #1) is the version that actually contains emit_event(). Earlier 0.3.1 pin was broken because the function didn't exist anywhere.

## Incident context

PR #83 merged Apr 27 with a 0.3.1 pin, but emit_event was never published in any SDK version. Workers crash-looped on staging with ImportError. Reverted, then properly published worker-sdk 0.3.2, now re-landing.

## Verification

- worker-sdk 0.3.2 confirmed on PyPI: https://pypi.org/project/heimdex-worker-sdk/0.3.2/
- Staging EC2 editable mount at /opt/heimdex/heimdex-worker-sdk/ already pulled to 7e1505e (includes events.py)
- Migration 049 is already applied on staging DB (worker_events table exists from previous merge); alembic chain stays intact

## Test plan

- [ ] CI green
- [ ] Staging deploy succeeds (workers boot without ImportError)
- [ ] Verify a worker actually POSTs to /internal/worker-events on next job