### PR TITLE
chore(shorts-render-worker): bump worker-sdk to 0.4.0 (watchdog)

### DIFF
--- a/services/shorts-render-worker/Dockerfile
+++ b/services/shorts-render-worker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install worker SDK
-RUN pip install --no-cache-dir "heimdex-worker-sdk==0.3.3"
+RUN pip install --no-cache-dir "heimdex-worker-sdk==0.4.0"
 
 # Install Python dependencies.
 # heimdex-media-contracts + heimdex-media-pipelines are volume-mounted


### PR DESCRIPTION
## Summary
Bumps `heimdex-worker-sdk` pin from `0.3.3` to `0.4.0` in `services/shorts-render-worker/Dockerfile`. v0.4.0 adds the consumer-side watchdog that recovers from the boto3 long-poll wedge that caused the 2026-04-30 ebsdemo render outage.

## What 0.4.0 adds
- `sqs_consumer_heartbeat` log every 5 min — idle worker is visibly alive
- Proactive boto3 client refresh every 1h — defeats long-running connection staleness
- Watchdog daemon thread — forces `reset_client()` if `receive_jobs` hasn't completed in 90s

All three are additive with safe defaults, no caller-side change required.

## Risk
Single Dockerfile pin bump. SDK change is backward-compatible (existing call sites work, defaults are conservative). Other 14 workers stay on 0.3.3 for now — no urgency since they haven't exhibited the wedge, and each bump is independent.

## Test plan
- [x] SDK tests: 31 pass on `tests/test_sqs_consumer.py` + `tests/test_sqs_client.py` (5 new watchdog cases)
- [x] PyPI v0.4.0 published successfully (release.yml run 25166072131)
- [ ] Post-merge: SSH to prod EC2, `docker compose build shorts-render-worker && docker compose up -d --no-deps shorts-render-worker`, verify boot logs include `sqs_consumer_started` AND a `sqs_consumer_heartbeat` after ~5 min