### PR TITLE
fix(shorts-editor): drag + resize V2 overlays in the preview canvas

### DIFF
--- a/services/web/src/features/shorts-editor/components/PreviewPanel.tsx
+++ b/services/web/src/features/shorts-editor/components/PreviewPanel.tsx
@@ -19,6 +19,9 @@ interface PreviewPanelProps {
   overlays?: EditorOverlay[];
   selectedOverlayId?: string | null;
   onSelectOverlay?: (id: string | null) => void;
+  // V2 update callback — used for drag (transform.x/y) and resize
+  // (fontSizePx for text, transform.widthPx/heightPx for background).
+  onUpdateOverlay?: (id: string, updates: Partial<EditorOverlay>) => void;
   playheadMs: number;
   isPlaying: boolean;
   totalDurationMs: number;
@@ -52,6 +55,7 @@ export function PreviewPanel({
   overlays = [],
   selectedOverlayId = null,
   onSelectOverlay,
+  onUpdateOverlay,
   playheadMs,
   isPlaying,
   totalDurationMs,
@@ -94,6 +98,21 @@ export function PreviewPanel({
     origY: number;
     origFontSizePx: number;
     lockedWidth: number | null;
+  } | null>(null);
+
+  // V2 overlay drag state — separate from V1 dragRef so the two paths
+  // don't step on each other when a session has both populated.
+  const overlayDragRef = useRef<{
+    mode: "move" | "resize";
+    overlayId: string;
+    overlayKind: "text" | "background";
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+    origFontSizePx: number;
+    origWidthPx: number;
+    origHeightPx: number;
   } | null>(null);
 
   const getSubtitleIndex = useCallback((subtitleId: string): number => {
@@ -153,33 +172,134 @@ export function PreviewPanel({
   }, [getSubtitleIndex]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
-    const drag = dragRef.current;
     const container = containerRef.current;
-    if (!drag || !container) return;
-
+    if (!container) return;
     const rect = container.getBoundingClientRect();
 
-    if (drag.mode === "move") {
-      const deltaX = (e.clientX - drag.startX) / rect.width;
-      const deltaY = (e.clientY - drag.startY) / rect.height;
-      const newX = Math.max(0, Math.min(1, drag.origX + deltaX));
-      const newY = Math.max(0, Math.min(1, drag.origY + deltaY));
-      onUpdateSubtitlePosition(drag.subtitleIndex, newX, newY);
-    } else {
-      const centerX = rect.left + drag.origX * rect.width;
-      const centerY = rect.top + drag.origY * rect.height;
-      const currentDist = Math.hypot(e.clientX - centerX, e.clientY - centerY);
-      const initialDist = drag.startX; // stored initial distance
-      if (initialDist < 1) return;
-      const scale = currentDist / initialDist;
-      const newSize = Math.round(Math.max(8, Math.min(200, drag.origFontSizePx * scale)));
-      onUpdateSubtitleFontSize(drag.subtitleIndex, newSize);
+    // V1 subtitle drag --------------------------------------------------
+    const drag = dragRef.current;
+    if (drag) {
+      if (drag.mode === "move") {
+        const deltaX = (e.clientX - drag.startX) / rect.width;
+        const deltaY = (e.clientY - drag.startY) / rect.height;
+        const newX = Math.max(0, Math.min(1, drag.origX + deltaX));
+        const newY = Math.max(0, Math.min(1, drag.origY + deltaY));
+        onUpdateSubtitlePosition(drag.subtitleIndex, newX, newY);
+      } else {
+        const centerX = rect.left + drag.origX * rect.width;
+        const centerY = rect.top + drag.origY * rect.height;
+        const currentDist = Math.hypot(e.clientX - centerX, e.clientY - centerY);
+        const initialDist = drag.startX; // stored initial distance
+        if (initialDist >= 1) {
+          const scale = currentDist / initialDist;
+          const newSize = Math.round(Math.max(8, Math.min(200, drag.origFontSizePx * scale)));
+          onUpdateSubtitleFontSize(drag.subtitleIndex, newSize);
+        }
+      }
     }
-  }, [onUpdateSubtitlePosition, onUpdateSubtitleFontSize]);
+
+    // V2 overlay drag --------------------------------------------------
+    const ovDrag = overlayDragRef.current;
+    if (ovDrag) {
+      const overlay = overlays.find((o) => o.id === ovDrag.overlayId);
+      if (!overlay || !onUpdateOverlay) return;
+
+      if (ovDrag.mode === "move") {
+        const deltaX = (e.clientX - ovDrag.startX) / rect.width;
+        const deltaY = (e.clientY - ovDrag.startY) / rect.height;
+        const newX = Math.max(0, Math.min(1, ovDrag.origX + deltaX));
+        const newY = Math.max(0, Math.min(1, ovDrag.origY + deltaY));
+        onUpdateOverlay(ovDrag.overlayId, {
+          transform: { ...overlay.transform, x: newX, y: newY },
+        } as Partial<EditorOverlay>);
+      } else {
+        const centerX = rect.left + ovDrag.origX * rect.width;
+        const centerY = rect.top + ovDrag.origY * rect.height;
+        const currentDist = Math.hypot(e.clientX - centerX, e.clientY - centerY);
+        const initialDist = ovDrag.startX;
+        if (initialDist >= 1) {
+          const scale = currentDist / initialDist;
+          if (ovDrag.overlayKind === "text") {
+            const newSize = Math.round(
+              Math.max(8, Math.min(200, ovDrag.origFontSizePx * scale)),
+            );
+            onUpdateOverlay(ovDrag.overlayId, {
+              fontSizePx: newSize,
+            } as Partial<EditorOverlay>);
+          } else {
+            const newW = Math.round(Math.max(10, Math.min(10000, ovDrag.origWidthPx * scale)));
+            const newH = Math.round(Math.max(10, Math.min(10000, ovDrag.origHeightPx * scale)));
+            onUpdateOverlay(ovDrag.overlayId, {
+              transform: {
+                ...overlay.transform,
+                widthPx: newW,
+                heightPx: newH,
+              },
+            } as Partial<EditorOverlay>);
+          }
+        }
+      }
+    }
+  }, [onUpdateSubtitlePosition, onUpdateSubtitleFontSize, onUpdateOverlay, overlays]);
 
   const handlePointerUp = useCallback(() => {
     dragRef.current = null;
+    overlayDragRef.current = null;
   }, []);
+
+  // V2 overlay handlers — body drag = move, corner drag = resize.
+  // Selection happens on pointerdown so a drag-without-click still
+  // updates the panel selection mid-gesture.
+  const handleOverlayMovePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>, overlay: EditorOverlay) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelectOverlay?.(overlay.id);
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      overlayDragRef.current = {
+        mode: "move",
+        overlayId: overlay.id,
+        overlayKind: overlay.kind,
+        startX: e.clientX,
+        startY: e.clientY,
+        origX: overlay.transform.x,
+        origY: overlay.transform.y,
+        origFontSizePx:
+          overlay.kind === "text" ? overlay.fontSizePx : 0,
+        origWidthPx: overlay.transform.widthPx ?? 0,
+        origHeightPx: overlay.transform.heightPx ?? 0,
+      };
+    },
+    [onSelectOverlay],
+  );
+
+  const handleOverlayResizePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>, overlay: EditorOverlay) => {
+      e.preventDefault();
+      e.stopPropagation();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const centerX = rect.left + overlay.transform.x * rect.width;
+      const centerY = rect.top + overlay.transform.y * rect.height;
+      const startDist = Math.hypot(e.clientX - centerX, e.clientY - centerY);
+      overlayDragRef.current = {
+        mode: "resize",
+        overlayId: overlay.id,
+        overlayKind: overlay.kind,
+        startX: startDist, // reuse startX to store initial radial distance
+        startY: 0,
+        origX: overlay.transform.x,
+        origY: overlay.transform.y,
+        origFontSizePx:
+          overlay.kind === "text" ? overlay.fontSizePx : 0,
+        origWidthPx: overlay.transform.widthPx ?? 0,
+        origHeightPx: overlay.transform.heightPx ?? 0,
+      };
+    },
+    [],
+  );
 
   return (
     <div
@@ -302,6 +422,12 @@ export function PreviewPanel({
               overlay={o}
               isSelected={selectedOverlayId === o.id}
               onClick={() => onSelectOverlay?.(o.id)}
+              onMovePointerDown={(e) =>
+                handleOverlayMovePointerDown(e, o)
+              }
+              onResizePointerDown={(_corner, e) =>
+                handleOverlayResizePointerDown(e, o)
+              }
             />
           ))}
 

--- a/services/web/src/features/shorts-editor/components/ShortsEditorPage.tsx
+++ b/services/web/src/features/shorts-editor/components/ShortsEditorPage.tsx
@@ -431,6 +431,7 @@ export function ShortsEditorPage() {
             overlays={state.overlays}
             selectedOverlayId={state.selectedOverlayId}
             onSelectOverlay={editor.selectOverlay}
+            onUpdateOverlay={editor.updateOverlay}
             playheadMs={state.playheadMs}
             isPlaying={state.isPlaying}
             totalDurationMs={state.totalDurationMs}

--- a/services/web/src/features/shorts-editor/components/preview/OverlayRenderer.tsx
+++ b/services/web/src/features/shorts-editor/components/preview/OverlayRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type CSSProperties, type PointerEventHandler } from "react";
+import { type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 
 import { resolveFontFamily } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
@@ -13,29 +13,45 @@ import type {
   TransformProps,
 } from "../../lib/overlay-types";
 
+type Corner = "nw" | "ne" | "sw" | "se";
+
 interface OverlayRendererProps {
   overlay: EditorOverlay;
   isSelected: boolean;
-  onPointerDown?: PointerEventHandler<HTMLDivElement>;
+  // Body drag — caller wires this to a "move" gesture that updates
+  // overlay.transform.x / .y.
+  onMovePointerDown?: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  // Corner drag — caller wires this to a "resize" gesture that updates
+  // fontSizePx (text) or transform.widthPx/heightPx (background).
+  onResizePointerDown?: (
+    corner: Corner,
+    e: ReactPointerEvent<HTMLDivElement>,
+  ) => void;
   onClick?: () => void;
 }
 
 /**
  * Renders an EditorOverlay (text or background) as a positioned, styled
  * <div>/<p> in the preview canvas. Pure: no state, no network — caller
- * controls selection + drag.
+ * controls selection + drag math.
  *
- * Visual fidelity goal: what the user sees here approximates what the
- * worker bakes via PIL. Differences:
- * - Browser kerning vs PIL kerning will drift slightly. Tracked in plan
- *   as Risk 3 (rendered MP4 may not be pixel-identical to preview).
- * - Stroke is rendered via -webkit-text-stroke (text) or border (bg).
- * - Shadow uses CSS drop-shadow (filter) for the blur+spread approximation.
+ * Drag UX (matches V1 PreviewPanel's subtitle behavior):
+ * - Body pointerdown → caller-driven "move" — translates X/Y delta into
+ *   normalized transform.x/y updates.
+ * - Corner pointerdown (when selected) → caller-driven "resize" —
+ *   translates radial distance ratio into a proportional fontSizePx
+ *   (text) or widthPx/heightPx (background) update.
+ *
+ * Visual fidelity:
+ * - Browser kerning vs PIL kerning will drift slightly (Risk 3 in plan).
+ * - Stroke is rendered via -webkit-text-stroke (text) or outline (bg).
+ * - Shadow uses CSS text-shadow stack / box-shadow (with spread).
  */
 export function OverlayRenderer({
   overlay,
   isSelected,
-  onPointerDown,
+  onMovePointerDown,
+  onResizePointerDown,
   onClick,
 }: OverlayRendererProps) {
   if (overlay.kind === "text") {
@@ -43,7 +59,8 @@ export function OverlayRenderer({
       <TextOverlayBox
         overlay={overlay}
         isSelected={isSelected}
-        onPointerDown={onPointerDown}
+        onMovePointerDown={onMovePointerDown}
+        onResizePointerDown={onResizePointerDown}
         onClick={onClick}
       />
     );
@@ -52,7 +69,8 @@ export function OverlayRenderer({
     <BackgroundOverlayBox
       overlay={overlay}
       isSelected={isSelected}
-      onPointerDown={onPointerDown}
+      onMovePointerDown={onMovePointerDown}
+      onResizePointerDown={onResizePointerDown}
       onClick={onClick}
     />
   );
@@ -65,20 +83,21 @@ export function OverlayRenderer({
 function TextOverlayBox({
   overlay,
   isSelected,
-  onPointerDown,
+  onMovePointerDown,
+  onResizePointerDown,
   onClick,
 }: {
   overlay: EditorTextOverlay;
   isSelected: boolean;
-  onPointerDown?: PointerEventHandler<HTMLDivElement>;
+  onMovePointerDown?: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  onResizePointerDown?: (
+    corner: Corner,
+    e: ReactPointerEvent<HTMLDivElement>,
+  ) => void;
   onClick?: () => void;
 }) {
   const containerStyle = positionContainerStyle(overlay.transform, overlay.layerIndex);
 
-  // Effects → CSS. Stroke is approximated via -webkit-text-stroke; opacity
-  // is on the wrapper so it composes with shadow/stroke. Shadow uses CSS
-  // text-shadow stack (no spread on text — CSS drop-shadow on the wrapper
-  // covers spread approximately).
   const textStyle: CSSProperties = {
     fontFamily: resolveFontFamily(overlay.fontFamily),
     fontSize: `${Math.max(8, overlay.fontSizePx * 0.5)}px`,
@@ -106,10 +125,10 @@ function TextOverlayBox({
       data-overlay-id={overlay.id}
       style={{ ...containerStyle, opacity: overlay.effects.opacity }}
       className={cn(
-        "absolute select-none cursor-grab",
-        isSelected && "ring-2 ring-indigo-400",
+        "absolute select-none cursor-grab active:cursor-grabbing",
+        isSelected && "ring-2 ring-indigo-400 ring-offset-1",
       )}
-      onPointerDown={onPointerDown}
+      onPointerDown={onMovePointerDown}
       onClick={(e) => {
         e.stopPropagation();
         onClick?.();
@@ -123,6 +142,10 @@ function TextOverlayBox({
       ) : (
         <p style={textStyle}>{overlay.text}</p>
       )}
+
+      {isSelected && onResizePointerDown && (
+        <ResizeHandles onResize={onResizePointerDown} />
+      )}
     </div>
   );
 }
@@ -134,12 +157,17 @@ function TextOverlayBox({
 function BackgroundOverlayBox({
   overlay,
   isSelected,
-  onPointerDown,
+  onMovePointerDown,
+  onResizePointerDown,
   onClick,
 }: {
   overlay: EditorBackgroundOverlay;
   isSelected: boolean;
-  onPointerDown?: PointerEventHandler<HTMLDivElement>;
+  onMovePointerDown?: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  onResizePointerDown?: (
+    corner: Corner,
+    e: ReactPointerEvent<HTMLDivElement>,
+  ) => void;
   onClick?: () => void;
 }) {
   const containerStyle = positionContainerStyle(
@@ -169,17 +197,56 @@ function BackgroundOverlayBox({
       data-overlay-id={overlay.id}
       style={{ ...containerStyle, opacity: overlay.effects.opacity }}
       className={cn(
-        "absolute select-none cursor-grab",
-        isSelected && "ring-2 ring-indigo-400",
+        "absolute select-none cursor-grab active:cursor-grabbing",
+        isSelected && "ring-2 ring-indigo-400 ring-offset-1",
       )}
-      onPointerDown={onPointerDown}
+      onPointerDown={onMovePointerDown}
       onClick={(e) => {
         e.stopPropagation();
         onClick?.();
       }}
     >
       <div style={boxStyle} />
+
+      {isSelected && onResizePointerDown && (
+        <ResizeHandles onResize={onResizePointerDown} />
+      )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Resize handles (4 corners)
+// ---------------------------------------------------------------------------
+
+const CORNER_STYLES: Record<Corner, string> = {
+  nw: "-top-1.5 -left-1.5 cursor-nwse-resize",
+  ne: "-top-1.5 -right-1.5 cursor-nesw-resize",
+  sw: "-bottom-1.5 -left-1.5 cursor-nesw-resize",
+  se: "-bottom-1.5 -right-1.5 cursor-nwse-resize",
+};
+
+function ResizeHandles({
+  onResize,
+}: {
+  onResize: (corner: Corner, e: ReactPointerEvent<HTMLDivElement>) => void;
+}) {
+  return (
+    <>
+      {(["nw", "ne", "sw", "se"] as const).map((corner) => (
+        <div
+          key={corner}
+          className={cn(
+            "absolute z-10 h-3 w-3 rounded-full border-2 border-white bg-indigo-500",
+            CORNER_STYLES[corner],
+          )}
+          onPointerDown={(e) => onResize(corner, e)}
+          // Stop click bubbling so corner clicks don't double as
+          // body-clicks (which would re-fire selection).
+          onClick={(e) => e.stopPropagation()}
+        />
+      ))}
+    </>
   );
 }
 
@@ -203,8 +270,6 @@ function positionContainerStyle(
 function textShadowAndStrokeStyles(e: EffectsProps): CSSProperties {
   const out: CSSProperties = {};
   if (e.stroke) {
-    // -webkit-text-stroke is supported across modern browsers; falls back
-    // gracefully to no stroke on older targets.
     (out as CSSProperties & { WebkitTextStroke?: string }).WebkitTextStroke =
       `${e.stroke.widthPx}px ${e.stroke.color}`;
   }
@@ -215,8 +280,6 @@ function textShadowAndStrokeStyles(e: EffectsProps): CSSProperties {
 }
 
 function cssTextShadow(s: ShadowProps): string {
-  // CSS text-shadow has no spread; we approximate by stacking offsets in a
-  // small ring so a wider/spread shadow still reads. Blur is native.
   if (s.spreadPx > 0) {
     const offsets: Array<[number, number]> = [];
     const r = Math.max(1, s.spreadPx);
@@ -233,6 +296,5 @@ function cssTextShadow(s: ShadowProps): string {
 }
 
 function cssBoxShadow(s: ShadowProps): string {
-  // box-shadow supports spread natively.
   return `${s.offsetX}px ${s.offsetY}px ${s.blurPx}px ${s.spreadPx}px ${s.color}`;
 }


### PR DESCRIPTION
## Summary

QA reported that V2 overlays were locked in the preview — couldn't move or resize. V1 had pointer-driven drag (move) + corner-handle resize on subtitles; the V2 OverlayRenderer only exposed `onClick`.

This was deferred from PR #92 ("V2 OverlayRenderer doesn't yet ship pointer drag/resize on the preview"). Adding it now since users hit it immediately.

## What's new

- Body pointerdown → "move" gesture, normalized translate of `transform.x` / `transform.y`. `setPointerCapture` so the drag survives cursor leaving the box.
- Corner handles (4) appear when `isSelected`. Pointerdown → "resize" using radial distance ratio:
  - **Text overlay**: scales `fontSizePx` (8..200)
  - **Background overlay**: scales `transform.widthPx` + `heightPx` (10..10000)
- Selection happens on pointerdown so the panel stays in sync mid-drag.
- Routing: `PreviewPanel` manages a separate `overlayDragRef` parallel to V1's `dragRef`; both pointer paths can run in the same session.

## Test plan

- [x] TypeScript clean
- [x] 741/741 vitest pass
- [ ] CI green
- [ ] Staging smoke after deploy:
  - V2 text overlay: drag body → moves on canvas + panel X/Y values update
  - V2 text overlay: drag corner → font size scales + panel `pt` value updates
  - V2 background overlay: drag body → moves
  - V2 background overlay: drag corner → W/H scale + panel values update
  - V1 mode (flag off): drag still works on subtitles (no regression)

## Known follow-ups

- Rotation handle (separate gesture) — rotation still only via panel stepper.
- Keyboard nudge (arrow keys to move 1px) — V1 didn't have it either.