### PR TITLE
feat(shorts-editor): one-time localStorage → API preset migration (PR 5a)

### DIFF
--- a/services/web/src/features/shorts-editor/__tests__/preset-migration.test.ts
+++ b/services/web/src/features/shorts-editor/__tests__/preset-migration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the V1 → V2 preset migration.
+ *
+ * Mocks `createPreset` so we test the migration's idempotency + payload
+ * shape, not the API client itself.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api/subtitle-presets", () => ({
+  createPreset: vi.fn(),
+}));
+
+import { createPreset } from "@/lib/api/subtitle-presets";
+import {
+  _resetMigrationStateForTests,
+  legacyToCreatePayload,
+  runOneTimePresetMigration,
+} from "../lib/preset-migration";
+
+const LEGACY_KEY = "heimdex:subtitle-presets";
+const MIGRATED_FLAG_KEY = "heimdex:subtitle-presets-migrated";
+
+const mockGetToken = async () => "fake-token";
+
+function legacyPresetFixture(overrides: Partial<{ name: string; backgroundColor: string | null }> = {}) {
+  return {
+    id: "preset_1",
+    name: overrides.name ?? "헤드라인",
+    style: {
+      fontFamily: "Pretendard",
+      fontSizePx: 36,
+      fontColor: "#FFFFFF",
+      fontWeight: 700,
+      positionX: 0.5,
+      positionY: 0.85,
+      backgroundColor: overrides.backgroundColor ?? null,
+      backgroundOpacity: 0.6,
+    },
+    createdAt: 1700000000000,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  _resetMigrationStateForTests();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("legacyToCreatePayload", () => {
+  it("maps V1 SubtitleStyle → V2 PresetCreate without losing fields", () => {
+    const payload = legacyToCreatePayload(
+      legacyPresetFixture({ backgroundColor: "#000000" }),
+    );
+
+    expect(payload).toMatchObject({
+      name: "헤드라인",
+      kind: "text",
+      is_shared: false,
+    });
+    expect(payload.style_json).toMatchObject({
+      font_family: "Pretendard",
+      font_size_px: 36,
+      font_color: "#FFFFFF",
+      font_weight: 700,
+      italic: false,
+      underline: false,
+      text_align: "center",
+      line_height: 1.3,
+      letter_spacing: 0,
+      highlight_color: "#000000",
+      highlight_padding_px: 8,
+      highlight_opacity: 0.6,
+    });
+    expect(payload.style_json["effects"]).toEqual({
+      opacity: 1.0,
+      stroke: null,
+      shadow: null,
+    });
+  });
+
+  it("does NOT include `text` in style_json (so apply preserves target text)", () => {
+    const payload = legacyToCreatePayload(legacyPresetFixture());
+    expect(payload.style_json).not.toHaveProperty("text");
+  });
+
+  it("maps null backgroundColor to null highlight_color", () => {
+    const payload = legacyToCreatePayload(legacyPresetFixture({ backgroundColor: null }));
+    expect(payload.style_json["highlight_color"]).toBeNull();
+  });
+});
+
+describe("runOneTimePresetMigration", () => {
+  it("returns alreadyMigrated when flag is set + does nothing", async () => {
+    localStorage.setItem(MIGRATED_FLAG_KEY, "true");
+    localStorage.setItem(LEGACY_KEY, JSON.stringify([legacyPresetFixture()]));
+
+    const result = await runOneTimePresetMigration(mockGetToken);
+
+    expect(result.alreadyMigrated).toBe(true);
+    expect(result.migrated).toBe(0);
+    expect(createPreset).not.toHaveBeenCalled();
+    // Legacy key NOT cleared — we don't touch already-migrated state
+    expect(localStorage.getItem(LEGACY_KEY)).not.toBeNull();
+  });
+
+  it("flags as migrated even when there are no legacy entries", async () => {
+    const result = await runOneTimePresetMigration(mockGetToken);
+
+    expect(result.migrated).toBe(0);
+    expect(result.noLegacyEntries).toBe(true);
+    expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBe("true");
+    expect(createPreset).not.toHaveBeenCalled();
+  });
+
+  it("posts each legacy preset, sets flag, clears legacy on full success", async () => {
+    const presets = [
+      legacyPresetFixture({ name: "preset-A" }),
+      legacyPresetFixture({ name: "preset-B" }),
+      legacyPresetFixture({ name: "preset-C" }),
+    ];
+    localStorage.setItem(LEGACY_KEY, JSON.stringify(presets));
+    vi.mocked(createPreset).mockResolvedValue({
+      id: "id",
+      org_id: "org",
+      user_id: "user",
+      name: "name",
+      kind: "text",
+      style_json: {},
+      is_shared: false,
+      is_owned: true,
+      created_at: "x",
+      updated_at: "x",
+    });
+
+    const result = await runOneTimePresetMigration(mockGetToken);
+
+    expect(result.migrated).toBe(3);
+    expect(result.skipped).toBe(0);
+    expect(createPreset).toHaveBeenCalledTimes(3);
+    expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBe("true");
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it("skips failed entries, sets flag, but KEEPS legacy on partial failure", async () => {
+    const presets = [
+      legacyPresetFixture({ name: "ok-1" }),
+      legacyPresetFixture({ name: "boom" }),
+      legacyPresetFixture({ name: "ok-2" }),
+    ];
+    localStorage.setItem(LEGACY_KEY, JSON.stringify(presets));
+    vi.mocked(createPreset)
+      .mockResolvedValueOnce({} as never)
+      .mockRejectedValueOnce(new Error("server boom"))
+      .mockResolvedValueOnce({} as never);
+
+    const result = await runOneTimePresetMigration(mockGetToken);
+
+    expect(result.migrated).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBe("true");
+    // Legacy preserved for recovery investigation
+    expect(localStorage.getItem(LEGACY_KEY)).not.toBeNull();
+  });
+
+  it("ignores garbage in legacy localStorage", async () => {
+    localStorage.setItem(LEGACY_KEY, "not-json{");
+
+    const result = await runOneTimePresetMigration(mockGetToken);
+
+    expect(result.migrated).toBe(0);
+    expect(result.noLegacyEntries).toBe(true);
+    expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBe("true");
+    expect(createPreset).not.toHaveBeenCalled();
+  });
+});

--- a/services/web/src/features/shorts-editor/components/OverlayPanel/index.tsx
+++ b/services/web/src/features/shorts-editor/components/OverlayPanel/index.tsx
@@ -14,6 +14,7 @@ import { TransformSection } from "./TransformSection";
 import { useOverlaySelection } from "../../hooks/useOverlaySelection";
 import { usePresets } from "../../hooks/usePresets";
 import { t } from "../../lib/i18n/strings";
+import { runOneTimePresetMigration } from "../../lib/preset-migration";
 import type {
   EditorBackgroundOverlay,
   EditorOverlay,
@@ -87,6 +88,27 @@ export function OverlayPanel({
     getToken: getAccessToken,
     enabled: true,
   });
+
+  // One-time legacy localStorage → API migration. Idempotent: the migration
+  // module itself short-circuits on a "migrated" flag in localStorage, so
+  // running this on every mount is cheap (one localStorage read) for users
+  // who never had V1 presets or have already migrated.
+  useEffect(() => {
+    let cancelled = false;
+    void runOneTimePresetMigration(getAccessToken).then((result) => {
+      if (!cancelled && result.migrated > 0) {
+        // Refresh so newly imported presets show up in the dropdown.
+        void presetsApi.reload();
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // presetsApi.reload changes reference each render — intentionally not in
+    // deps; we only want this to fire once per panel mount, not on every
+    // re-render. getAccessToken is stable (auth hook).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getAccessToken]);
 
   return (
     <div className="flex h-full flex-col bg-white">

--- a/services/web/src/features/shorts-editor/lib/preset-migration.ts
+++ b/services/web/src/features/shorts-editor/lib/preset-migration.ts
@@ -1,0 +1,159 @@
+/**
+ * One-time localStorage → backend preset migration.
+ *
+ * V1 stored named-style presets in localStorage at `heimdex:subtitle-presets`.
+ * V2 stores them in the API at `/api/shorts/presets`. On the first V2 panel
+ * mount per-browser, we POST each legacy entry, mark a "migrated" flag, and
+ * clear the legacy key.
+ *
+ * Idempotency contract:
+ * - Skip entirely if `heimdex:subtitle-presets-migrated=true`.
+ * - Skip if no legacy entries exist (still set the flag so we don't read
+ *   localStorage on every mount).
+ * - On per-preset failure (e.g. 409 name conflict, transient 5xx), log,
+ *   skip that entry, continue with the rest.
+ * - The flag is set even on partial failure — we don't want to retry the
+ *   same already-migrated rows forever. The legacy key is cleared ONLY on
+ *   complete success so partial-failure history is recoverable from
+ *   localStorage if a user reports loss.
+ */
+
+import { createPreset } from "@/lib/api/subtitle-presets";
+
+const LEGACY_KEY = "heimdex:subtitle-presets";
+const MIGRATED_FLAG_KEY = "heimdex:subtitle-presets-migrated";
+
+type TokenGetter = () => Promise<string | null>;
+
+interface LegacySubtitleStyle {
+  fontFamily: string;
+  fontSizePx: number;
+  fontColor: string;
+  fontWeight: number;
+  positionX: number; // dropped — presets store style only
+  positionY: number;
+  backgroundColor: string | null;
+  backgroundOpacity: number;
+}
+
+interface LegacyPreset {
+  id: string;
+  name: string;
+  style: LegacySubtitleStyle;
+  createdAt: number;
+}
+
+export interface MigrationResult {
+  migrated: number;
+  skipped: number;
+  alreadyMigrated: boolean;
+  noLegacyEntries: boolean;
+}
+
+const EMPTY_RESULT: MigrationResult = {
+  migrated: 0,
+  skipped: 0,
+  alreadyMigrated: false,
+  noLegacyEntries: true,
+};
+
+function readLegacy(): LegacyPreset[] {
+  try {
+    const raw = localStorage.getItem(LEGACY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as LegacyPreset[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Map a V1 preset to the V2 createPreset payload.
+ *
+ * Notable choices:
+ * - `kind: "text"` always — V1 had no background overlays.
+ * - `is_shared: false` — preserve user's privacy expectation; they can opt
+ *   in via the share toggle after migration.
+ * - `text` is intentionally NOT in style_json. mergeTextStyle in usePresets
+ *   uses the target overlay's text when the key is missing, which is what
+ *   we want for migrated presets (V1 never bound text to presets either).
+ * - V1 `backgroundColor` / `backgroundOpacity` map to V2 `highlight_color` /
+ *   `highlight_opacity` — same text-fitted-pill semantics.
+ */
+export function legacyToCreatePayload(p: LegacyPreset): {
+  name: string;
+  kind: "text";
+  style_json: Record<string, unknown>;
+  is_shared: boolean;
+} {
+  return {
+    name: p.name,
+    kind: "text",
+    is_shared: false,
+    style_json: {
+      font_family: p.style.fontFamily,
+      font_size_px: p.style.fontSizePx,
+      font_color: p.style.fontColor,
+      font_weight: p.style.fontWeight,
+      italic: false,
+      underline: false,
+      text_align: "center",
+      line_height: 1.3,
+      letter_spacing: 0,
+      highlight_color: p.style.backgroundColor,
+      highlight_padding_px: 8,
+      highlight_opacity: p.style.backgroundOpacity,
+      effects: { opacity: 1.0, stroke: null, shadow: null },
+    },
+  };
+}
+
+export async function runOneTimePresetMigration(
+  getToken: TokenGetter,
+): Promise<MigrationResult> {
+  if (typeof window === "undefined") return EMPTY_RESULT;
+
+  if (localStorage.getItem(MIGRATED_FLAG_KEY) === "true") {
+    return { ...EMPTY_RESULT, alreadyMigrated: true };
+  }
+
+  const legacy = readLegacy();
+  if (legacy.length === 0) {
+    localStorage.setItem(MIGRATED_FLAG_KEY, "true");
+    return EMPTY_RESULT;
+  }
+
+  let migrated = 0;
+  let skipped = 0;
+  for (const p of legacy) {
+    try {
+      await createPreset(legacyToCreatePayload(p), getToken);
+      migrated++;
+    } catch (err) {
+      // 409 (duplicate name across users in same org isn't possible — preset
+      // names are scoped per user — but a second tab could race the migration;
+      // 5xx and offline also land here). Skip + continue.
+      // eslint-disable-next-line no-console
+      console.warn("preset-migration: skipped", p.name, err);
+      skipped++;
+    }
+  }
+
+  localStorage.setItem(MIGRATED_FLAG_KEY, "true");
+  if (skipped === 0) {
+    localStorage.removeItem(LEGACY_KEY);
+  }
+  return {
+    migrated,
+    skipped,
+    alreadyMigrated: false,
+    noLegacyEntries: false,
+  };
+}
+
+/** Test-only — reset the migrated flag + restore legacy entries. */
+export function _resetMigrationStateForTests(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(MIGRATED_FLAG_KEY);
+}


### PR DESCRIPTION
## Summary

Stacks on top of #92. Migrates V1 localStorage presets to the new `/api/shorts/presets` endpoint on the first V2 panel mount per-browser. Idempotent — short-circuits via a `migrated` flag in localStorage on subsequent mounts.

This is **PR 5a of the shorts editor V2 plan**. PR 5b (the staging/prod feature flag flips) follows separately.

## What's new

- `lib/preset-migration.ts` (113 LOC) — pure migration logic:
  - Reads `heimdex:subtitle-presets` from localStorage
  - Maps each entry to a V2 PresetCreate (kind=text, is_shared=false, text key omitted to preserve target text on apply, V1 backgroundColor → V2 highlight_color)
  - POSTs via the existing `lib/api/subtitle-presets.ts` client
  - Sets `heimdex:subtitle-presets-migrated=true` flag on first run
  - Clears legacy key only on full success (partial failure preserves history for recovery)
- `OverlayPanel/index.tsx` — `useEffect` mount hook calls the migration; on success, reloads the preset list so imported presets show in the dropdown immediately
- `__tests__/preset-migration.test.ts` (8 tests) — payload shape, idempotency, full success, partial failure, garbage input, already-migrated skip

## Test plan

- [x] 8 new migration tests pass
- [x] TypeScript clean
- [x] Full vitest sweep: 741/741 pass — zero regressions
- [ ] CI green
- [ ] Manual smoke: in browser dev tools, seed localStorage with a V1 preset, mount V2 panel, confirm preset appears in API + localStorage cleared + flag set
- [ ] Manual smoke (re-mount): confirm migration short-circuits via flag (no API calls on second mount)

## Idempotency contract

- Run-on-every-mount: cheap. One localStorage read; bails if flag set.
- Run with no legacy entries: sets flag, makes 0 API calls.
- Run with N legacy entries, all succeed: N POSTs, flag set, legacy cleared.
- Run with N entries, K fail: (N-K) POSTs succeed, flag set, legacy preserved.
- Run after user clears localStorage manually: re-runs migration on next mount (acceptable).

## Decoupling

- The migration module imports `createPreset` from the existing API client — no new dependency on the panel's hook tree.
- `_resetMigrationStateForTests` is the only test-only export; production code never reaches for it.
- Field mapping (V1 → V2) lives in `legacyToCreatePayload` as a pure function, separately tested.

## Cross-repo dependency state

| Artifact | Status |
|---|---|
| `heimdex-media-contracts` 0.12.0 | PyPI ✓ |
| `heimdex-media-pipelines` 0.12.3 | GitHub release ✓ |
| API subtitle_presets module | #90 (open) |
| Worker pin bumps + Pillow | #91 (open) |
| Web V2 panel (parent of this PR) | #92 (open) |
| Preset migration (this PR) | here, base=#92 |
| Flag flip (PR 5b) | follows |

## Merge order

After #92 merges to main, rebase this branch and re-target base to main, then merge.