### PR TITLE
fix(shorts-editor): bridge V2 overlays to timeline + widen left panel

### DIFF
--- a/services/web/src/features/shorts-editor/components/EditorLayout.tsx
+++ b/services/web/src/features/shorts-editor/components/EditorLayout.tsx
@@ -11,9 +11,12 @@ interface EditorLayoutProps {
 
 export function EditorLayout({ leftPanel, preview, rightPanel, timeline }: EditorLayoutProps) {
   return (
-    <div className="grid h-[calc(100vh-64px)] grid-cols-[300px_1fr_420px] grid-rows-[1fr_260px] gap-0 overflow-hidden">
-      {/* Left panel — text overlay authoring or clip properties */}
-      <div className="overflow-y-auto border-r border-gray-200 bg-white">
+    <div className="grid h-[calc(100vh-64px)] grid-cols-[360px_1fr_420px] grid-rows-[1fr_260px] gap-0 overflow-hidden">
+      {/* Left panel — overlay authoring (V2) or clip properties.
+          Widened from 300px → 360px so V2 transform/effects sections fit
+          without horizontal overflow (3-column X/Y/rotation row, stroke
+          stepper + color swatch row). */}
+      <div className="overflow-y-auto overflow-x-hidden border-r border-gray-200 bg-white">
         {leftPanel}
       </div>
 

--- a/services/web/src/features/shorts-editor/components/ShortsEditorPage.tsx
+++ b/services/web/src/features/shorts-editor/components/ShortsEditorPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth";
@@ -17,6 +17,8 @@ import { ClipProperties } from "./ClipProperties";
 import { TextOverlayPanel } from "./TextOverlayPanel";
 import { OverlayPanel } from "./OverlayPanel";
 import { isShortsEditorV2Enabled } from "@/lib/feature-flags";
+import type { EditorSubtitle } from "../lib/types";
+import type { EditorTextOverlay } from "../lib/overlay-types";
 import { SceneListPanel } from "./SceneListPanel";
 
 function BackArrowIcon() {
@@ -83,6 +85,131 @@ export function ShortsEditorPage() {
       });
     },
     [state.subtitles, updateSubtitle],
+  );
+
+  // ---------------------------------------------------------------------
+  // V2 timeline bridge
+  // ---------------------------------------------------------------------
+  // The TimelinePanel (and SubtitleTrack inside it) only knows about V1
+  // subtitles. In V2 mode we project the overlays[] slice into a
+  // subtitle-shaped array so the timeline shows V2 text overlays as
+  // blocks, the "+ 자막" button creates V2 overlays, and selection /
+  // resize / drag callbacks dispatch V2 actions instead of V1.
+  //
+  // Background overlays are deliberately NOT projected here — the timeline
+  // only has a single "subtitle" lane and showing background blocks there
+  // would conflate two visually-distinct things. Backgrounds live on the
+  // canvas + are managed via the panel only.
+  const v2Enabled = isShortsEditorV2Enabled();
+
+  const v2TextOverlays = useMemo(
+    () =>
+      v2Enabled
+        ? state.overlays.filter(
+            (o): o is EditorTextOverlay => o.kind === "text",
+          )
+        : [],
+    [v2Enabled, state.overlays],
+  );
+
+  const timelineSubtitles: EditorSubtitle[] = useMemo(() => {
+    if (!v2Enabled) return state.subtitles;
+    return v2TextOverlays.map((o) => ({
+      id: o.id,
+      text: o.text,
+      startMs: o.startMs,
+      endMs: o.endMs,
+      // SubtitleBlock only reads {text, startMs, endMs}. Style is included
+      // for type compatibility; the timeline doesn't render with it.
+      style: {
+        fontFamily: o.fontFamily,
+        fontSizePx: o.fontSizePx,
+        fontColor: o.fontColor,
+        fontWeight: o.fontWeight,
+        positionX: o.transform.x,
+        positionY: o.transform.y,
+        backgroundColor: o.highlightColor,
+        backgroundOpacity: o.highlightOpacity,
+      },
+    }));
+  }, [v2Enabled, state.subtitles, v2TextOverlays]);
+
+  const timelineSelectedSubtitleIndex: number | null = useMemo(() => {
+    if (!v2Enabled) return state.selectedSubtitleIndex;
+    if (state.selectedOverlayId == null) return null;
+    const idx = v2TextOverlays.findIndex(
+      (o) => o.id === state.selectedOverlayId,
+    );
+    return idx >= 0 ? idx : null;
+  }, [
+    v2Enabled,
+    state.selectedSubtitleIndex,
+    state.selectedOverlayId,
+    v2TextOverlays,
+  ]);
+
+  const handleTimelineAddSubtitle = useCallback(
+    (sub: EditorSubtitle) => {
+      if (v2Enabled) {
+        // Discard the synthesized V1 subtitle's id/style; create a V2
+        // text overlay at the same timing instead. (UX regression: double-
+        // clicking the track ignores the click position and uses playhead;
+        // SubtitleTrack constructs `sub` with click-derived timing but we
+        // currently only have addTextOverlayAtPlayhead — TODO: extend the
+        // hook to accept explicit timing.)
+        editor.addTextOverlayAtPlayhead();
+      } else {
+        editor.addSubtitle(sub);
+      }
+    },
+    [v2Enabled, editor],
+  );
+
+  const handleTimelineSelectSubtitle = useCallback(
+    (index: number | null) => {
+      if (v2Enabled) {
+        if (index == null) {
+          editor.selectOverlay(null);
+          return;
+        }
+        const overlay = v2TextOverlays[index];
+        if (overlay) editor.selectOverlay(overlay.id);
+      } else {
+        editor.selectSubtitle(index);
+      }
+    },
+    [v2Enabled, editor, v2TextOverlays],
+  );
+
+  const handleTimelineUpdateSubtitle = useCallback(
+    (index: number, updates: Partial<Omit<EditorSubtitle, "id">>) => {
+      if (v2Enabled) {
+        const overlay = v2TextOverlays[index];
+        if (!overlay) return;
+        const overlayUpdates: Partial<EditorTextOverlay> = {};
+        if (updates.text !== undefined) overlayUpdates.text = updates.text;
+        if (updates.startMs !== undefined) overlayUpdates.startMs = updates.startMs;
+        if (updates.endMs !== undefined) overlayUpdates.endMs = updates.endMs;
+        if (Object.keys(overlayUpdates).length > 0) {
+          editor.updateOverlay(overlay.id, overlayUpdates);
+        }
+      } else {
+        editor.updateSubtitle(index, updates);
+      }
+    },
+    [v2Enabled, editor, v2TextOverlays],
+  );
+
+  const handleTimelineRemoveSubtitle = useCallback(
+    (index: number) => {
+      if (v2Enabled) {
+        const overlay = v2TextOverlays[index];
+        if (overlay) editor.removeOverlay(overlay.id);
+      } else {
+        editor.removeSubtitle(index);
+      }
+    },
+    [v2Enabled, editor, v2TextOverlays],
   );
 
   // Load from scene IDs (entry from ShortsCreatePage or ShortsPlanPanel)
@@ -208,18 +335,21 @@ export function ShortsEditorPage() {
       } else if (e.key === "Delete" || e.key === "Backspace") {
         if (state.selectedClipIndex != null) {
           editor.removeClip(state.selectedClipIndex);
+        } else if (v2Enabled && state.selectedOverlayId != null) {
+          editor.removeOverlay(state.selectedOverlayId);
         } else if (state.selectedSubtitleIndex != null) {
           editor.removeSubtitle(state.selectedSubtitleIndex);
         }
       } else if (e.key === "Escape") {
         editor.selectClip(null);
-        editor.selectSubtitle(null);
+        if (v2Enabled) editor.selectOverlay(null);
+        else editor.selectSubtitle(null);
       }
     };
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [state.isPlaying, state.selectedClipIndex, state.selectedSubtitleIndex, setPlaying, editor]);
+  }, [state.isPlaying, state.selectedClipIndex, state.selectedSubtitleIndex, state.selectedOverlayId, v2Enabled, setPlaying, editor]);
 
   if (isLoading) {
     return (
@@ -270,7 +400,7 @@ export function ShortsEditorPage() {
               onVolumeChange={editor.setClipVolume}
               onRemove={editor.removeClip}
             />
-          ) : isShortsEditorV2Enabled() ? (
+          ) : v2Enabled ? (
             <OverlayPanel
               state={state}
               onAddTextOverlay={editor.addTextOverlayAtPlayhead}
@@ -343,21 +473,21 @@ export function ShortsEditorPage() {
         timeline={
           <TimelinePanel
             clips={state.clips}
-            subtitles={state.subtitles}
+            subtitles={timelineSubtitles}
             zoom={state.zoom}
             playheadMs={state.playheadMs}
             isPlaying={state.isPlaying}
             totalDurationMs={state.totalDurationMs}
             selectedClipIndex={state.selectedClipIndex}
-            selectedSubtitleIndex={state.selectedSubtitleIndex}
+            selectedSubtitleIndex={timelineSelectedSubtitleIndex}
             onSelectClip={editor.selectClip}
-            onSelectSubtitle={editor.selectSubtitle}
+            onSelectSubtitle={handleTimelineSelectSubtitle}
             onTrimClip={editor.trimClip}
             onReorderClips={editor.reorderClips}
-            onUpdateSubtitle={editor.updateSubtitle}
-            onAddSubtitle={editor.addSubtitle}
+            onUpdateSubtitle={handleTimelineUpdateSubtitle}
+            onAddSubtitle={handleTimelineAddSubtitle}
             onRemoveClip={editor.removeClip}
-            onRemoveSubtitle={editor.removeSubtitle}
+            onRemoveSubtitle={handleTimelineRemoveSubtitle}
             onTogglePlay={() => setPlaying(!state.isPlaying)}
             onSeek={setPlayhead}
             onZoomChange={editor.setZoom}


### PR DESCRIPTION
## Summary

Three QA-reported issues from staging V2 testing, all the same root cause: PR #92 introduced a parallel `state.overlays[]` slice but the existing TimelinePanel/SubtitleTrack still wires to `state.subtitles[]`.

| # | Symptom | Root cause |
|---|---------|------------|
| 1 | `+ 텍스트 추가` button creates a text on screen but nothing appears on the subtitle timeline | Overlay went to `state.overlays`; timeline reads `state.subtitles` (empty) |
| 2 | Left panel overflows horizontally on V2 sections | V1's 300px column inherited; V2 transform/effects rows don't fit |
| 3 | Click `+ 자막` on the timeline → creates a box, can't edit on left panel | Timeline button creates a V1 SUBTITLE that V2 panel doesn't see |

## Fix

- `ShortsEditorPage` projects `state.overlays.filter(kind=text)` into a subtitle-shaped array (`timelineSubtitles`) when V2 is on. Selection / add / update / remove callbacks route through V2 actions via a thin compat shim. V1 mode keeps original wiring.
- Keyboard `Delete` and `Escape` branch on `v2Enabled` to operate on the right selection slice.
- `EditorLayout` left column widened 300px → 360px + `overflow-x-hidden` safety belt.

## Decoupling

`TimelinePanel`/`SubtitleTrack` themselves are unchanged — they still take `EditorSubtitle[]`. V2-awareness lives in `ShortsEditorPage`'s projection layer. When V1 sunsets, those components can swap their contract to `EditorOverlay[]` without further panel changes.

## Test plan

- [x] TypeScript clean
- [x] 741/741 vitest pass — zero regressions
- [ ] CI green
- [ ] Staging smoke after deploy:
  - V2 panel: add text → block appears on timeline
  - V2 panel: click timeline `+ 자막` → block appears, panel populates with the new overlay's fields
  - V2 panel: drag block on timeline → overlay timing updates
  - V2 panel: select block on timeline → panel switches to that overlay
  - V2 panel: no horizontal scrollbar in left column

## Known follow-ups

- Double-click on subtitle track in V2 mode adds at playhead (not click position) — UX regression vs V1; needs `addTextOverlayAt(startMs, endMs)` on the editor hook.
- Loading a saved short whose composition has legacy `subtitles[]` populated — V2 panel doesn't see them. One-time migration on `initFromComposition` is a separate follow-up.
- Backgrounds are intentionally NOT projected onto the timeline — they live on canvas + panel only.