### PR TITLE
fix(reranker): move offline ENVs after model bake to unbreak GPU build

### DIFF
--- a/services/drive-reranker-worker/Dockerfile.gpu
+++ b/services/drive-reranker-worker/Dockerfile.gpu
@@ -4,8 +4,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 ENV HF_HOME=/models/huggingface
-ENV TRANSFORMERS_OFFLINE=1
-ENV HF_HUB_OFFLINE=1
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
@@ -41,6 +39,13 @@ RUN --mount=type=secret,id=hf_token mkdir -p "${HF_HOME}" \
     && python -c "from transformers import AutoTokenizer, AutoModelForSequenceClassification; \
 AutoTokenizer.from_pretrained('BAAI/bge-reranker-base'); \
 AutoModelForSequenceClassification.from_pretrained('BAAI/bge-reranker-base')"
+
+# Lock to baked cache for runtime: skip the HEAD-revision check on every cold
+# start (slow + flaky on Aircloud egress) and prevent any silent updates.
+# MUST be set after the bake step above, otherwise from_pretrained() refuses
+# to download into a cold cache (LocalEntryNotFoundError on fresh build).
+ENV TRANSFORMERS_OFFLINE=1
+ENV HF_HUB_OFFLINE=1
 
 COPY dev-heimdex-for-livecommerce/services/drive-reranker-worker/src/ src/
 


### PR DESCRIPTION
## Summary

- `TRANSFORMERS_OFFLINE=1` + `HF_HUB_OFFLINE=1` were set at the top of `services/drive-reranker-worker/Dockerfile.gpu` since `33b680a` (2026-04-12), which prevented the in-build model pre-download from reaching huggingface.co. Fresh cache + offline mode → `LocalEntryNotFoundError`.
- Moving both ENVs to AFTER the bake step keeps the runtime guarantees (no HF HEAD on cold start, no silent updates) while letting the bake actually fetch the model.
- Surfaced today during the `workers=all` dispatch that re-published the other 7 GPU images; reranker was the only matrix job that failed (16-day-old failure mode that nobody noticed because GHCR `:latest` was frozen at `144286f`).

## Test plan

- [ ] Build GPU Worker Images workflow auto-fires on merge and rebuilds reranker image
- [ ] Watch `Build reranker GPU image` job — should complete (not exit 1 at the model pre-download step)
- [ ] After Aircloud picks up the new `:latest`, hit `/health` on the reranker endpoint to confirm the offline-mode model load still works at runtime
- [ ] (Optional canary) compare top-K search result overlap before/after for a sample of queries on staging — transformers floor is `>=4.49.0` so the resolved version may have changed since 2026-04-12