### PR TITLE
ci(gpu): disable BuildKit provenance/SBOM to unblock Aircloud image prep

### DIFF
--- a/.github/workflows/build-gpu-images.yml
+++ b/.github/workflows/build-gpu-images.yml
@@ -138,6 +138,13 @@ jobs:
           context: .
           file: dev-heimdex-for-livecommerce/services/drive-${{ matrix.worker }}-worker/Dockerfile.gpu
           push: true
+          # Suppress BuildKit provenance/SBOM attestations. They produce a second
+          # `unknown/unknown` manifest in the OCI image index, which breaks
+          # Aircloud's /prepare_github_container_registry_image parser with
+          # `list index out of range` (incident 2026-04-28). Re-enable once
+          # Aircloud's prep service handles OCI image indexes correctly.
+          provenance: false
+          sbom: false
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.worker }}-worker-gpu:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.worker }}-worker-gpu:${{ github.sha }}


### PR DESCRIPTION
## Summary

- `docker/build-push-action@v5` auto-attaches a GitHub provenance attestation on every push, producing an OCI image index with two manifests: the real `amd64/linux` image AND an `unknown/unknown` attestation entry.
- Aircloud's `/prepare_github_container_registry_image` parser cannot handle that shape and crashes with `list index out of range`, leaving GPU endpoints stuck in `Failed to run container` on the first prep of any new SHA digest.
- Setting `provenance: false` + `sbom: false` collapses the index back to a single platform manifest, which Aircloud parses cleanly. Verified shape with `docker buildx imagetools inspect`.

## Why now

Surfaced when transcode endpoint cycled with `Failed to run container: list index out of range` after the workers=all rebuild from earlier today (run 25027495963). Other rebuilt workers (caption/stt/ocr/face/visual-embed/blur) carry the same manifest shape and would fail identically on next cold start — fixing at the source unblocks the whole fleet.

## Test plan

- [ ] Build GPU Worker Images workflow auto-fires on merge → all 7 GPU images rebuild without provenance attestation
- [ ] `docker buildx imagetools inspect ghcr.io/.../heimdex-transcode-worker-gpu:latest` shows a single `amd64/linux` manifest, no `unknown/unknown`
- [ ] Aircloud transcode endpoint `d9ba8982-…` accepts the new image on cold start (no more `list index out of range`)
- [ ] Container starts cleanly (worker-sdk 0.3.2 ImportError fix from earlier session also lands)

## Follow-up

File with Aircloud support — their prep parser should handle OCI image indexes correctly. Once they fix it upstream, we can reconsider re-enabling provenance for supply-chain attestation value.