### PR TITLE
fix(api,web): return raw JPG when single image is exported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
             tests/test_shorts_render_cleanup.py \
             tests/test_shorts_render_hardening.py \
             tests/test_internal_router_deferred_caption.py \
+            tests/test_export_images.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/modules/export/router.py
+++ b/services/api/app/modules/export/router.py
@@ -865,7 +865,8 @@ async def export_images(
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
     user: Annotated[User, Depends(get_current_user)],
 ):
-    """Download multiple keyframe images as a ZIP archive."""
+    """Download keyframe images. Returns a raw JPG when exactly one is requested,
+    otherwise a ZIP archive."""
     settings = get_settings()
     s3 = S3Client(bucket=settings.drive_s3_bucket)
     org_id = str(org_ctx.org_id)
@@ -877,6 +878,37 @@ async def export_images(
         if img.scene_id not in seen:
             seen.add(img.scene_id)
             unique_images.append(img)
+
+    # Single image: return raw JPG, skip the zip step.
+    if len(unique_images) == 1:
+        img = unique_images[0]
+        s3_key = f"{org_id}/drive/keyframes/{img.video_id}/{img.scene_id}.jpg"
+        image_bytes = await s3.get_object_bytes_async(s3_key)
+        if image_bytes is None:
+            logger.warning(
+                "image_export_missing_keyframe",
+                extra={"scene_id": img.scene_id, "s3_key": s3_key},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No keyframe images found for the requested scenes",
+            )
+        title_part = _sanitize_filename(img.video_title or img.video_id, max_len=80)
+        filename = f"{title_part}_{img.scene_id}.jpg"
+        logger.info(
+            "images_exported",
+            extra={
+                "org_id": org_id,
+                "image_count": 1,
+                "format": "jpg",
+                "file_size_bytes": len(image_bytes),
+            },
+        )
+        return Response(
+            content=image_bytes,
+            media_type="image/jpeg",
+            headers={"Content-Disposition": _content_disposition(filename)},
+        )
 
     tmp_dir = Path(tempfile.mkdtemp(prefix="heimdex_images_"))
     try:
@@ -917,6 +949,7 @@ async def export_images(
             extra={
                 "org_id": org_id,
                 "image_count": collected,
+                "format": "zip",
                 "zip_size_bytes": zip_path.stat().st_size,
             },
         )

--- a/services/api/tests/test_export_images.py
+++ b/services/api/tests/test_export_images.py
@@ -1,0 +1,110 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import FileResponse, Response
+
+from app.modules.export.router import export_images
+from app.modules.export.schemas import ExportImageItem, ExportImagesRequest
+from app.modules.tenancy.context import OrgContext
+
+
+def _make_request(items):
+    return ExportImagesRequest(
+        images=[ExportImageItem(**item) for item in items]
+    )
+
+
+def _make_org_ctx():
+    return OrgContext(org_id=uuid4(), org_slug="testorg")
+
+
+def _make_user():
+    user = MagicMock()
+    user.id = uuid4()
+    return user
+
+
+@pytest.fixture
+def patched_export_deps():
+    """Patch S3Client + get_settings inside the router module."""
+    with patch("app.modules.export.router.S3Client") as s3_cls, \
+         patch("app.modules.export.router.get_settings") as get_settings:
+        settings = MagicMock()
+        settings.drive_s3_bucket = "test-bucket"
+        get_settings.return_value = settings
+
+        s3_instance = MagicMock()
+        s3_cls.return_value = s3_instance
+        yield s3_instance
+
+
+@pytest.mark.asyncio
+async def test_single_image_returns_raw_jpeg(patched_export_deps):
+    fake_bytes = b"\xff\xd8\xff\xe0FAKEJPG"
+    patched_export_deps.get_object_bytes_async = AsyncMock(return_value=fake_bytes)
+
+    req = _make_request([
+        {"video_id": "gd_abc", "scene_id": "gd_abc_scene_005", "video_title": "Demo Video"},
+    ])
+
+    resp = await export_images(req, _make_org_ctx(), _make_user())
+
+    assert isinstance(resp, Response)
+    assert not isinstance(resp, FileResponse)
+    assert resp.media_type == "image/jpeg"
+    assert resp.body == fake_bytes
+    disposition = resp.headers["content-disposition"]
+    assert disposition.startswith("attachment;")
+    assert "Demo Video_gd_abc_scene_005.jpg" in disposition
+    assert ".zip" not in disposition
+
+
+@pytest.mark.asyncio
+async def test_single_image_dedupes_to_one_returns_jpeg(patched_export_deps):
+    """Two identical scene_ids should still produce the single-file response."""
+    patched_export_deps.get_object_bytes_async = AsyncMock(return_value=b"jpgbytes")
+
+    req = _make_request([
+        {"video_id": "gd_abc", "scene_id": "gd_abc_scene_001", "video_title": "X"},
+        {"video_id": "gd_abc", "scene_id": "gd_abc_scene_001", "video_title": "X"},
+    ])
+
+    resp = await export_images(req, _make_org_ctx(), _make_user())
+
+    assert resp.media_type == "image/jpeg"
+    assert resp.body == b"jpgbytes"
+    patched_export_deps.get_object_bytes_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_single_image_missing_keyframe_returns_404(patched_export_deps):
+    patched_export_deps.get_object_bytes_async = AsyncMock(return_value=None)
+
+    req = _make_request([
+        {"video_id": "gd_abc", "scene_id": "gd_abc_scene_005", "video_title": "Demo"},
+    ])
+
+    with pytest.raises(HTTPException) as exc:
+        await export_images(req, _make_org_ctx(), _make_user())
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_multi_image_returns_zip(patched_export_deps):
+    patched_export_deps.get_object_bytes_async = AsyncMock(return_value=b"\xff\xd8jpg")
+
+    req = _make_request([
+        {"video_id": "gd_a", "scene_id": "gd_a_scene_001", "video_title": "A"},
+        {"video_id": "gd_b", "scene_id": "gd_b_scene_002", "video_title": "B"},
+    ])
+
+    resp = await export_images(req, _make_org_ctx(), _make_user())
+
+    assert isinstance(resp, FileResponse)
+    assert resp.media_type == "application/zip"
+    disposition = resp.headers["content-disposition"]
+    assert "heimdex_images_" in disposition
+    assert ".zip" in disposition

--- a/services/web/src/features/images/ImageDownloadBar.tsx
+++ b/services/web/src/features/images/ImageDownloadBar.tsx
@@ -44,9 +44,11 @@ export function ImageDownloadBar() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
+      const fallbackName =
+        selection.count === 1 ? "heimdex_image.jpg" : "heimdex_images.zip";
       a.download =
         res.headers.get("Content-Disposition")?.match(/filename="([^"]+)"/)?.[1] ||
-        "heimdex_images.zip";
+        fallbackName;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- `/api/export/images` no longer zips a one-entry archive — n=1 returns raw `image/jpeg` with the file's name in `Content-Disposition`; n≥2 keeps the existing `ZIP_STORED` path.
- Frontend `ImageDownloadBar` fallback filename now picks `.jpg` vs `.zip` based on `selection.count`. Real filename still comes from the response header; this only matters in the rare unparseable case.
- Adds 4 unit tests for the export-images handler (new file — endpoint had zero coverage before). Added to CI allowlist.

## Why
Customers asked: don't make me unzip a single image. Tiny ergonomics fix.

## Test plan
- [x] `pytest tests/test_export_images.py` — 4 passed locally
- [x] `npx tsc --noEmit -p .` clean on web
- [ ] Post-merge: hit staging at `devorg.app.heimdexdemo.dev`, select 1 image → expect `.jpg` download, no zip
- [ ] Same on staging with 2+ images → expect `heimdex_images_*.zip`
- [ ] Korean-titled video → filename round-trip preserves Korean characters