### PR TITLE
fix(worker-events): bound payload size and concurrent DB sessions (H1, H2)

### DIFF
--- a/services/api/app/modules/worker_events/internal_schemas.py
+++ b/services/api/app/modules/worker_events/internal_schemas.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .schemas import WorkerEventCategory, WorkerEventLevel
+
+_MAX_MESSAGE_LEN = 4096
+_MAX_METADATA_BYTES = 16 * 1024
 
 
 class WorkerEventIngestRequest(BaseModel):
@@ -17,8 +21,21 @@ class WorkerEventIngestRequest(BaseModel):
     job_id: UUID | None = None
     video_id: UUID | None = None
     duration_ms: int | None = Field(default=None, ge=0)
-    message: str | None = None
+    message: str | None = Field(default=None, max_length=_MAX_MESSAGE_LEN)
     metadata: dict[str, Any] | None = None
+
+    @field_validator("metadata")
+    @classmethod
+    def _bound_metadata_size(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        if v is None:
+            return v
+        encoded_size = len(json.dumps(v, default=str).encode("utf-8"))
+        if encoded_size > _MAX_METADATA_BYTES:
+            raise ValueError(
+                f"metadata exceeds {_MAX_METADATA_BYTES} bytes "
+                f"(got {encoded_size} bytes JSON-serialized)"
+            )
+        return v
 
 
 class WorkerEventIngestResponse(BaseModel):

--- a/services/api/app/modules/worker_events/recorder.py
+++ b/services/api/app/modules/worker_events/recorder.py
@@ -10,6 +10,12 @@ from .schemas import WorkerEventCategory, WorkerEventLevel
 
 logger = get_logger(__name__)
 
+# Caps concurrent DB sessions held for event recording. The asyncpg pool is
+# small (~10) and shared with user-facing request handlers; without this gate
+# an event burst (workers fire ~4 events/job × N concurrent jobs) raced with
+# real traffic and could exhaust the pool.
+_RECORDER_SEMAPHORE = asyncio.Semaphore(20)
+
 
 async def _record_worker_event(
     *,
@@ -31,26 +37,27 @@ async def _record_worker_event(
     Failures are logged and swallowed — observability must never block work.
     """
     try:
-        from app.db.base import get_async_session_factory
+        async with _RECORDER_SEMAPHORE:
+            from app.db.base import get_async_session_factory
 
-        from .repository import WorkerEventRepository
+            from .repository import WorkerEventRepository
 
-        factory = get_async_session_factory()
-        async with factory() as session:
-            repo = WorkerEventRepository(session)
-            await repo.create(
-                service=service,
-                event_name=event_name,
-                category=category,
-                level=level,
-                org_id=org_id,
-                job_id=job_id,
-                video_id=video_id,
-                duration_ms=duration_ms,
-                message=message,
-                metadata=metadata,
-            )
-            await session.commit()
+            factory = get_async_session_factory()
+            async with factory() as session:
+                repo = WorkerEventRepository(session)
+                await repo.create(
+                    service=service,
+                    event_name=event_name,
+                    category=category,
+                    level=level,
+                    org_id=org_id,
+                    job_id=job_id,
+                    video_id=video_id,
+                    duration_ms=duration_ms,
+                    message=message,
+                    metadata=metadata,
+                )
+                await session.commit()
     except Exception:
         logger.warning("worker_event_recording_failed", exc_info=True)
 


### PR DESCRIPTION
Pre-prod hardenings for the worker_events feature merged in #84.

## Changes

**H1 — Payload size caps** (`internal_schemas.py`)
- `message`: `max_length=4096`
- `metadata`: `field_validator` rejecting JSON-serialized payloads >16 KB

Without these, a misbehaving worker logging huge dicts could balloon the JSONB column and fill RDS.

**H2 — Bounded concurrent DB sessions** (`recorder.py`)
- Module-level `asyncio.Semaphore(20)` wraps the session-acquire path
- Caps concurrent recorder sessions at 20 (asyncpg pool is ~10, shared with user-facing handlers)

Without this, event bursts (11 workers × ~4 events/job × concurrent jobs) could exhaust the pool and cascade 5xxs into real traffic.

## Validation

- All 335 CI allowlist tests pass locally
- Smoke tests pass: 5KB message rejected ✓, 17KB metadata rejected ✓, UUID in metadata serializes ✓, semaphore initialized at value=20 ✓
- Recorder still fire-and-forget (bare `except Exception` swallow preserved)
- No behavior change when payloads are within bounds

## Why now

Code review of the production-bound diff (commits b54e063..bf737a6) flagged H1 and H2. We're holding the prod deploy until these land — see `project_emit_event_incident.md` for last incident's lesson on rushing.

## Test plan

- [ ] CI green
- [ ] Auto staging deploy succeeds
- [ ] After staging soak (~10 min), confirm worker_events still recording with no errors and pool stays healthy
- [ ] Then trigger Deploy Production