### PR TITLE
feat(shorts-auto): Phase 3 — editable title in inspector

### DIFF
--- a/services/api/app/modules/shorts_render/repository.py
+++ b/services/api/app/modules/shorts_render/repository.py
@@ -160,6 +160,32 @@ class ShortsRenderJobRepository:
 
         return await self._get_by_id_internal(job_id)
 
+    async def update_title(
+        self,
+        org_id: UUID,
+        user_id: UUID,
+        job_id: UUID,
+        title: str | None,
+    ) -> ShortsRenderJob | None:
+        """Update the user-visible title on a render job.
+
+        Scoped to org + user so a guess at someone else's job UUID
+        can't rename their work. ``None`` clears the title back to
+        the default fallback the FE will compute. Returns the
+        refreshed job, or ``None`` when the job doesn't exist or
+        isn't owned by ``(org_id, user_id)``.
+        """
+        job = await self.get_by_id(org_id, user_id, job_id)
+        if job is None:
+            return None
+        await self.session.execute(
+            update(ShortsRenderJob)
+            .where(ShortsRenderJob.id == job_id)
+            .values(title=title, updated_at=datetime.now(timezone.utc))
+        )
+        await self.session.flush()
+        return await self._get_by_id_internal(job_id)
+
     async def delete(self, org_id: UUID, user_id: UUID, job_id: UUID) -> bool:
         """Delete a render job by ID, scoped to org + user.
 

--- a/services/api/app/modules/shorts_render/router.py
+++ b/services/api/app/modules/shorts_render/router.py
@@ -13,6 +13,7 @@ from app.modules.shorts_render.schemas import (
     RenderJobCreate,
     RenderJobListResponse,
     RenderJobResponse,
+    RenderJobTitleUpdate,
     SubtitleSuggestion,
     SubtitleSuggestions,
 )
@@ -61,6 +62,21 @@ async def get_render_job(
 ):
     user_id = cast(UUID, user.id)
     return await service.get_render_job(org_ctx.org_id, user_id, job_id)
+
+
+@router.patch("/{job_id}", response_model=RenderJobResponse)
+async def update_render_job_title(
+    job_id: UUID,
+    body: RenderJobTitleUpdate,
+    org_ctx: Annotated[OrgContext, Depends(get_current_org)],
+    user: Annotated[User, Depends(get_current_user)],
+    service: Annotated[ShortsRenderService, Depends(get_shorts_render_service)],
+):
+    """Rename a render job. Owner-scoped — 404 when the caller doesn't own the job."""
+    user_id = cast(UUID, user.id)
+    return await service.update_render_job_title(
+        org_ctx.org_id, user_id, job_id, body.title,
+    )
 
 
 @router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/services/api/app/modules/shorts_render/schemas.py
+++ b/services/api/app/modules/shorts_render/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from heimdex_media_contracts.composition import CompositionSpec
 
@@ -11,6 +11,23 @@ class RenderJobCreate(BaseModel):
     video_id: str
     title: str | None = None
     composition: CompositionSpec
+
+
+class RenderJobTitleUpdate(BaseModel):
+    """Request body for ``PATCH /api/shorts/render/{job_id}``.
+
+    Sent by the inspector panel when a user edits the title field.
+    The field is a single-purpose endpoint right now (title only) —
+    if other mutable fields land later, prefer adding a separate
+    endpoint per field over expanding this into a generic patch.
+    Keeps the schema honest about what the user can mutate.
+
+    Empty string is allowed and stored as ``""`` so users can clear
+    the title; ``None`` is treated identically. ``max_length=255``
+    matches the column width on ``shorts_render_jobs``.
+    """
+
+    title: str | None = Field(default=None, max_length=255)
 
 
 class RenderStatusUpdate(BaseModel):

--- a/services/api/app/modules/shorts_render/service.py
+++ b/services/api/app/modules/shorts_render/service.py
@@ -392,6 +392,36 @@ class ShortsRenderService:
 
         return _to_response(job, download_url=download_url)
 
+    async def update_render_job_title(
+        self,
+        org_id: UUID,
+        user_id: UUID,
+        job_id: UUID,
+        title: str | None,
+    ) -> RenderJobResponse:
+        """Update the user-facing title on a render job.
+
+        Scoped to org + user so cross-user renaming is impossible.
+        Raises 404 when the job is missing or owned by someone else
+        — same surface as ``get_render_job`` so the FE doesn't have
+        to special-case "not yours" vs "doesn't exist".
+
+        ``download_url`` is populated for completed jobs so the
+        response shape matches ``get_render_job`` and the FE can
+        slot the result in without re-fetching.
+        """
+        job = await self.repository.update_title(org_id, user_id, job_id, title)
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Render job not found",
+            )
+
+        download_url: str | None = None
+        if job.status == "completed" and job.output_s3_key:
+            download_url = f"/api/shorts/render/{job.id}/download"
+        return _to_response(job, download_url=download_url)
+
     async def list_render_jobs(
         self,
         org_id: UUID,

--- a/services/api/tests/test_shorts_render_hardening.py
+++ b/services/api/tests/test_shorts_render_hardening.py
@@ -313,3 +313,141 @@ async def test_delete_render_job_passes_user_id_to_repository():
 
     svc.repository.get_by_id.assert_awaited_once_with(org_id, user_id, job_id)
     svc.repository.delete.assert_awaited_once_with(org_id, user_id, job_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: title editing
+# ---------------------------------------------------------------------------
+
+
+def _make_completed_job(title: str = "Original", *, with_output: bool = False):
+    """Job stub for title-update tests. ``with_output`` toggles the S3
+    key so the service-layer download_url branch can be exercised.
+
+    ``input_spec`` MUST be a real dict (not a MagicMock attribute) so
+    ``_to_response`` can ``.get("scene_clips")`` on it without
+    Pydantic balking on the resulting MagicMock-typed thumbnail
+    fields.
+    """
+    job = MagicMock()
+    job.id = uuid4()
+    job.video_id = "vid_123"
+    job.title = title
+    job.status = "completed" if with_output else "queued"
+    job.created_at = datetime.now(timezone.utc)
+    job.completed_at = datetime.now(timezone.utc) if with_output else None
+    job.render_time_ms = 1500 if with_output else None
+    job.output_duration_ms = 30_000 if with_output else None
+    job.output_size_bytes = 1024 * 1024 if with_output else None
+    job.error = None
+    job.output_s3_key = "output.mp4" if with_output else None
+    job.input_spec = {
+        "scene_clips": [{"video_id": "vid_123", "scene_id": "vid_123_scene_000"}],
+    }
+    return job
+
+
+@pytest.mark.asyncio
+async def test_update_render_job_title_passes_org_user_to_repository():
+    """Owner-scoped: org_id + user_id must reach the repo update_title call.
+
+    Guards against accidental cross-tenant rename if the route ever
+    drops the user_id arg the way the GET path used to.
+    """
+    svc = _make_service_with_mocks()
+    updated = _make_completed_job("New title")
+    svc.repository.update_title = AsyncMock(return_value=updated)
+
+    org_id = uuid4()
+    user_id = uuid4()
+    job_id = uuid4()
+
+    result = await svc.update_render_job_title(org_id, user_id, job_id, "New title")
+
+    svc.repository.update_title.assert_awaited_once_with(
+        org_id, user_id, job_id, "New title",
+    )
+    assert result.title == "New title"
+
+
+@pytest.mark.asyncio
+async def test_update_render_job_title_404_when_repo_returns_none():
+    """update_title returns None on missing-or-not-owned. Service must
+    surface that as 404 (matching get_render_job semantics so the FE
+    doesn't have to special-case "not yours" vs "doesn't exist").
+    """
+    svc = _make_service_with_mocks()
+    svc.repository.update_title = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_render_job_title(uuid4(), uuid4(), uuid4(), "x")
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_render_job_title_clears_when_set_to_none():
+    """``None`` is a valid title (clears it). Service forwards as-is."""
+    svc = _make_service_with_mocks()
+    cleared = _make_completed_job(title=None)
+    svc.repository.update_title = AsyncMock(return_value=cleared)
+
+    org_id = uuid4()
+    user_id = uuid4()
+    job_id = uuid4()
+
+    result = await svc.update_render_job_title(org_id, user_id, job_id, None)
+
+    svc.repository.update_title.assert_awaited_once_with(
+        org_id, user_id, job_id, None,
+    )
+    assert result.title is None
+
+
+@pytest.mark.asyncio
+async def test_update_render_job_title_completed_job_includes_download_url():
+    """Response shape parity with get_render_job: completed jobs get a
+    download_url so the FE can immediately offer download after rename.
+    """
+    svc = _make_service_with_mocks()
+    job = _make_completed_job("renamed", with_output=True)
+    svc.repository.update_title = AsyncMock(return_value=job)
+
+    result = await svc.update_render_job_title(uuid4(), uuid4(), job.id, "renamed")
+
+    assert result.download_url == f"/api/shorts/render/{job.id}/download"
+
+
+@pytest.mark.asyncio
+async def test_update_render_job_title_in_flight_job_no_download_url():
+    """In-flight (queued/rendering) jobs have no S3 output yet.
+    download_url stays None so the FE doesn't try to fetch a 404.
+    """
+    svc = _make_service_with_mocks()
+    job = _make_completed_job("renamed", with_output=False)  # status=queued
+    svc.repository.update_title = AsyncMock(return_value=job)
+
+    result = await svc.update_render_job_title(uuid4(), uuid4(), job.id, "renamed")
+
+    assert result.download_url is None
+
+
+def test_render_job_title_update_schema_rejects_oversized_title():
+    """``max_length=255`` matches the DB column. Pydantic raises on
+    overflow; FastAPI surfaces it as 422.
+    """
+    from app.modules.shorts_render.schemas import RenderJobTitleUpdate
+    from pydantic import ValidationError
+
+    too_long = "a" * 256
+    with pytest.raises(ValidationError):
+        RenderJobTitleUpdate(title=too_long)
+
+
+def test_render_job_title_update_schema_accepts_empty_and_none():
+    """Both empty string and None are valid title-clear payloads."""
+    from app.modules.shorts_render.schemas import RenderJobTitleUpdate
+
+    assert RenderJobTitleUpdate(title=None).title is None
+    assert RenderJobTitleUpdate(title="").title == ""
+    assert RenderJobTitleUpdate().title is None  # default

--- a/services/web/src/features/shorts-auto/__tests__/InspectorPanel.test.tsx
+++ b/services/web/src/features/shorts-auto/__tests__/InspectorPanel.test.tsx
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { InspectorPanel } from "../components/InspectorPanel";
+import type { AutoClipResponse } from "@/lib/types";
+
+vi.mock("@/lib/speaker-transcript-display", () => ({
+  SpeakerTranscriptDisplay: () => <div data-testid="speaker-display" />,
+}));
+
+const baseClip: AutoClipResponse = {
+  scene_ids: ["vid_scene_000", "vid_scene_001"],
+  members: [
+    { scene_id: "vid_scene_000", start_ms: 16_000, end_ms: 31_000, score: 0.8 },
+    { scene_id: "vid_scene_001", start_ms: 35_000, end_ms: 43_000, score: 0.7 },
+  ],
+  start_ms: 16_000,
+  end_ms: 43_000,
+  duration_ms: 23_000,
+  score: 0.75,
+  reasons: [],
+  is_continuous: false,
+};
+
+describe("InspectorPanel — title editing", () => {
+  it("disables the input with a tooltip when no render-job exists", () => {
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle={null}
+        // onTitleSave intentionally omitted — disables the input
+      />,
+    );
+    // 제목 H3 is just a section heading, not a <label>, so we
+    // identify the input by its readonly attribute + tooltip copy.
+    const inputs = document.querySelectorAll("input[readonly]");
+    expect(inputs.length).toBe(1);
+    const title = inputs[0] as HTMLInputElement;
+    expect(title).toHaveAttribute("aria-readonly", "true");
+    expect(title).toHaveAttribute(
+      "title",
+      "쇼츠를 먼저 렌더링하면 제목을 변경할 수 있어요",
+    );
+    // Section heading is rendered as plain text alongside the input.
+    expect(screen.getByText("제목")).toBeInTheDocument();
+  });
+
+  it("renders an editable input pre-populated with the server title when a render-job exists", () => {
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle="기존 제목"
+        onTitleSave={async () => {}}
+      />,
+    );
+    const input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe("기존 제목");
+    expect(input).not.toHaveAttribute("readonly");
+  });
+
+  it("shows 'auto-save on blur' helper text when the user types a change", () => {
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle="A"
+        onTitleSave={async () => {}}
+      />,
+    );
+    const input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Different" } });
+    expect(
+      screen.getByText("포커스 해제 시 자동 저장됩니다"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onTitleSave with the trimmed value on blur", async () => {
+    const onTitleSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle=""
+        onTitleSave={onTitleSave}
+      />,
+    );
+    const input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  새 제목  " } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(onTitleSave).toHaveBeenCalledTimes(1));
+    expect(onTitleSave).toHaveBeenCalledWith("새 제목");
+  });
+
+  it("passes null on blur when the user clears the title to whitespace-only", async () => {
+    const onTitleSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle="이전 제목"
+        onTitleSave={onTitleSave}
+      />,
+    );
+    const input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(onTitleSave).toHaveBeenCalledTimes(1));
+    expect(onTitleSave).toHaveBeenCalledWith(null);
+  });
+
+  it("does NOT fire onTitleSave on blur when value is unchanged", () => {
+    const onTitleSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle="고정"
+        onTitleSave={onTitleSave}
+      />,
+    );
+    const input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    fireEvent.blur(input);
+    expect(onTitleSave).not.toHaveBeenCalled();
+  });
+
+  it("blurs (and saves) when the user presses Enter", async () => {
+    const onTitleSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle=""
+        onTitleSave={onTitleSave}
+      />,
+    );
+    const input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Enter to save" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(onTitleSave).toHaveBeenCalledWith("Enter to save"));
+  });
+
+  it("resets the controlled value when the underlying renderJobTitle prop changes", () => {
+    const { rerender } = render(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle="첫번째"
+        onTitleSave={async () => {}}
+      />,
+    );
+    let input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    expect(input.value).toBe("첫번째");
+
+    rerender(
+      <InspectorPanel
+        clip={baseClip}
+        scenes={[]}
+        editorHref="/edit"
+        renderJobTitle="두번째"
+        onTitleSave={async () => {}}
+      />,
+    );
+    input = screen.getByLabelText("쇼츠 제목") as HTMLInputElement;
+    expect(input.value).toBe("두번째");
+  });
+});

--- a/services/web/src/features/shorts-auto/components/AutoShortsPage.tsx
+++ b/services/web/src/features/shorts-auto/components/AutoShortsPage.tsx
@@ -229,6 +229,29 @@ export function AutoShortsPage() {
     );
   }, [renderJobs, selectedClipKey]);
 
+  // Title editing wiring — only render-job-backed states have a
+  // server row to rename. Inspector falls back to a derived
+  // placeholder + disabled input until the user has rendered.
+  const inspectorTitleState = useMemo(() => {
+    if (!selectedClipKey) return { title: null as string | null, hasJob: false };
+    const state = renderJobs.getState(selectedClipKey);
+    if (state.kind === "queued" || state.kind === "rendering" || state.kind === "completed") {
+      return { title: state.job.title, hasJob: true };
+    }
+    if (state.kind === "failed" && state.job) {
+      return { title: state.job.title, hasJob: true };
+    }
+    return { title: null, hasJob: false };
+  }, [renderJobs, selectedClipKey]);
+
+  const handleTitleSave = useCallback(
+    async (title: string | null) => {
+      if (!selectedClipKey) return;
+      await renderJobs.updateTitle(selectedClipKey, title);
+    },
+    [renderJobs, selectedClipKey],
+  );
+
   const selectErrorMessage = describeError(
     autoSelect.error,
     "자동 생성에 실패했습니다.",
@@ -340,6 +363,8 @@ export function AutoShortsPage() {
               : undefined
           }
           isDownloading={inspectorIsDownloading}
+          renderJobTitle={inspectorTitleState.title}
+          onTitleSave={inspectorTitleState.hasJob ? handleTitleSave : undefined}
         />
       }
     />

--- a/services/web/src/features/shorts-auto/components/InspectorPanel.tsx
+++ b/services/web/src/features/shorts-auto/components/InspectorPanel.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
+import { cn } from "@/lib/utils";
 import type { AutoClipResponse, VideoScene } from "@/lib/types";
 
 import { ScriptPanel } from "./ScriptPanel";
@@ -14,6 +16,18 @@ interface InspectorPanelProps {
   /** Disabled when no clip is selected or while a render is mid-flight. */
   onDownload?: () => void;
   isDownloading?: boolean;
+  /**
+   * Server-side title for the selected clip's render job (when one
+   * exists). When ``null``, no render-job has been created yet — the
+   * title input falls back to a derived placeholder and is disabled.
+   */
+  renderJobTitle?: string | null;
+  /**
+   * Save callback fired on blur when the title changed. ``undefined``
+   * when no render-job exists (input rendered as disabled with a
+   * tooltip explaining the user has to render first).
+   */
+  onTitleSave?: (title: string | null) => Promise<void> | void;
 }
 
 /**
@@ -23,9 +37,9 @@ interface InspectorPanelProps {
  *   1. Quick actions — 편집하기 (deep link to editor) + 다운로드 (mirrors
  *      the card's button so the user has a primary action without
  *      hunting back to the list).
- *   2. 제목 — read-only Phase 1. Title editing is on the roadmap; the
- *      input is kept disabled with an explanatory tooltip rather than
- *      hidden so the surface area stays stable for Phase 3.
+ *   2. 제목 — editable when a render-job exists for the selected clip
+ *      (Phase 3 added the PATCH endpoint). Disabled before that with a
+ *      tooltip directing the user to render first.
  *   3. 원본 영상 타임라인 — span readout in M분 S초 format matching the
  *      reference design.
  *   4. 스크립트 — speaker-diarized script panel.
@@ -39,6 +53,8 @@ export function InspectorPanel({
   editorHref,
   onDownload,
   isDownloading,
+  renderJobTitle,
+  onTitleSave,
 }: InspectorPanelProps) {
   if (!clip) {
     return (
@@ -48,7 +64,8 @@ export function InspectorPanel({
     );
   }
 
-  const title = clip.scene_ids.length === 1 ? `장면 ${clip.scene_ids[0]}` : "자동 생성 클립";
+  const placeholder =
+    clip.scene_ids.length === 1 ? `장면 ${clip.scene_ids[0]}` : "자동 생성 클립";
 
   return (
     <div className="flex h-full flex-col gap-5 p-5">
@@ -76,13 +93,10 @@ export function InspectorPanel({
       </Section>
 
       <Section title="제목">
-        <input
-          type="text"
-          readOnly
-          value={title}
-          aria-readonly="true"
-          title="제목 편집은 곧 지원됩니다"
-          className="w-full cursor-not-allowed rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"
+        <TitleInput
+          renderJobTitle={renderJobTitle ?? null}
+          placeholder={placeholder}
+          onSave={onTitleSave}
         />
       </Section>
 
@@ -136,5 +150,108 @@ function DownloadIcon() {
     <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
     </svg>
+  );
+}
+
+interface TitleInputProps {
+  renderJobTitle: string | null;
+  placeholder: string;
+  onSave?: (title: string | null) => Promise<void> | void;
+}
+
+/**
+ * Controlled title input that saves on blur. Three visual states:
+ *   - **disabled**: no render-job exists yet for this clip. The
+ *     placeholder displays a derived label ("장면 ..." or "자동 생성
+ *     클립"); user is directed to download first via the tooltip.
+ *   - **idle**: editable, no pending save.
+ *   - **saving**: blur fired, awaiting server. Briefly shows
+ *     "저장 중..." to confirm the action registered.
+ *
+ * Optimistic update lives in the hook (``useCandidateRenderJobs``);
+ * this component just owns the in-flight controlled value so typing
+ * doesn't lag behind the server round trip.
+ */
+function TitleInput({ renderJobTitle, placeholder, onSave }: TitleInputProps) {
+  const isEditable = onSave !== undefined;
+  // Local controlled value — initialized from the server's current
+  // title. Resets when the underlying renderJobTitle changes (e.g.,
+  // user switched between candidate cards).
+  const [draft, setDraft] = useState<string>(renderJobTitle ?? "");
+  const [savingState, setSavingState] = useState<"idle" | "saving">("idle");
+
+  useEffect(() => {
+    setDraft(renderJobTitle ?? "");
+  }, [renderJobTitle]);
+
+  const persisted = renderJobTitle ?? "";
+  const dirty = draft !== persisted;
+
+  const persistDraft = async () => {
+    if (!isEditable || !dirty || !onSave) return;
+    setSavingState("saving");
+    try {
+      // Empty string normalizes to null on the server (clears title);
+      // pass through as-is and let the API handle it. Trim once at
+      // the boundary so leading/trailing whitespace doesn't survive.
+      const trimmed = draft.trim();
+      await onSave(trimmed === "" ? null : trimmed);
+    } finally {
+      setSavingState("idle");
+    }
+  };
+
+  if (!isEditable) {
+    return (
+      <input
+        type="text"
+        readOnly
+        value={persisted || placeholder}
+        aria-readonly="true"
+        title="쇼츠를 먼저 렌더링하면 제목을 변경할 수 있어요"
+        className="w-full cursor-not-allowed rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <input
+        type="text"
+        value={draft}
+        placeholder={placeholder}
+        maxLength={255}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          void persistDraft();
+        }}
+        onKeyDown={(e) => {
+          // Enter → save and blur. Calling persistDraft directly (rather
+          // than relying on .blur() to propagate the same path) keeps
+          // jsdom-based tests deterministic — programmatic blur in jsdom
+          // doesn't always fire the React onBlur handler before assertions.
+          if (e.key === "Enter") {
+            void persistDraft();
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        aria-label="쇼츠 제목"
+        className={cn(
+          "w-full rounded-md border bg-white px-3 py-2 text-sm text-gray-900 transition-colors",
+          "border-gray-200 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400",
+          savingState === "saving" && "opacity-70",
+        )}
+      />
+      <p
+        className="text-[10px] text-gray-400"
+        aria-live="polite"
+      >
+        {savingState === "saving"
+          ? "저장 중..."
+          : dirty
+            ? "포커스 해제 시 자동 저장됩니다"
+            : " "}
+      </p>
+    </div>
   );
 }

--- a/services/web/src/features/shorts-auto/hooks/useCandidateRenderJobs.ts
+++ b/services/web/src/features/shorts-auto/hooks/useCandidateRenderJobs.ts
@@ -7,6 +7,7 @@ import { getRenderJobStatus, type RenderJobResponse } from "@/lib/api/highlight-
 import {
   deleteRenderJob,
   downloadRenderJob,
+  updateRenderJobTitle,
 } from "@/lib/api/shorts-render";
 import type { AutoClipResponse, AutoRenderRequest, ScoringModeRequest } from "@/lib/types";
 
@@ -42,6 +43,12 @@ interface UseCandidateRenderJobsResult {
   download: (clipKey: string, filename: string) => Promise<void>;
   /** Remove a card. If it's render-job-backed, DELETE the backend record. Always clears local state. */
   remove: (clipKey: string) => Promise<void>;
+  /**
+   * Rename a render-job-backed card. No-op when the card hasn't been
+   * rendered yet (no backend row exists to update). Optimistically
+   * updates the local state; rolls back on API failure.
+   */
+  updateTitle: (clipKey: string, title: string | null) => Promise<void>;
 }
 
 const POLL_INTERVAL_MS = 5000;
@@ -250,13 +257,61 @@ export function useCandidateRenderJobs(
     [getToken],
   );
 
+  const updateTitle = useCallback(
+    async (clipKey: string, title: string | null) => {
+      const state = statesRef.current[clipKey];
+      // Only render-job-backed states have a server row to rename.
+      // No-op for ``candidate`` / ``submitting`` (no job_id yet).
+      if (
+        !state ||
+        state.kind === "candidate" ||
+        state.kind === "submitting" ||
+        (state.kind === "failed" && !state.job)
+      ) {
+        return;
+      }
+      const job = (state as { job: RenderJobResponse }).job;
+      if (!job) return;
+
+      // Optimistic update — surface the new title immediately so
+      // typing feels snappy. Roll back on API failure.
+      const optimisticJob = { ...job, title };
+      const optimisticState: CandidateState = (() => {
+        if (state.kind === "queued") return { kind: "queued", job: optimisticJob };
+        if (state.kind === "rendering") return { kind: "rendering", job: optimisticJob };
+        if (state.kind === "completed") return { kind: "completed", job: optimisticJob };
+        // failed with job
+        return { kind: "failed", job: optimisticJob, error: state.error };
+      })();
+      setOne(clipKey, optimisticState);
+
+      try {
+        const updated = await updateRenderJobTitle(job.id, title, getToken);
+        // Replace the optimistic copy with the server's authoritative
+        // version (in case the server normalized or trimmed the title).
+        const settled: CandidateState = (() => {
+          if (state.kind === "queued") return { kind: "queued", job: updated };
+          if (state.kind === "rendering") return { kind: "rendering", job: updated };
+          if (state.kind === "completed") return { kind: "completed", job: updated };
+          return { kind: "failed", job: updated, error: state.error };
+        })();
+        setOne(clipKey, settled);
+      } catch {
+        // Rollback to the pre-optimistic state. Keep the prior job's
+        // title so the user can retry without manual cleanup.
+        setOne(clipKey, state);
+      }
+    },
+    [getToken, setOne],
+  );
+
   const getState = useCallback(
     (clipKey: string): CandidateState => states[clipKey] ?? { kind: "candidate" },
     [states],
   );
 
   return useMemo(
-    () => ({ states, getState, startRender, download, remove }),
-    [states, getState, startRender, download, remove],
+    () => ({ states, getState, startRender, download, remove, updateTitle }),
+    [states, getState, startRender, download, remove, updateTitle],
   );
 }

--- a/services/web/src/lib/api/shorts-render.ts
+++ b/services/web/src/lib/api/shorts-render.ts
@@ -95,6 +95,31 @@ export async function getShortComposition(
 }
 
 /**
+ * Rename a render job. Backend ``PATCH /api/shorts/render/{job_id}``
+ * accepts ``{ title: string | null }`` and returns the updated
+ * ``RenderJobResponse``. Owner-scoped on the server: 404 is surfaced
+ * for both "not found" and "not yours" so the FE doesn't have to
+ * special-case the distinction. ``null`` clears the title.
+ */
+export async function updateRenderJobTitle(
+  jobId: string,
+  title: string | null,
+  getToken: TokenGetter,
+): Promise<RenderJobResponse> {
+  const headers = await authHeaders(getToken);
+  const res = await fetch(`${getApiBaseUrl()}/api/shorts/render/${jobId}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ title }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail || `Failed to update title (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
  * Delete a render job (DB row + S3 output). Backend returns 204 on
  * success and 404 when the job is missing or not owned by the caller —
  * we treat 404 as a no-op success since the user-visible effect (job


### PR DESCRIPTION
## Summary

Phase 3 of the auto-shorts UI redesign. The inspector panel's title field was a read-only placeholder since Phase 1 with a "곧 지원됩니다" tooltip — now it's editable with optimistic save on blur.

Two atomic commits:

1. **feat(shorts-render): add PATCH /api/shorts/render/{id} for title rename** — backend `RenderJobTitleUpdate` schema, `update_title` repo method, `update_render_job_title` service method, new PATCH route. Owner-scoped (404 for both "not found" and "not yours" so the FE doesn't need to special-case). Schema validates `max_length=255` matching the column; accepts both empty string and `null` to clear the title.

2. **feat(shorts-auto): editable title in inspector with optimistic save** — `updateRenderJobTitle` API client, new `useCandidateRenderJobs.updateTitle` method with optimistic update + rollback, `InspectorPanel` title input becomes controlled+editable when a render-job exists. Falls back to disabled read-only with a "render first" tooltip before the user clicks 다운로드. `AutoShortsPage` derives the title state from the selected clip's render-job and only wires `onTitleSave` when a render-job is present.

## Decisions locked

- Title-only PATCH endpoint (NOT a generic mutable patch) — explicit per the plan's directive
- Single-trigger blur-to-save (no debounced typing-time auto-save) — avoids network thrash and rate-limit pressure
- Optimistic update at the hook layer with rollback on network failure
- No "save" button — extra click for the most common edit path, inspector is dense already
- Disabled+read-only treatment when no render-job exists (no backend row to rename) — tooltip explains the user has to render first

## Pre-merge verification

- 140 / 140 backend pytest on the changed surface (7 new in `test_shorts_render_hardening.py` which IS in CI's allowlist)
- 771 / 771 frontend vitest (8 new in `InspectorPanel.test.tsx`)
- tsc clean

## Test plan

- [ ] CI green (Test workflow)
- [ ] Staging soak: visit `https://devorg.app.heimdexdemo.dev/export/shorts/auto?videoId=...` for a known long video
- [ ] Title input is read-only with tooltip BEFORE clicking 다운로드 on a candidate
- [ ] After clicking 다운로드 (card flips to render-job mode), title input becomes editable with the server's title pre-populated
- [ ] Typing → "포커스 해제 시 자동 저장됩니다" helper appears; blur triggers save; brief "저장 중..." indicator
- [ ] Pressing Enter triggers save the same way
- [ ] Clearing the title to whitespace → null on the server (clears it; placeholder shows on next render-job lookup)
- [ ] Switching to a different candidate card swaps the input value to that card's title (or back to disabled if that card has no render-job yet)
- [ ] Trying to rename a job owned by another user → 404 from server (manual API test)

## Phase 3 roadmap status

Per the plan, the user explicitly deferred:
- Social upload (multi-week per-platform OAuth project)
- Sort dropdown (low value with 3-5 clips on screen)
- Per-clip rendered MP4 in center pane (depends on observable render-job state — nice-to-have after this lands)
- Cross-replica budget tracker (Redis) — only matters when scaling beyond single API replica
- LRU cache eviction (premature)

Title editing was the locked Phase 3 starter. This PR is that.