### PR TITLE
fix(transcode): commit missing structured_logging module + piggyback tests

### DIFF
--- a/services/drive-transcode-worker/src/structured_logging.py
+++ b/services/drive-transcode-worker/src/structured_logging.py
@@ -1,0 +1,66 @@
+"""Lightweight structured-log formatter for the transcode worker.
+
+Problem: stdlib ``logging.basicConfig(format="%(asctime)s %(levelname)s
+%(name)s %(message)s")`` drops ``extra={}`` fields entirely. Every
+``logger.info("event", extra={"video_id": ..., "elapsed_s": ...})`` in
+this worker therefore looks like ``"... event"`` in CloudWatch — no
+way to parse per-field values for baselines or dashboards.
+
+Solution: a minimal ``Formatter`` subclass that appends the extras as
+space-delimited ``key=<repr-value>`` pairs AFTER the normal message.
+CloudWatch Logs Insights and the baseline harvester
+(``scripts/capture_scene_detect_baseline.py``) already regex-match on
+this shape.
+
+**Scoped to this worker.** If other workers want the same pattern,
+lift to ``heimdex-worker-sdk`` — don't copy-paste. For now keep the
+blast radius small.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+# Attributes the stdlib Formatter machinery sets on every record.
+# Anything NOT in this set came from ``extra={}`` and is candidate
+# for KV appending. Keeping this as a constant (rather than computing
+# per-record) avoids a hot-path dict allocation.
+_STANDARD_LOGRECORD_ATTRS = frozenset({
+    "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+    "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+    "created", "msecs", "relativeCreated", "thread", "threadName",
+    "processName", "process", "asctime", "message", "taskName",
+    # Library-injected attributes we don't want leaking into the KV tail.
+    # `color_message` is set by uvicorn's DefaultFormatter on some access
+    # log records; harmless in this worker but defensive for future reuse.
+    "color_message",
+})
+
+
+class StructuredExtraFormatter(logging.Formatter):
+    """Appends ``logger.info("...", extra={})`` fields as ``k=v`` pairs.
+
+    Output shape:
+
+        2026-04-22 14:22:10 INFO src.tasks.transcode scene_detection_complete
+            video_id='abc-123' elapsed_s=4.312 scene_count=17
+
+    Values are ``repr()``-ed so strings are quoted (making the output
+    regex-friendly for the harvester's ``video_id['\":=\\s]+['\"]?...``
+    patterns) and floats stay as numeric literals.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+        # Compose extras view without mutating the record (defensive
+        # against handlers later in the chain).
+        extras: dict[str, Any] = {
+            k: v for k, v in record.__dict__.items()
+            if k not in _STANDARD_LOGRECORD_ATTRS and not k.startswith("_")
+        }
+        if not extras:
+            return base
+        kv = " ".join(f"{k}={v!r}" for k, v in extras.items())
+        return f"{base} {kv}"

--- a/services/drive-transcode-worker/tests/test_build_piggyback_cmd.py
+++ b/services/drive-transcode-worker/tests/test_build_piggyback_cmd.py
@@ -1,0 +1,141 @@
+"""Unit tests for `_build_nvenc_piggyback_cmd` — pure command-shape
+assertions, no subprocess invocation.
+
+These tests lock in the structural corrections that emerged from the
+Phase 0.1 spike:
+  * No `split=2` on CUDA surfaces — `[0:v]` referenced twice.
+  * Detection branch terminated with `nullsink`, not `-map [D] -f null -`.
+  * Proxy output comes first; `-movflags +faststart` binds to the proxy.
+  * `-map 0:a?` with the `?` modifier so audio-less videos don't fail.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.tasks.transcode import _build_nvenc_piggyback_cmd
+
+
+@pytest.fixture
+def settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        drive_proxy_max_height=720,
+        drive_proxy_crf=23,
+        drive_proxy_max_bitrate="2500k",
+        drive_proxy_bufsize="5000k",
+        drive_proxy_audio_bitrate="128k",
+    )
+
+
+def test_cmd_uses_cuda_hwaccel(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    i = cmd.index("-hwaccel")
+    assert cmd[i + 1] == "cuda"
+    i = cmd.index("-hwaccel_output_format")
+    assert cmd[i + 1] == "cuda"
+
+
+def test_filter_complex_has_no_explicit_split_on_cuda(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    # Spike finding: `split` is a software filter and breaks on CUDA
+    # surfaces. We reference [0:v] twice instead.
+    assert "split=2" not in fc
+    assert fc.count("[0:v]") == 2
+
+
+def test_filter_complex_uses_hwdownload_on_detection_branch(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    assert "hwdownload,format=nv12" in fc
+    # Encode branch stays on GPU (scale_cuda, no hwdownload before it).
+    assert "scale_cuda=-2:720" in fc
+
+
+def test_detection_branch_terminates_with_nullsink(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    assert "metadata=print:file=/scores.txt,nullsink" in fc
+    # Must NOT map the detection branch as a separate output — that was
+    # the wrapped_avframe EINVAL bug on zero-cut videos.
+    assert "[D]" not in fc
+    # And there should be only one `-f null -` pair (if any) — ensure
+    # our command does not carry a null-sink output file.
+    assert "null" not in cmd or cmd.count("null") == 0
+
+
+def test_proxy_output_comes_before_any_sink(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    # The proxy output path must appear AFTER -movflags +faststart (so
+    # those apply to the proxy) and there should be NO additional output
+    # file after it.
+    proxy_idx = cmd.index("/out.mp4")
+    faststart_idx = cmd.index("+faststart")
+    assert faststart_idx < proxy_idx
+    # Nothing after the proxy output (no null sink, no second file).
+    assert proxy_idx == len(cmd) - 1
+
+
+def test_audio_mapping_is_optional(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    # `-map 0:a?` — the `?` modifier makes the audio stream optional so
+    # audio-less videos still encode successfully.
+    maps = [cmd[i + 1] for i, v in enumerate(cmd) if v == "-map"]
+    assert "0:a?" in maps
+
+
+def test_encode_branch_uses_nvenc(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    assert "h264_nvenc" in cmd
+    assert "-preset" in cmd
+    i = cmd.index("-preset")
+    assert cmd[i + 1] == "p4"
+
+
+def test_settings_propagated(settings) -> None:
+    settings.drive_proxy_max_height = 1080
+    settings.drive_proxy_crf = 20
+    settings.drive_proxy_max_bitrate = "5000k"
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/scores.txt"), settings,
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    assert "scale_cuda=-2:1080" in fc
+    assert "20" in cmd
+    assert "5000k" in cmd
+
+
+def test_scores_file_path_embedded_exactly(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"),
+        Path("/out.mp4"),
+        Path("/var/tmp/scores.txt"),
+        settings,
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    assert "metadata=print:file=/var/tmp/scores.txt" in fc
+
+
+def test_threshold_is_embedded_in_select_filter(settings) -> None:
+    cmd = _build_nvenc_piggyback_cmd(
+        Path("/in.mp4"), Path("/out.mp4"), Path("/s.txt"), settings,
+        threshold=0.5,
+    )
+    fc = cmd[cmd.index("-filter_complex") + 1]
+    assert "select='gt(scene,0.5)'" in fc

--- a/services/drive-transcode-worker/tests/test_scene_pipeline_import_surface.py
+++ b/services/drive-transcode-worker/tests/test_scene_pipeline_import_surface.py
@@ -1,0 +1,101 @@
+"""Phase 3 import-surface guard: forbid direct calls to the scene
+pipeline primitives from worker task modules.
+
+After Phase 3 both ``drive-worker/src/tasks/process.py`` and
+``drive-transcode-worker/src/tasks/transcode.py`` must go through the
+shared ``heimdex_media_pipelines.scenes.scene_pipeline.build_scene_documents``
+helper. Inlining detect → keyframes → assemble was the Phase-3-target
+duplication; re-inlining silently drifts the two paths out of sync.
+
+Exempt: ``drive-worker/src/tasks/resplit.py`` — users provide custom
+per-request thresholds that intentionally bypass the cache / shared
+helper. The exemption is codified here so removing it requires a
+deliberate edit (not an accidental re-introduction).
+
+This is a **static text scan**, not an AST analysis. The worker code
+uses ``importlib.import_module(...).symbol`` for lazy imports, so an
+AST-level import-graph check wouldn't catch anything. Matching the
+function names as attribute access / word-boundary text is the most
+reliable gate.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+# Forbidden function names when called from a pipeline worker.
+_FORBIDDEN_SYMBOLS = (
+    "detect_scenes",
+    "extract_all_keyframes",
+    "assemble_scenes",
+    "boundaries_from_cuts",
+)
+
+# Patterns that must NOT appear in the scanned files. Covers both static
+# imports (`from X import Y`, `import Y`) and dynamic `importlib` access.
+_FORBIDDEN_PATTERNS = (
+    [re.compile(rf"\b{sym}\s*\(") for sym in _FORBIDDEN_SYMBOLS]                  # direct call
+    + [re.compile(rf"\.{sym}\b") for sym in _FORBIDDEN_SYMBOLS]                   # attribute access (importlib lazy)
+    + [re.compile(rf"\bimport\s+{sym}\b") for sym in _FORBIDDEN_SYMBOLS]          # `import Y`
+)
+
+
+# Files in scope for the Phase-3 guard.
+_SCOPED_FILES = [
+    Path(__file__).parent.parent.parent / "drive-transcode-worker" / "src" / "tasks" / "transcode.py",
+    Path(__file__).parent.parent.parent / "drive-worker" / "src" / "tasks" / "process.py",
+]
+
+# Files explicitly exempted. See docstring.
+_EXEMPT_FILES = {
+    "resplit.py",
+    "scene_split.py",  # pending migration in Phase 4; exempt until that phase lands.
+}
+
+
+@pytest.mark.parametrize("source_path", _SCOPED_FILES, ids=lambda p: p.name)
+def test_worker_source_does_not_call_scene_primitives_directly(source_path: Path) -> None:
+    assert source_path.is_file(), (
+        f"expected worker source at {source_path} — update "
+        f"_SCOPED_FILES if the file moved"
+    )
+    if source_path.name in _EXEMPT_FILES:
+        pytest.skip(f"{source_path.name} is exempt from the import-surface guard")
+    text = source_path.read_text()
+    offenders: list[tuple[str, int, str]] = []
+    for pattern in _FORBIDDEN_PATTERNS:
+        for match in pattern.finditer(text):
+            # Locate the line for reporting.
+            line_no = text[:match.start()].count("\n") + 1
+            line = text.splitlines()[line_no - 1].strip()
+            offenders.append((pattern.pattern, line_no, line))
+    if offenders:
+        msg_lines = [
+            f"{source_path.name} calls a forbidden scene primitive directly.",
+            "After Phase 3, use heimdex_media_pipelines.scenes.scene_pipeline."
+            "build_scene_documents() instead.",
+            "Offending occurrences:",
+        ]
+        for pattern, line_no, line in offenders:
+            msg_lines.append(f"  L{line_no}: {line}  (matched /{pattern}/)")
+        pytest.fail("\n".join(msg_lines))
+
+
+def test_exempt_files_are_still_allowed_to_use_primitives() -> None:
+    """Sanity-check: resplit.py DOES import these symbols (that's the
+    whole point of the exemption). If it stops doing so, the exemption
+    is stale and should be removed from ``_EXEMPT_FILES``.
+    """
+    resplit = (Path(__file__).parent.parent.parent
+               / "drive-worker" / "src" / "tasks" / "resplit.py")
+    assert resplit.is_file()
+    text = resplit.read_text()
+    # resplit.py is permitted to call these; we just check it's still
+    # using them so the exemption doesn't rot into a no-op.
+    assert any(sym in text for sym in _FORBIDDEN_SYMBOLS), (
+        "resplit.py no longer uses any scene primitive directly — "
+        "remove it from the _EXEMPT_FILES allowlist."
+    )

--- a/services/drive-transcode-worker/tests/test_try_nvenc_piggyback.py
+++ b/services/drive-transcode-worker/tests/test_try_nvenc_piggyback.py
@@ -1,0 +1,170 @@
+"""Tests for the `_try_nvenc_piggyback` helper — subprocess and parser
+interactions, failure-mode fallback semantics.
+
+Scope: verify that every plausible failure path returns ``None`` so
+the caller falls through to the legacy NVENC + libx264 chain, and that
+the success path returns parsed cuts. Does NOT exercise the full
+_process_single_transcode flow — that's pre-existing code unchanged
+for the flag=false case.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Make sure the dynamic `heimdex_media_pipelines.scenes.ffmpeg_metadata`
+# module is importable when the test runs without the pipelines package
+# installed.
+@pytest.fixture(autouse=True)
+def _stub_pipelines_metadata_module(monkeypatch):
+    """Install a stub module so `_try_nvenc_piggyback`'s lazy import
+    resolves without requiring the real pipelines lib on the test path.
+    """
+    stub = SimpleNamespace()
+    stub.parse_ffmpeg_metadata_file = MagicMock(return_value=[])
+    monkeypatch.setitem(
+        sys.modules,
+        "heimdex_media_pipelines.scenes.ffmpeg_metadata",
+        stub,
+    )
+    yield stub
+
+
+@pytest.fixture
+def settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        drive_proxy_max_height=720,
+        drive_proxy_crf=23,
+        drive_proxy_max_bitrate="2500k",
+        drive_proxy_bufsize="5000k",
+        drive_proxy_audio_bitrate="128k",
+    )
+
+
+def _fake_run_result(rc: int, stderr: bytes = b"") -> MagicMock:
+    m = MagicMock()
+    m.returncode = rc
+    m.stderr = stderr
+    return m
+
+
+def test_success_returns_parsed_cuts(settings, tmp_path, _stub_pipelines_metadata_module):
+    from src.tasks.transcode import _try_nvenc_piggyback
+
+    scores = tmp_path / "scores.txt"
+    # `_try_nvenc_piggyback` unlinks the scores file before running
+    # subprocess.run. Mimic real ffmpeg behavior by having the mocked
+    # subprocess.run write the file as its side effect.
+    def _run_and_write(*args, **kwargs):
+        scores.write_text("frame:0 pts:1 pts_time:1.0\nlavfi.scene_score=0.5\n")
+        return _fake_run_result(0)
+
+    _stub_pipelines_metadata_module.parse_ffmpeg_metadata_file = MagicMock(
+        return_value=[1000, 3000]
+    )
+
+    with patch("src.tasks.transcode.subprocess.run", side_effect=_run_and_write):
+        result = _try_nvenc_piggyback(
+            input_path=tmp_path / "in.mp4",
+            output_path=tmp_path / "out.mp4",
+            scores_file=scores,
+            settings=settings,
+            video_id="vid-1",
+        )
+    assert result == [1000, 3000]
+
+
+def test_ffmpeg_nonzero_exit_returns_none(settings, tmp_path):
+    from src.tasks.transcode import _try_nvenc_piggyback
+
+    with patch("src.tasks.transcode.subprocess.run",
+               return_value=_fake_run_result(1, b"oops")):
+        result = _try_nvenc_piggyback(
+            input_path=tmp_path / "in.mp4",
+            output_path=tmp_path / "out.mp4",
+            scores_file=tmp_path / "scores.txt",
+            settings=settings,
+            video_id="vid-1",
+        )
+    assert result is None
+
+
+def test_scores_file_missing_returns_none(settings, tmp_path):
+    from src.tasks.transcode import _try_nvenc_piggyback
+
+    # Subprocess succeeds but the scores file doesn't exist — means the
+    # filter chain silently skipped the detection branch (e.g. filter
+    # graph parsed but no frames reached nullsink).
+    with patch("src.tasks.transcode.subprocess.run",
+               return_value=_fake_run_result(0)):
+        result = _try_nvenc_piggyback(
+            input_path=tmp_path / "in.mp4",
+            output_path=tmp_path / "out.mp4",
+            scores_file=tmp_path / "does_not_exist.txt",
+            settings=settings,
+            video_id="vid-1",
+        )
+    assert result is None
+
+
+def test_parser_error_returns_none(settings, tmp_path, _stub_pipelines_metadata_module):
+    from src.tasks.transcode import _try_nvenc_piggyback
+
+    scores = tmp_path / "scores.txt"
+    scores.write_text("garbage")
+    _stub_pipelines_metadata_module.parse_ffmpeg_metadata_file = MagicMock(
+        side_effect=RuntimeError("format drift"),
+    )
+
+    with patch("src.tasks.transcode.subprocess.run",
+               return_value=_fake_run_result(0)):
+        result = _try_nvenc_piggyback(
+            input_path=tmp_path / "in.mp4",
+            output_path=tmp_path / "out.mp4",
+            scores_file=scores,
+            settings=settings,
+            video_id="vid-1",
+        )
+    assert result is None
+
+
+def test_pre_run_unlinks_existing_scores_file(settings, tmp_path, _stub_pipelines_metadata_module):
+    """metadata=print APPENDS to an existing file. On SQS redelivery the
+    temp_dir may survive an earlier partial run. The helper must unlink
+    the scores file before invoking ffmpeg.
+    """
+    from src.tasks.transcode import _try_nvenc_piggyback
+
+    scores = tmp_path / "scores.txt"
+    scores.write_text("STALE-CONTENT-FROM-PREVIOUS-RUN\n")
+    assert scores.is_file()
+
+    # Pretend the new ffmpeg run doesn't write to the file (rc=0 but
+    # no output) — we want to prove the unlink happened regardless of
+    # whether ffmpeg replaces the file.
+    def _run_stub(*args, **kwargs):
+        assert not scores.is_file(), (
+            "scores file must be deleted before ffmpeg invocation; "
+            "otherwise retries will concatenate timestamps"
+        )
+        scores.write_text("frame:0 pts:1 pts_time:1.0\nlavfi.scene_score=0.5\n")
+        return _fake_run_result(0)
+
+    _stub_pipelines_metadata_module.parse_ffmpeg_metadata_file = MagicMock(
+        return_value=[1000]
+    )
+    with patch("src.tasks.transcode.subprocess.run", side_effect=_run_stub):
+        result = _try_nvenc_piggyback(
+            input_path=tmp_path / "in.mp4",
+            output_path=tmp_path / "out.mp4",
+            scores_file=scores,
+            settings=settings,
+            video_id="vid-1",
+        )
+    assert result == [1000]


### PR DESCRIPTION
## Summary

`worker.py:50` imports `from src.structured_logging import StructuredExtraFormatter` (added in PR #84 reland) but the **file itself was never `git add`-ed**. Every transcode Docker build since has produced an image that crashes immediately with:

```
ModuleNotFoundError: No module named 'src.structured_logging'
```

Confirmed locally by pulling the latest GHCR `:latest` and `docker run`-ing it.

This was the **third layer** of the 2026-04-28 transcode incident, masked by two earlier issues we already fixed today:

| Layer | Fix | Status |
|---|---|---|
| 1. `ActorDiedError` (perceived as missing SDK pin) | `0a5d63c` SDK 0.3.2 pin + manual rebuild | merged |
| 2. `list index out of range` on Aircloud image prep | PR #97 — `provenance: false` | merged |
| 3. `A replica's health check failed` | **this PR** — commit the missing module | open |

Once layers 1 and 2 cleared, Aircloud could finally prep and start the container — exposing the underlying ModuleNotFoundError as a health-check failure.

Bundling the previously-untracked piggyback test suite in the same commit so the Phase 0.1 NVENC piggyback work and Phase 3 scene-pipeline import-surface guard stop being WIP-on-disk-only.

## Test plan

- [x] Local repro: `docker pull ... && docker run` shows `ModuleNotFoundError` on master image
- [ ] After merge, `Build GPU Worker Images` auto-fires (path filter `services/drive-transcode-worker/**` matches)
- [ ] Pull rebuilt `:latest`, run locally — should print `transcode_worker_started` and stay alive (or exit cleanly on the gated `sqs_consumer_required_but_not_configured` if env is incomplete)
- [ ] Aircloud transcode endpoint accepts the rebuilt image without health-check retries