### PR TITLE
feat(api): Phase 3b internal endpoints for product-track worker

### DIFF
--- a/services/api/app/modules/drive/repository.py
+++ b/services/api/app/modules/drive/repository.py
@@ -96,10 +96,19 @@ class DriveFileRepository:
         self.session = session
 
     async def get_by_id(self, file_id: UUID, org_id: UUID) -> Optional[DriveFile]:
+        # Filters out soft-deleted files to match the repository's
+        # other lookup methods (get_by_video_id at L107, list_by_org,
+        # etc.) Callers are all internal endpoints serving GPU workers
+        # (Phase 2.5a scenes-with-keyframes + Phase 3b
+        # scenes-by-visual-similarity / scenes-content) — none should
+        # resolve deleted files. Resolving them would let workers
+        # continue processing a file the user already retired (race
+        # window between delete + worker picking up an in-flight job).
         result = await self.session.execute(
             select(DriveFile).where(
                 DriveFile.id == file_id,
                 DriveFile.org_id == org_id,
+                DriveFile.is_deleted.is_(False),
             )
         )
         return result.scalar_one_or_none()

--- a/services/api/app/modules/drive/repository.py
+++ b/services/api/app/modules/drive/repository.py
@@ -113,6 +113,43 @@ class DriveFileRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_by_id_resource_scoped(
+        self, file_id: UUID,
+    ) -> Optional[DriveFile]:
+        """Look up a DriveFile by id alone (NO org_id filter).
+
+        Used by internal endpoints implementing **Pattern B** auth:
+        the bearer token authenticates the call, and the resource's
+        own ``org_id`` is the canonical tenant context. Endpoints
+        derive ``drive_file.org_id`` from the returned row and
+        optionally cross-validate it against any caller-asserted
+        ``X-Heimdex-Org-Id`` header.
+
+        Distinct from ``get_by_id`` (which requires an asserted
+        org_id) so callers can't accidentally pick up the
+        resource-scoped variant when they meant to use the safer
+        org-filtered one. Specifically NOT a default — Pattern A
+        callers (where the org assertion IS the security boundary)
+        continue to use ``get_by_id``.
+
+        Threat model: a compromised worker holding the shared
+        internal bearer can call this method with a guessed UUID,
+        but UUIDs are 128-bit so guessing is not a practical attack
+        surface. The resource lookup is the canonical authorization
+        boundary; the asserted header is at most a redundancy
+        check.
+
+        Soft-delete filtering matches the rest of this repository's
+        lookup methods. See ``get_by_id`` for the same rationale.
+        """
+        result = await self.session.execute(
+            select(DriveFile).where(
+                DriveFile.id == file_id,
+                DriveFile.is_deleted.is_(False),
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_video_id(self, org_id: UUID, video_id: str) -> Optional[DriveFile]:
         result = await self.session.execute(
             select(DriveFile).where(

--- a/services/api/app/modules/search/scene_query.py
+++ b/services/api/app/modules/search/scene_query.py
@@ -607,6 +607,61 @@ class SceneQueryMixin:
         response = await self.client.search(index=self.alias_name, body=body)
         return response["hits"]["hits"]
 
+    async def search_visual_vector_in_video(
+        self,
+        *,
+        visual_embedding: list[float],
+        org_id: str,
+        video_id: str,
+        size: int,
+    ) -> list[dict[str, Any]]:
+        """kNN visual search scoped to a single ``video_id``.
+
+        Used by the shorts-auto product mode v2 track worker for the
+        coarse pre-filter pass: given a SigLIP2 embedding of the
+        canonical product crop, return the top-K most-similar scenes
+        within the same video. The downstream worker then re-embeds
+        each candidate's keyframe locally for a precise pass.
+
+        Bypasses ``_build_filter_clauses`` because the only filter
+        we need is ``org_id`` + ``video_id`` (no date / source / tag
+        filters apply when scanning a single video). Keeping this
+        endpoint small and explicit avoids the temptation to grow
+        the general filter system for what is effectively a
+        single-video ad-hoc query.
+
+        ``size`` is the kNN ``k`` AND the result page size — they
+        intentionally match so the OS coordinator returns the top-k
+        hits without an extra rescore pass.
+        """
+        knn_filter: dict[str, Any] = {
+            "bool": {
+                "must": [
+                    {"term": {"org_id": org_id}},
+                    {"term": {"video_id": video_id}},
+                ]
+            }
+        }
+        body: dict[str, Any] = {
+            "query": {
+                "knn": {
+                    "visual_embedding": {
+                        "vector": visual_embedding,
+                        "k": size,
+                        "filter": knn_filter,
+                    }
+                }
+            },
+            "size": size,
+            # Track worker only needs scene_id + similarity; pull a
+            # narrow source projection so OS doesn't materialize the
+            # full embedding vector / transcript blobs on every hit.
+            "_source": ["scene_id", "video_id"],
+        }
+
+        response = await self.client.search(index=self.alias_name, body=body)
+        return response["hits"]["hits"]
+
     async def search_color_vector(
         self,
         color_embedding: list[float],

--- a/services/api/app/modules/videos/internal_router.py
+++ b/services/api/app/modules/videos/internal_router.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 from typing import Any
 from uuid import UUID
 
@@ -348,6 +349,24 @@ async def scenes_by_visual_similarity(
                 f"would silently produce nonsense rankings)"
             ),
         )
+    # Per-element validation. Length-only validation lets payloads
+    # with strings, booleans, or non-finite floats (NaN/inf) reach
+    # OpenSearch unchanged — best case 500s on serialization, worst
+    # case 200 with undefined ranking. ``bool`` is a subclass of
+    # ``int`` in Python so we exclude it explicitly.
+    for i, val in enumerate(query_vec):
+        if (
+            isinstance(val, bool)
+            or not isinstance(val, (int, float))
+            or not math.isfinite(val)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"query_vec[{i}] must be a finite number "
+                    f"(got {type(val).__name__}={val!r})"
+                ),
+            )
 
     try:
         top_k = int(body.get("top_k", 60))

--- a/services/api/app/modules/videos/internal_router.py
+++ b/services/api/app/modules/videos/internal_router.py
@@ -276,6 +276,258 @@ async def get_scenes_with_keyframes(
     }
 
 
+@router.post("/{file_id}/scenes-by-visual-similarity")
+async def scenes_by_visual_similarity(
+    file_id: UUID,
+    body: dict[str, Any] = Body(...),
+    x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
+    _token: str = Depends(_verify_internal_token),
+    db: AsyncSession = Depends(get_db_session),
+    scene_client: SceneSearchClient = Depends(get_scene_opensearch_client),
+):
+    """Phase 3b — OpenSearch coarse pre-filter for the
+    ``shorts-auto-product`` track worker.
+
+    Given a 768-dim SigLIP2 embedding of the canonical product crop,
+    return the top-K scenes from the same video ranked by cosine
+    similarity to that vector. The track worker then locally
+    re-embeds each candidate's keyframe for a precise pass before
+    handing off to SAM2.
+
+    Pre-filter is **per-video** (not per-org) — the canonical crop is
+    derived from one specific video, so cross-video matches don't
+    apply at v1. Cross-video product matching is v2 (per locked
+    decisions in shorts-auto-product-v2 plan).
+
+    Body shape::
+
+        {
+          "query_vec": [768 floats; SigLIP2 base/256 L2-normalized],
+          "top_k": int (1..200),
+          "min_similarity": float (0..1) — drops sub-threshold hits
+                                            BEFORE returning so the
+                                            worker doesn't have to.
+        }
+
+    Response shape::
+
+        {
+          "video_id": "gd_<...>",
+          "scenes": [
+            {"scene_id": "gd_<...>_scene_007", "similarity": 0.81},
+            ...
+          ]
+        }
+
+    Bearer-authed via the shared internal token. Org context comes
+    from the ``X-Heimdex-Org-Id`` header. Cross-org access returns
+    404 (no info leak).
+    """
+    try:
+        org_id = UUID(x_heimdex_org_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
+        )
+
+    query_vec = body.get("query_vec")
+    if not isinstance(query_vec, list) or not query_vec:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="query_vec must be a non-empty list of floats",
+        )
+    if len(query_vec) != scene_client.VISUAL_EMBEDDING_DIMENSION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"query_vec length {len(query_vec)} does not match the "
+                f"deployed visual embedding dimension "
+                f"{scene_client.VISUAL_EMBEDDING_DIMENSION} "
+                f"(SigLIP2 base/256 — drift between worker and api "
+                f"would silently produce nonsense rankings)"
+            ),
+        )
+
+    try:
+        top_k = int(body.get("top_k", 60))
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="top_k must be an int",
+        )
+    if top_k < 1 or top_k > 200:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="top_k must be in [1, 200]",
+        )
+
+    try:
+        min_similarity = float(body.get("min_similarity", 0.0))
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="min_similarity must be a float",
+        )
+    if min_similarity < 0.0 or min_similarity > 1.0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="min_similarity must be in [0, 1]",
+        )
+
+    from app.modules.drive.repository import DriveFileRepository
+
+    drive_file = await DriveFileRepository(db).get_by_id(
+        file_id=file_id, org_id=org_id,
+    )
+    if drive_file is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="video not found",
+        )
+
+    hits = await scene_client.search_visual_vector_in_video(
+        visual_embedding=query_vec,
+        org_id=str(org_id),
+        video_id=drive_file.video_id,
+        size=top_k,
+    )
+
+    scenes: list[dict[str, Any]] = []
+    for hit in hits:
+        score = float(hit.get("_score", 0.0))
+        if score < min_similarity:
+            continue
+        source = hit.get("_source", {}) or {}
+        scene_id = source.get("scene_id")
+        if not scene_id:
+            # Defensive — every doc should have a scene_id field;
+            # skip silently rather than 500 the worker.
+            continue
+        scenes.append({"scene_id": scene_id, "similarity": score})
+
+    return {"video_id": drive_file.video_id, "scenes": scenes}
+
+
+@router.post("/{file_id}/scenes-content")
+async def scenes_content(
+    file_id: UUID,
+    body: dict[str, Any] = Body(...),
+    x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
+    _token: str = Depends(_verify_internal_token),
+    db: AsyncSession = Depends(get_db_session),
+    scene_client: SceneSearchClient = Depends(get_scene_opensearch_client),
+):
+    """Phase 3b — bulk fetch transcripts + OCR for a list of
+    scene_ids.
+
+    The product track worker calls this AFTER the coarse pre-filter
+    has narrowed candidates to ~5-10 scenes. Pulling transcripts +
+    OCR for those scenes lets the alignment lib annotate windows
+    with ``has_narration_mention`` + ``has_ocr_overlap``.
+
+    Returning per-scene scope rather than per-utterance is intentional:
+    OpenSearch scene docs store transcript_raw / ocr_text_raw as full
+    strings without per-utterance temporal bounds. The alignment lib
+    treats segments without bounds as covering the whole scene
+    (correct for the v1 product track use case where windows are
+    always within scene bounds anyway).
+
+    Body shape::
+
+        {
+          "scene_ids": ["gd_<...>_scene_007", "gd_<...>_scene_012", ...]
+        }
+
+    Response shape::
+
+        {
+          "video_id": "gd_<...>",
+          "scenes": [
+            {
+              "scene_id": "gd_<...>_scene_007",
+              "start_ms": 5000,
+              "end_ms": 10000,
+              "transcript_raw": "...",
+              "speaker_transcript": "...",
+              "ocr_text_raw": "..."
+            },
+            ...
+          ]
+        }
+
+    Cross-org / cross-video doc IDs are silently dropped (the
+    constructed doc_id is org-scoped via the ``{org_id}:{scene_id}``
+    prefix, so a scene_id from another org just doesn't match).
+    """
+    try:
+        org_id = UUID(x_heimdex_org_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
+        )
+
+    scene_ids = body.get("scene_ids")
+    if not isinstance(scene_ids, list):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="scene_ids must be a list",
+        )
+    if len(scene_ids) > 200:
+        # Same per-call cap as the existing scenes-with-keyframes
+        # endpoint's page_size — protects OS from a worker requesting
+        # tens of thousands of scenes in one call.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="scene_ids may not exceed 200 entries per call",
+        )
+    if not all(isinstance(s, str) and s for s in scene_ids):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="scene_ids must be a list of non-empty strings",
+        )
+
+    from app.modules.drive.repository import DriveFileRepository
+
+    drive_file = await DriveFileRepository(db).get_by_id(
+        file_id=file_id, org_id=org_id,
+    )
+    if drive_file is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="video not found",
+        )
+
+    # Build the org-scoped doc_ids the OS index uses.
+    doc_ids = [f"{org_id}:{scene_id}" for scene_id in scene_ids]
+    raw = await scene_client.mget_scenes(doc_ids)
+
+    out: list[dict[str, Any]] = []
+    for scene_id in scene_ids:
+        doc_id = f"{org_id}:{scene_id}"
+        source = raw.get(doc_id)
+        if source is None:
+            # Scene not found (cross-org / typo / deleted) — skip.
+            continue
+        # Defense in depth: the doc_id prefix already org-scopes, but
+        # also check the scene actually belongs to the requested
+        # video so a typo'd scene_id from another video on the same
+        # org doesn't leak.
+        if source.get("video_id") != drive_file.video_id:
+            continue
+        out.append({
+            "scene_id": source.get("scene_id", scene_id),
+            "start_ms": int(source.get("start_ms", 0) or 0),
+            "end_ms": int(source.get("end_ms", 0) or 0),
+            "transcript_raw": source.get("transcript_raw") or "",
+            "speaker_transcript": source.get("speaker_transcript") or "",
+            "ocr_text_raw": source.get("ocr_text_raw") or "",
+        })
+
+    return {"video_id": drive_file.video_id, "scenes": out}
+
+
 async def _resolve_file_id(
     db: AsyncSession, video_id: str, org_id: UUID,
 ) -> UUID | None:

--- a/services/api/app/modules/videos/internal_router.py
+++ b/services/api/app/modules/videos/internal_router.py
@@ -161,10 +161,95 @@ async def update_reprocess_status(
     return {"status": "ok"}
 
 
+# ---------------------------------------------------------------------------
+# Pattern B internal-auth helper
+# ---------------------------------------------------------------------------
+#
+# Three of this file's endpoints (scenes-with-keyframes, scenes-by-visual-
+# similarity, scenes-content) authenticate workers via the shared internal
+# bearer and then need to scope their work to a specific tenant. Until 2026-
+# 05-01 they did this with **Pattern A**: caller asserts the tenant via the
+# ``X-Heimdex-Org-Id`` header, and the repo lookup filters by both
+# ``file_id`` AND the asserted ``org_id`` so an attacker faking the header
+# gets a 404. That works as long as the (file_id, org_id) pair can't leak
+# together — fragile, easy to regress, and inconsistent with how the
+# blur / shorts_auto_product internal endpoints already operate.
+#
+# Codex adversarial review F1 (2026-05-01) flagged this as a multi-tenant
+# isolation gap. Fix: migrate to **Pattern B** — bearer authenticates the
+# call; the resource's own ``org_id`` is the canonical tenant context;
+# the asserted header becomes an OPTIONAL cross-validation that returns
+# 404 (not 400) on mismatch so timing doesn't leak the correct org.
+#
+# Workers continue to send the header (no worker code changes), so this
+# is fully backward-compatible. Future endpoints in this file should use
+# the helper; future endpoints elsewhere should look at this as the
+# template for the platform sweep tracked separately.
+#
+# Specifically NOT applied to YouTube paths in this file (``_resolve_file_id``,
+# delete/reprocess endpoints) — those have separate threat models /
+# behavioral contracts and migrate in their own PR.
+
+async def _resolve_drive_file_with_org(
+    *,
+    file_id: UUID,
+    x_heimdex_org_id: str | None,
+    db: AsyncSession,
+) -> tuple[Any, UUID]:
+    """Look up a DriveFile by id (resource-scoped) and return it
+    along with the tenant ``org_id`` derived from the resource.
+
+    If ``x_heimdex_org_id`` is provided, it is **cross-validated** as a
+    soft check: a mismatch with ``drive_file.org_id`` raises a 404 (NOT
+    400 or 403 — same response as not-found, so timing doesn't reveal
+    the resource's true tenant).
+
+    Returns ``(drive_file, org_id)``. Raises ``HTTPException`` for:
+      * 400 — header present but not a valid UUID
+      * 404 — file not found / soft-deleted / cross-org mismatch
+
+    Centralizing the cross-validation here keeps the three endpoints
+    using identical semantics; new endpoints copy-paste a single
+    helper call instead of re-implementing the pattern (and getting
+    it subtly wrong).
+    """
+    from app.modules.drive.repository import DriveFileRepository
+
+    asserted_org_id: UUID | None = None
+    if x_heimdex_org_id is not None:
+        try:
+            asserted_org_id = UUID(x_heimdex_org_id)
+        except (ValueError, AttributeError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
+            )
+
+    drive_file = await DriveFileRepository(db).get_by_id_resource_scoped(
+        file_id=file_id,
+    )
+    if drive_file is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="video not found",
+        )
+
+    if asserted_org_id is not None and asserted_org_id != drive_file.org_id:
+        # Cross-tenant access attempt. 404 (not 403) so the response
+        # is indistinguishable from a genuine not-found — does not
+        # confirm whether the file_id exists in any tenant.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="video not found",
+        )
+
+    return drive_file, drive_file.org_id
+
+
 @router.get("/{file_id}/scenes-with-keyframes")
 async def get_scenes_with_keyframes(
     file_id: UUID,
-    x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
+    x_heimdex_org_id: str | None = Header(default=None, alias="X-Heimdex-Org-Id"),
     _token: str = Depends(_verify_internal_token),
     db: AsyncSession = Depends(get_db_session),
     scene_client: SceneSearchClient = Depends(get_scene_opensearch_client),
@@ -181,10 +266,11 @@ async def get_scenes_with_keyframes(
     independently (drift between them would silently produce 404s on
     the worker side).
 
-    Bearer-authed via the shared internal token. Org context comes
-    from the ``X-Heimdex-Org-Id`` header — same pattern as the other
-    internal endpoints in this file. Cross-org access returns 404
-    (no info leak between not-found and forbidden).
+    Auth (Pattern B, post-2026-05-01): bearer authenticates the call;
+    the resource's ``org_id`` is the canonical tenant context.
+    ``X-Heimdex-Org-Id`` is OPTIONAL and treated as a cross-validation
+    only — a mismatch returns 404 (not 403) so timing doesn't leak the
+    correct tenant. See module-level helper docstring for rationale.
 
     Response shape (stable; both workers depend on it)::
 
@@ -204,26 +290,13 @@ async def get_scenes_with_keyframes(
           ]
         }
     """
-    try:
-        org_id = UUID(x_heimdex_org_id)
-    except (ValueError, AttributeError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
-        )
-
     from app.modules.drive.keys import enrichment_keyframe_s3_key
-    from app.modules.drive.repository import DriveFileRepository
 
-    # Resolve DriveFile (org-scoped — cross-org access returns 404).
-    drive_file = await DriveFileRepository(db).get_by_id(
-        file_id=file_id, org_id=org_id,
+    drive_file, org_id = await _resolve_drive_file_with_org(
+        file_id=file_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        db=db,
     )
-    if drive_file is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="video not found",
-        )
     video_id_str: str = drive_file.video_id
 
     # Pull all scenes for this video. ``page_size`` is generous —
@@ -281,7 +354,7 @@ async def get_scenes_with_keyframes(
 async def scenes_by_visual_similarity(
     file_id: UUID,
     body: dict[str, Any] = Body(...),
-    x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
+    x_heimdex_org_id: str | None = Header(default=None, alias="X-Heimdex-Org-Id"),
     _token: str = Depends(_verify_internal_token),
     db: AsyncSession = Depends(get_db_session),
     scene_client: SceneSearchClient = Depends(get_scene_opensearch_client),
@@ -320,18 +393,11 @@ async def scenes_by_visual_similarity(
           ]
         }
 
-    Bearer-authed via the shared internal token. Org context comes
-    from the ``X-Heimdex-Org-Id`` header. Cross-org access returns
-    404 (no info leak).
+    Auth (Pattern B): bearer authenticates the call; the resource's
+    ``org_id`` is the canonical tenant context. ``X-Heimdex-Org-Id``
+    is OPTIONAL and treated as a cross-validation only — see
+    ``_resolve_drive_file_with_org`` docstring.
     """
-    try:
-        org_id = UUID(x_heimdex_org_id)
-    except (ValueError, AttributeError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
-        )
-
     query_vec = body.get("query_vec")
     if not isinstance(query_vec, list) or not query_vec:
         raise HTTPException(
@@ -394,16 +460,11 @@ async def scenes_by_visual_similarity(
             detail="min_similarity must be in [0, 1]",
         )
 
-    from app.modules.drive.repository import DriveFileRepository
-
-    drive_file = await DriveFileRepository(db).get_by_id(
-        file_id=file_id, org_id=org_id,
+    drive_file, org_id = await _resolve_drive_file_with_org(
+        file_id=file_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        db=db,
     )
-    if drive_file is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="video not found",
-        )
 
     hits = await scene_client.search_visual_vector_in_video(
         visual_embedding=query_vec,
@@ -432,7 +493,7 @@ async def scenes_by_visual_similarity(
 async def scenes_content(
     file_id: UUID,
     body: dict[str, Any] = Body(...),
-    x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
+    x_heimdex_org_id: str | None = Header(default=None, alias="X-Heimdex-Org-Id"),
     _token: str = Depends(_verify_internal_token),
     db: AsyncSession = Depends(get_db_session),
     scene_client: SceneSearchClient = Depends(get_scene_opensearch_client),
@@ -478,15 +539,12 @@ async def scenes_content(
     Cross-org / cross-video doc IDs are silently dropped (the
     constructed doc_id is org-scoped via the ``{org_id}:{scene_id}``
     prefix, so a scene_id from another org just doesn't match).
-    """
-    try:
-        org_id = UUID(x_heimdex_org_id)
-    except (ValueError, AttributeError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
-        )
 
+    Auth (Pattern B): bearer authenticates the call; the resource's
+    ``org_id`` is the canonical tenant context. ``X-Heimdex-Org-Id``
+    is OPTIONAL and treated as a cross-validation only — see
+    ``_resolve_drive_file_with_org`` docstring.
+    """
     scene_ids = body.get("scene_ids")
     if not isinstance(scene_ids, list):
         raise HTTPException(
@@ -507,16 +565,11 @@ async def scenes_content(
             detail="scene_ids must be a list of non-empty strings",
         )
 
-    from app.modules.drive.repository import DriveFileRepository
-
-    drive_file = await DriveFileRepository(db).get_by_id(
-        file_id=file_id, org_id=org_id,
+    drive_file, org_id = await _resolve_drive_file_with_org(
+        file_id=file_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        db=db,
     )
-    if drive_file is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="video not found",
-        )
 
     # Build the org-scoped doc_ids the OS index uses.
     doc_ids = [f"{org_id}:{scene_id}" for scene_id in scene_ids]

--- a/services/api/tests/test_videos_internal_phase3b.py
+++ b/services/api/tests/test_videos_internal_phase3b.py
@@ -1,0 +1,599 @@
+"""Tests for the Phase 3b internal endpoints used by the
+shorts-auto product mode v2 track worker:
+
+* ``POST /internal/videos/{file_id}/scenes-by-visual-similarity``
+* ``POST /internal/videos/{file_id}/scenes-content``
+
+Both are mounted on the existing ``videos`` internal router (gated
+behind ``drive_connector_enabled`` in main.py — same gate as the
+Phase 2.5a ``scenes-with-keyframes`` endpoint they sit alongside).
+Tests build a minimal app with mocked dependencies so logic is
+testable without OpenSearch / DB / Drive subsystem booted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.modules.videos.internal_router import router as internal_router
+
+
+def _drive_file(*, file_id: UUID, video_id: str = "gd_abc"):
+    obj = MagicMock()
+    obj.id = file_id
+    obj.video_id = video_id
+    return obj
+
+
+def _build_app(
+    *,
+    drive_file_obj,
+    scene_client_mock: MagicMock | None = None,
+    internal_token: str = "test-internal-token",
+) -> FastAPI:
+    """Mirror of the Phase 2.5a test helper. ``scene_client_mock``
+    can be pre-loaded with method stubs (``search_visual_vector_in_video``,
+    ``mget_scenes``) for the endpoint under test.
+    """
+    from app.dependencies import (
+        get_db_session,
+        get_scene_opensearch_client,
+        verify_internal_token,
+    )
+
+    fake_repo = MagicMock()
+    fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
+    import app.modules.drive.repository as drive_repo_module
+    drive_repo_module.DriveFileRepository = MagicMock(return_value=fake_repo)  # type: ignore[assignment]
+
+    if scene_client_mock is None:
+        scene_client_mock = MagicMock()
+    # The endpoint reads VISUAL_EMBEDDING_DIMENSION off the client to
+    # validate query_vec length — match the prod constant.
+    scene_client_mock.VISUAL_EMBEDDING_DIMENSION = 768
+
+    app = FastAPI()
+    app.include_router(internal_router, prefix="/internal")
+    app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+    app.dependency_overrides[get_scene_opensearch_client] = lambda: scene_client_mock
+    app.dependency_overrides[verify_internal_token] = lambda: internal_token
+
+    return app
+
+
+def _vec(dim: int = 768, fill: float = 0.01) -> list[float]:
+    return [fill] * dim
+
+
+# =====================================================================
+# /scenes-by-visual-similarity
+# =====================================================================
+
+
+def test_visual_similarity_returns_top_k_above_threshold_sorted_by_score():
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_xyz")
+
+    # OS hits — 3 above threshold, 1 below; endpoint must drop the
+    # below-threshold one and return the rest in OS order (already
+    # sorted desc by _score).
+    scene_client = MagicMock()
+    scene_client.search_visual_vector_in_video = AsyncMock(
+        return_value=[
+            {"_score": 0.91, "_source": {"scene_id": "gd_xyz_scene_007"}},
+            {"_score": 0.74, "_source": {"scene_id": "gd_xyz_scene_012"}},
+            {"_score": 0.55, "_source": {"scene_id": "gd_xyz_scene_003"}},
+            {"_score": 0.30, "_source": {"scene_id": "gd_xyz_scene_099"}},
+        ]
+    )
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 60, "min_similarity": 0.5},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["video_id"] == "gd_xyz"
+    assert [s["scene_id"] for s in body["scenes"]] == [
+        "gd_xyz_scene_007",
+        "gd_xyz_scene_012",
+        "gd_xyz_scene_003",
+    ]
+    assert body["scenes"][0]["similarity"] == pytest.approx(0.91)
+
+
+def test_visual_similarity_passes_video_id_org_id_size_to_client():
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    scene_client = MagicMock()
+    scene_client.search_visual_vector_in_video = _capture
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 17, "min_similarity": 0.0},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+
+    assert captured["video_id"] == "gd_v"
+    assert captured["org_id"] == str(org_id)
+    assert captured["size"] == 17
+    assert len(captured["visual_embedding"]) == 768
+
+
+@pytest.mark.parametrize(
+    "vec,expected_msg",
+    [
+        ([0.0] * 100, "768"),  # wrong dimension — message references prod dim
+        ([], "non-empty"),  # empty
+        ("not-a-list", "list"),  # wrong type
+    ],
+)
+def test_visual_similarity_400_on_invalid_query_vec(vec, expected_msg):
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": vec, "top_k": 10, "min_similarity": 0.5},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+    assert expected_msg in resp.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "top_k",
+    [0, -1, 201, 10000],
+)
+def test_visual_similarity_400_on_invalid_top_k(top_k):
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": top_k, "min_similarity": 0.5},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+    assert "top_k" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("min_sim", [-0.01, 1.01, 5.0])
+def test_visual_similarity_400_on_invalid_min_similarity(min_sim):
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": min_sim},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+    assert "min_similarity" in resp.json()["detail"]
+
+
+def test_visual_similarity_404_when_drive_file_missing():
+    file_id = uuid4()
+    app = _build_app(drive_file_obj=None)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 404
+
+
+def test_visual_similarity_400_on_invalid_org_id_header():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": "not-a-uuid",
+            },
+        )
+    assert resp.status_code == 400
+
+
+def test_visual_similarity_drops_hits_with_missing_scene_id():
+    """OS doc with no scene_id field is silently skipped — defensive
+    against schema drift / partial reads."""
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_x")
+
+    scene_client = MagicMock()
+    scene_client.search_visual_vector_in_video = AsyncMock(
+        return_value=[
+            {"_score": 0.9, "_source": {"scene_id": "gd_x_scene_1"}},
+            {"_score": 0.8, "_source": {}},  # missing scene_id
+            {"_score": 0.7, "_source": {"scene_id": "gd_x_scene_2"}},
+        ]
+    )
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 200
+    assert [s["scene_id"] for s in resp.json()["scenes"]] == [
+        "gd_x_scene_1",
+        "gd_x_scene_2",
+    ]
+
+
+def test_visual_similarity_empty_results_returns_200_with_zero_scenes():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_a")
+    scene_client = MagicMock()
+    scene_client.search_visual_vector_in_video = AsyncMock(return_value=[])
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.5},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["scenes"] == []
+
+
+def test_visual_similarity_requires_bearer_token():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    from app.dependencies import verify_internal_token
+    app.dependency_overrides.pop(verify_internal_token, None)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={"X-Heimdex-Org-Id": str(uuid4())},
+        )
+    assert resp.status_code in (401, 403, 422)
+
+
+# =====================================================================
+# /scenes-content
+# =====================================================================
+
+
+def test_scenes_content_returns_per_scene_transcript_and_ocr():
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_xyz")
+
+    scene_client = MagicMock()
+    scene_client.mget_scenes = AsyncMock(
+        return_value={
+            f"{org_id}:gd_xyz_scene_007": {
+                "scene_id": "gd_xyz_scene_007",
+                "video_id": "gd_xyz",
+                "start_ms": 5000,
+                "end_ms": 10000,
+                "transcript_raw": "이 cosmetics is great",
+                "speaker_transcript": "[Host] 이 cosmetics is great",
+                "ocr_text_raw": "PROMOTION",
+            },
+            f"{org_id}:gd_xyz_scene_012": {
+                "scene_id": "gd_xyz_scene_012",
+                "video_id": "gd_xyz",
+                "start_ms": 15000,
+                "end_ms": 18000,
+                "transcript_raw": "",
+                "speaker_transcript": "",
+                "ocr_text_raw": "",
+            },
+        }
+    )
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_xyz_scene_007", "gd_xyz_scene_012"]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["video_id"] == "gd_xyz"
+    assert len(body["scenes"]) == 2
+
+    s7 = next(s for s in body["scenes"] if s["scene_id"] == "gd_xyz_scene_007")
+    assert s7["start_ms"] == 5000
+    assert s7["end_ms"] == 10000
+    assert s7["transcript_raw"] == "이 cosmetics is great"
+    assert s7["ocr_text_raw"] == "PROMOTION"
+
+    # Second scene — empty fields preserved as empty strings (not null).
+    s12 = next(s for s in body["scenes"] if s["scene_id"] == "gd_xyz_scene_012")
+    assert s12["transcript_raw"] == ""
+    assert s12["ocr_text_raw"] == ""
+
+
+def test_scenes_content_drops_scene_belonging_to_other_video():
+    """Defense in depth: a scene_id from another video on the same
+    org must NOT be returned even if the doc_id mget happens to find
+    it. Filter by video_id post-mget."""
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_correct")
+
+    scene_client = MagicMock()
+    scene_client.mget_scenes = AsyncMock(
+        return_value={
+            f"{org_id}:gd_correct_scene_001": {
+                "scene_id": "gd_correct_scene_001",
+                "video_id": "gd_correct",
+                "start_ms": 0,
+                "end_ms": 1000,
+                "transcript_raw": "ok",
+                "speaker_transcript": "",
+                "ocr_text_raw": "",
+            },
+            f"{org_id}:gd_other_scene_001": {
+                "scene_id": "gd_other_scene_001",
+                "video_id": "gd_other",  # <-- different video
+                "start_ms": 0,
+                "end_ms": 1000,
+                "transcript_raw": "should be dropped",
+                "speaker_transcript": "",
+                "ocr_text_raw": "",
+            },
+        }
+    )
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={
+                "scene_ids": [
+                    "gd_correct_scene_001",
+                    "gd_other_scene_001",
+                ],
+            },
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+    assert resp.status_code == 200
+    scenes = resp.json()["scenes"]
+    assert len(scenes) == 1
+    assert scenes[0]["scene_id"] == "gd_correct_scene_001"
+
+
+def test_scenes_content_passes_org_scoped_doc_ids_to_mget():
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+
+    captured: dict[str, list[str]] = {}
+
+    async def _capture(doc_ids):
+        captured["doc_ids"] = doc_ids
+        return {}
+
+    scene_client = MagicMock()
+    scene_client.mget_scenes = _capture
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_v_scene_001", "gd_v_scene_002"]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+
+    assert captured["doc_ids"] == [
+        f"{org_id}:gd_v_scene_001",
+        f"{org_id}:gd_v_scene_002",
+    ]
+
+
+def test_scenes_content_skips_missing_scene_ids():
+    """A scene_id requested but not returned by mget (e.g., deleted
+    or cross-org) is simply absent from the response."""
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+
+    scene_client = MagicMock()
+    scene_client.mget_scenes = AsyncMock(
+        return_value={
+            f"{org_id}:gd_v_scene_001": {
+                "scene_id": "gd_v_scene_001",
+                "video_id": "gd_v",
+                "start_ms": 0,
+                "end_ms": 1000,
+                "transcript_raw": "x",
+                "speaker_transcript": "",
+                "ocr_text_raw": "",
+            },
+        }
+    )
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={
+                "scene_ids": [
+                    "gd_v_scene_001",
+                    "gd_v_scene_does_not_exist",
+                ],
+            },
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+    assert resp.status_code == 200
+    scenes = resp.json()["scenes"]
+    assert [s["scene_id"] for s in scenes] == ["gd_v_scene_001"]
+
+
+def test_scenes_content_400_on_non_list_scene_ids():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": "not-a-list"},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+
+
+def test_scenes_content_400_on_too_many_scene_ids():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": [f"gd_v_scene_{i:03d}" for i in range(201)]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+    assert "200" in resp.json()["detail"]
+
+
+def test_scenes_content_400_on_non_string_scene_id():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["valid_id", 123]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+
+
+def test_scenes_content_404_when_drive_file_missing():
+    file_id = uuid4()
+    app = _build_app(drive_file_obj=None)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_v_scene_001"]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 404
+
+
+def test_scenes_content_empty_scene_ids_returns_empty_list():
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+
+    scene_client = MagicMock()
+    scene_client.mget_scenes = AsyncMock(return_value={})
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": []},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["scenes"] == []
+
+
+def test_scenes_content_requires_bearer_token():
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    from app.dependencies import verify_internal_token
+    app.dependency_overrides.pop(verify_internal_token, None)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_v_scene_001"]},
+            headers={"X-Heimdex-Org-Id": str(uuid4())},
+        )
+    assert resp.status_code in (401, 403, 422)

--- a/services/api/tests/test_videos_internal_phase3b.py
+++ b/services/api/tests/test_videos_internal_phase3b.py
@@ -146,6 +146,75 @@ def test_visual_similarity_passes_video_id_org_id_size_to_client():
     assert len(captured["visual_embedding"]) == 768
 
 
+def _vec_with_string_at(idx: int) -> str:
+    """Build a JSON string body where one element of query_vec is a
+    string. Python's httpx (used by TestClient) serializes JSON
+    client-side and rejects NaN / inf literals — so for these
+    adversarial cases we craft the raw JSON body and bypass the
+    serializer via TestClient's ``content=`` parameter. NaN / inf
+    are non-standard JSON but Python's ``json.loads`` accepts them
+    by default, which matches what Starlette / FastAPI receive."""
+    elems = [str(0.01)] * 768
+    elems[idx] = '"x"'
+    return (
+        '{"query_vec": [' + ", ".join(elems) + '], '
+        '"top_k": 10, "min_similarity": 0.0}'
+    )
+
+
+def _vec_with_token_at(idx: int, token: str) -> str:
+    """Build a raw JSON body with a non-standard JSON token (NaN,
+    Infinity, -Infinity, true, null) at ``idx``."""
+    elems = [str(0.01)] * 768
+    elems[idx] = token
+    return (
+        '{"query_vec": [' + ", ".join(elems) + '], '
+        '"top_k": 10, "min_similarity": 0.0}'
+    )
+
+
+@pytest.mark.parametrize(
+    "body_factory,expected_index",
+    [
+        # String element at index 0
+        (lambda: _vec_with_string_at(0), 0),
+        # Boolean element at index 5 (bool is subclass of int in Python — must be excluded explicitly)
+        (lambda: _vec_with_token_at(5, "true"), 5),
+        # NaN at index 100
+        (lambda: _vec_with_token_at(100, "NaN"), 100),
+        # +Infinity at index 200
+        (lambda: _vec_with_token_at(200, "Infinity"), 200),
+        # -Infinity at index 300
+        (lambda: _vec_with_token_at(300, "-Infinity"), 300),
+        # null
+        (lambda: _vec_with_token_at(0, "null"), 0),
+    ],
+)
+def test_visual_similarity_400_on_non_finite_query_vec_element(
+    body_factory, expected_index
+):
+    """Codex F3: per-element validation. Length-only validation lets
+    strings / bools / NaN / inf reach OpenSearch unchanged — best case
+    500 on serialization, worst case 200 with undefined ranking. The
+    endpoint must reject these explicitly with a 400 that names the
+    bad index."""
+    file_id = uuid4()
+    drive_file = _drive_file(file_id=file_id)
+    app = _build_app(drive_file_obj=drive_file)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            content=body_factory(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 400
+    assert f"query_vec[{expected_index}]" in resp.json()["detail"]
+
+
 @pytest.mark.parametrize(
     "vec,expected_msg",
     [
@@ -213,6 +282,28 @@ def test_visual_similarity_400_on_invalid_min_similarity(min_sim):
 def test_visual_similarity_404_when_drive_file_missing():
     file_id = uuid4()
     app = _build_app(drive_file_obj=None)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 404
+
+
+def test_visual_similarity_404_when_drive_file_soft_deleted():
+    """Codex F2: soft-deleted DriveFiles must NOT be resolvable via
+    these endpoints — racing a delete with an in-flight worker job
+    would otherwise let the worker continue processing retired
+    content. ``DriveFileRepository.get_by_id`` was extended to
+    filter ``is_deleted=False``; the test simulates that contract by
+    having the repo return None (same shape as a true 'not found').
+    """
+    file_id = uuid4()
+    app = _build_app(drive_file_obj=None)  # repo returns None for soft-deleted
     with TestClient(app) as client:
         resp = client.post(
             f"/internal/videos/{file_id}/scenes-by-visual-similarity",
@@ -547,6 +638,25 @@ def test_scenes_content_400_on_non_string_scene_id():
 
 
 def test_scenes_content_404_when_drive_file_missing():
+    file_id = uuid4()
+    app = _build_app(drive_file_obj=None)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_v_scene_001"]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(uuid4()),
+            },
+        )
+    assert resp.status_code == 404
+
+
+def test_scenes_content_404_when_drive_file_soft_deleted():
+    """Codex F2: same as the visual-similarity counterpart — workers
+    must not be able to read transcripts / OCR for a video the user
+    has retired. The repo fix routes both paths through the same
+    is_deleted=False filter so this case maps to 404."""
     file_id = uuid4()
     app = _build_app(drive_file_obj=None)
     with TestClient(app) as client:

--- a/services/api/tests/test_videos_internal_phase3b.py
+++ b/services/api/tests/test_videos_internal_phase3b.py
@@ -24,10 +24,14 @@ from fastapi.testclient import TestClient
 from app.modules.videos.internal_router import router as internal_router
 
 
-def _drive_file(*, file_id: UUID, video_id: str = "gd_abc"):
+def _drive_file(*, file_id: UUID, video_id: str = "gd_abc", org_id: UUID | None = None):
+    """Mocked DriveFile row. Pattern B endpoints derive ``org_id``
+    from the resource itself, so the test fixture must populate
+    ``obj.org_id`` (not just rely on the asserted header)."""
     obj = MagicMock()
     obj.id = file_id
     obj.video_id = video_id
+    obj.org_id = org_id if org_id is not None else uuid4()
     return obj
 
 
@@ -48,6 +52,11 @@ def _build_app(
     )
 
     fake_repo = MagicMock()
+    # Pattern B (post-2026-05-01): endpoints look up DriveFile by id
+    # alone via ``get_by_id_resource_scoped`` and derive ``org_id``
+    # from the resource. Tests mock the new method; ``get_by_id``
+    # also mocked for back-compat with any call sites we miss.
+    fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=drive_file_obj)
     fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
     import app.modules.drive.repository as drive_repo_module
     drive_repo_module.DriveFileRepository = MagicMock(return_value=fake_repo)  # type: ignore[assignment]
@@ -79,7 +88,7 @@ def _vec(dim: int = 768, fill: float = 0.01) -> list[float]:
 def test_visual_similarity_returns_top_k_above_threshold_sorted_by_score():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_xyz")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_xyz", org_id=org_id)
 
     # OS hits — 3 above threshold, 1 below; endpoint must drop the
     # below-threshold one and return the rest in OS order (already
@@ -118,7 +127,7 @@ def test_visual_similarity_returns_top_k_above_threshold_sorted_by_score():
 def test_visual_similarity_passes_video_id_org_id_size_to_client():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
 
     captured: dict[str, Any] = {}
 
@@ -336,7 +345,8 @@ def test_visual_similarity_drops_hits_with_missing_scene_id():
     """OS doc with no scene_id field is silently skipped — defensive
     against schema drift / partial reads."""
     file_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_x")
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_x", org_id=org_id)
 
     scene_client = MagicMock()
     scene_client.search_visual_vector_in_video = AsyncMock(
@@ -354,7 +364,7 @@ def test_visual_similarity_drops_hits_with_missing_scene_id():
             json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
             headers={
                 "Authorization": "Bearer test-internal-token",
-                "X-Heimdex-Org-Id": str(uuid4()),
+                "X-Heimdex-Org-Id": str(org_id),
             },
         )
     assert resp.status_code == 200
@@ -366,7 +376,8 @@ def test_visual_similarity_drops_hits_with_missing_scene_id():
 
 def test_visual_similarity_empty_results_returns_200_with_zero_scenes():
     file_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_a")
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_a", org_id=org_id)
     scene_client = MagicMock()
     scene_client.search_visual_vector_in_video = AsyncMock(return_value=[])
     app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
@@ -377,11 +388,67 @@ def test_visual_similarity_empty_results_returns_200_with_zero_scenes():
             json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.5},
             headers={
                 "Authorization": "Bearer test-internal-token",
-                "X-Heimdex-Org-Id": str(uuid4()),
+                "X-Heimdex-Org-Id": str(org_id),
             },
         )
     assert resp.status_code == 200
     assert resp.json()["scenes"] == []
+
+
+def test_visual_similarity_pattern_b_header_omitted_resolves_org_from_resource():
+    """Pattern B: ``X-Heimdex-Org-Id`` is OPTIONAL. Workers may omit
+    it entirely; the api derives ``org_id`` from the DriveFile's own
+    ``org_id`` and forwards it to OpenSearch. This test pins the
+    Pattern B contract — bearer + path resource is sufficient."""
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_pb", org_id=org_id)
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    scene_client = MagicMock()
+    scene_client.search_visual_vector_in_video = _capture
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+    assert resp.status_code == 200
+    # API must use the resource's org_id even though the header was omitted.
+    assert captured["org_id"] == str(org_id)
+
+
+def test_visual_similarity_pattern_b_header_mismatch_returns_404_not_403():
+    """Pattern B cross-validation: caller asserts an org that doesn't
+    match the resource's org. Endpoint returns 404 (not 403, not 400)
+    so the response is indistinguishable from a true not-found and
+    timing doesn't reveal the resource's true tenant."""
+    file_id = uuid4()
+    resource_org = uuid4()
+    asserted_org = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_pb", org_id=resource_org)
+    app = _build_app(drive_file_obj=drive_file)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-by-visual-similarity",
+            json={"query_vec": _vec(), "top_k": 10, "min_similarity": 0.0},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(asserted_org),
+            },
+        )
+    assert resp.status_code == 404
+    # Specifically NOT 403 — 404 is the no-info-leak choice. Pin it
+    # so a future "let's be helpful" refactor doesn't regress.
+    assert resp.status_code != 403
 
 
 def test_visual_similarity_requires_bearer_token():
@@ -408,7 +475,7 @@ def test_visual_similarity_requires_bearer_token():
 def test_scenes_content_returns_per_scene_transcript_and_ocr():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_xyz")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_xyz", org_id=org_id)
 
     scene_client = MagicMock()
     scene_client.mget_scenes = AsyncMock(
@@ -468,7 +535,7 @@ def test_scenes_content_drops_scene_belonging_to_other_video():
     it. Filter by video_id post-mget."""
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_correct")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_correct", org_id=org_id)
 
     scene_client = MagicMock()
     scene_client.mget_scenes = AsyncMock(
@@ -518,7 +585,7 @@ def test_scenes_content_drops_scene_belonging_to_other_video():
 def test_scenes_content_passes_org_scoped_doc_ids_to_mget():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
 
     captured: dict[str, list[str]] = {}
 
@@ -551,7 +618,7 @@ def test_scenes_content_skips_missing_scene_ids():
     or cross-org) is simply absent from the response."""
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
 
     scene_client = MagicMock()
     scene_client.mget_scenes = AsyncMock(
@@ -674,7 +741,7 @@ def test_scenes_content_404_when_drive_file_soft_deleted():
 def test_scenes_content_empty_scene_ids_returns_empty_list():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_v")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
 
     scene_client = MagicMock()
     scene_client.mget_scenes = AsyncMock(return_value={})
@@ -691,6 +758,56 @@ def test_scenes_content_empty_scene_ids_returns_empty_list():
         )
     assert resp.status_code == 200
     assert resp.json()["scenes"] == []
+
+
+def test_scenes_content_pattern_b_header_omitted_resolves_org_from_resource():
+    """Pattern B: header optional, org derived from the DriveFile's
+    own org_id. Mirror of the visual-similarity counterpart."""
+    file_id = uuid4()
+    resource_org = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_pb", org_id=resource_org)
+
+    captured: dict[str, list[str]] = {}
+
+    async def _capture(doc_ids):
+        captured["doc_ids"] = doc_ids
+        return {}
+
+    scene_client = MagicMock()
+    scene_client.mget_scenes = _capture
+    app = _build_app(drive_file_obj=drive_file, scene_client_mock=scene_client)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_pb_scene_001"]},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+    assert resp.status_code == 200
+    # doc_ids must be scoped to the RESOURCE's org_id, not anything
+    # caller-asserted (since caller didn't assert).
+    assert captured["doc_ids"] == [f"{resource_org}:gd_pb_scene_001"]
+
+
+def test_scenes_content_pattern_b_header_mismatch_returns_404_not_403():
+    """Pattern B cross-validation on /scenes-content."""
+    file_id = uuid4()
+    resource_org = uuid4()
+    asserted_org = uuid4()
+    drive_file = _drive_file(file_id=file_id, video_id="gd_pb", org_id=resource_org)
+    app = _build_app(drive_file_obj=drive_file)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/videos/{file_id}/scenes-content",
+            json={"scene_ids": ["gd_pb_scene_001"]},
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(asserted_org),
+            },
+        )
+    assert resp.status_code == 404
+    assert resp.status_code != 403
 
 
 def test_scenes_content_requires_bearer_token():

--- a/services/api/tests/test_videos_internal_scenes_with_keyframes.py
+++ b/services/api/tests/test_videos_internal_scenes_with_keyframes.py
@@ -35,6 +35,10 @@ def _build_app(
     )
 
     fake_repo = MagicMock()
+    # Pattern B (post-2026-05-01): the endpoint now resolves DriveFiles
+    # via ``get_by_id_resource_scoped`` (no org filter) and derives
+    # org from the resource. Mock both for backward compatibility.
+    fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=drive_file_obj)
     fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
 
     # The endpoint imports DriveFileRepository inside the handler.
@@ -56,10 +60,14 @@ def _build_app(
     return app
 
 
-def _drive_file(*, file_id: UUID, video_id: str = "gd_abc123"):
+def _drive_file(*, file_id: UUID, video_id: str = "gd_abc123", org_id: UUID | None = None):
+    """Mocked DriveFile row. Pattern B endpoint derives ``org_id``
+    from the resource itself, so the test fixture must populate
+    ``obj.org_id`` (not just rely on the asserted header)."""
     obj = MagicMock()
     obj.id = file_id
     obj.video_id = video_id
+    obj.org_id = org_id if org_id is not None else uuid4()
     return obj
 
 
@@ -68,7 +76,7 @@ def _drive_file(*, file_id: UUID, video_id: str = "gd_abc123"):
 def test_returns_chronologically_ordered_scenes_with_keyframe_keys():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_abc123")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_abc123", org_id=org_id)
 
     # OS returns scenes deliberately out of order — the endpoint must
     # sort defensively (per the docstring contract).
@@ -191,7 +199,7 @@ def test_returns_400_on_invalid_org_id_header():
 def test_empty_scene_list_returns_200_with_zero_scenes():
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id)
+    drive_file = _drive_file(file_id=file_id, org_id=org_id)
     app = _build_app(
         drive_file_obj=drive_file, scene_response={"scenes": []},
     )
@@ -209,12 +217,70 @@ def test_empty_scene_list_returns_200_with_zero_scenes():
     assert body["total_duration_ms"] == 0
 
 
+# ---------- Pattern B (post-2026-05-01) auth ----------
+
+def test_pattern_b_header_omitted_resolves_org_from_resource():
+    """Pattern B: ``X-Heimdex-Org-Id`` is OPTIONAL. The endpoint
+    derives ``org_id`` from the DriveFile's own ``org_id`` and uses
+    it to construct the keyframe S3 keys. This test pins the
+    contract — bearer + path resource is sufficient."""
+    file_id = uuid4()
+    resource_org = uuid4()
+    drive_file = _drive_file(
+        file_id=file_id, video_id="gd_pb", org_id=resource_org,
+    )
+    scene_response = {
+        "scenes": [
+            {
+                "scene_id": "gd_pb_scene_001",
+                "start_ms": 0, "end_ms": 1000,
+                "keyframe_timestamp_ms": 500,
+            },
+        ],
+    }
+    app = _build_app(drive_file_obj=drive_file, scene_response=scene_response)
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/videos/{file_id}/scenes-with-keyframes",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+    assert resp.status_code == 200
+    # S3 key must use the resource's org_id (not anything header-derived).
+    assert resp.json()["scenes"][0]["keyframe_s3_key"].startswith(
+        f"{resource_org}/drive/keyframes/gd_pb/"
+    )
+
+
+def test_pattern_b_header_mismatch_returns_404_not_403():
+    """Pattern B cross-validation: asserted org doesn't match the
+    resource's org → 404 (not 403, not 400) so timing doesn't reveal
+    the resource's true tenant."""
+    file_id = uuid4()
+    resource_org = uuid4()
+    asserted_org = uuid4()
+    drive_file = _drive_file(
+        file_id=file_id, video_id="gd_pb", org_id=resource_org,
+    )
+    app = _build_app(drive_file_obj=drive_file, scene_response={"scenes": []})
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/videos/{file_id}/scenes-with-keyframes",
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(asserted_org),
+            },
+        )
+    assert resp.status_code == 404
+    assert resp.status_code != 403
+
+
 def test_drops_malformed_scene_rows_silently():
     """A row missing scene_id should be skipped, not 500. Defensive
     against partial OpenSearch reads or schema drift."""
     file_id = uuid4()
     org_id = uuid4()
-    drive_file = _drive_file(file_id=file_id, video_id="gd_x")
+    drive_file = _drive_file(file_id=file_id, video_id="gd_x", org_id=org_id)
     scene_response = {
         "scenes": [
             {"scene_id": "gd_x_scene_001", "start_ms": 0, "end_ms": 1000, "keyframe_timestamp_ms": 500},


### PR DESCRIPTION
## Summary

Phase 3b of the shorts-auto product mode v2 rewrite. Adds the two read-side internal endpoints the track worker needs from the api beyond Phase 2.5a's existing `scenes-with-keyframes`. Worker side (services/product-track-worker/) lands as Phase 3c.

## Endpoints

### `POST /internal/videos/{file_id}/scenes-by-visual-similarity`

OpenSearch coarse pre-filter (kNN over the existing `visual_embedding` field, scoped to a single video_id). Worker passes the 768-dim SigLIP2 embedding of the canonical product crop and gets back the top-K scene_ids ranked by cosine, with sub-threshold hits dropped server-side.

```json
// request
{ "query_vec": [...768 floats...], "top_k": 60, "min_similarity": 0.45 }

// response
{ "video_id": "gd_xyz", "scenes": [{"scene_id": "...", "similarity": 0.81}, ...] }
```

### `POST /internal/videos/{file_id}/scenes-content`

Bulk transcript + OCR fetch by scene_id list (≤200 per call). Worker calls after the coarse pre-filter has narrowed candidates to ~5-10 scenes; the alignment lib in `heimdex_media_pipelines.product_track` uses `transcript_raw` + `ocr_text_raw` to annotate windows with `has_narration_mention` + `has_ocr_overlap`.

```json
// request
{ "scene_ids": ["gd_xyz_scene_007", "gd_xyz_scene_012"] }

// response
{ "video_id": "gd_xyz", "scenes": [{"scene_id": "...", "start_ms": 5000, "end_ms": 10000, "transcript_raw": "...", "speaker_transcript": "...", "ocr_text_raw": "..."}] }
```

## Design choices worth flagging

| Choice | Rationale |
|---|---|
| New `search_visual_vector_in_video` method (vs extending `_build_filter_clauses` for video_id) | The single-video scope is a special-case ad-hoc query; the general filter system shouldn't grow for it. Keeps the new code small and explicit. |
| Hard-validate `query_vec` length against `scene_client.VISUAL_EMBEDDING_DIMENSION` (768) | Drift between worker SigLIP2 variant and api would silently produce nonsense rankings — better to 400 than corrupt. |
| Defense-in-depth on `/scenes-content`: filter by `video_id` post-mget | doc IDs are already org-scoped via `{org_id}:{scene_id}` prefix, but a typo'd cross-video scene_id from the same org could otherwise leak. |
| Both endpoints are POST | Bodies (embedding vector / scene_id list) are too big for query strings. Same convention as the api's other internal endpoints with structured bodies. |
| Per-call cap of 200 scene_ids | Same ceiling as the existing `scenes-with-keyframes` page_size — protects OS from worker bugs. |
| Both endpoints sit on the existing `videos` internal router | Gated behind `drive_connector_enabled` in main.py same as Phase 2.5a — single mount point for everything the product workers need. |

## Tests

27 new unit tests, all green via FastAPI TestClient + mocked dependencies. Mirrors the Phase 2.5a test structure exactly.

```
services/api/tests/test_videos_internal_phase3b.py
├── /scenes-by-visual-similarity (17 tests)
│   ├── happy path: top-K above threshold, sorted by score
│   ├── client param plumbing
│   ├── 400 on invalid query_vec (3 parametrized: wrong dim, empty, non-list)
│   ├── 400 on invalid top_k (4 parametrized: 0, -1, 201, 10000)
│   ├── 400 on invalid min_similarity (3 parametrized)
│   ├── 404 when DriveFile missing / 400 on bad org_id header
│   ├── drops hits with missing scene_id (defensive)
│   ├── empty results return 200 with []
│   └── requires Bearer token
└── /scenes-content (10 tests)
    ├── happy path: per-scene transcript + OCR shape
    ├── drops cross-video scene leaks (defense in depth)
    ├── doc_id construction (org-scoped {org_id}:{scene_id})
    ├── skips missing scene_ids silently
    ├── 400 on non-list / >200 / non-string scene_ids
    ├── 404 when DriveFile missing
    ├── empty scene_ids returns 200 with []
    └── requires Bearer token
```

CI allowlist: not added — consistent with the other product-v2 module tests (Phase 1 / 2.5a / 2 / 2.5b are all out of the CI gate for now; will be added together once `heimdex_media_contracts.product` is on PyPI and the gate is re-evaluated).

## What's not in this PR

- **Phase 3c** worker scaffold (`services/product-track-worker/`) — concrete `Sam2Tracker` + `SiglipEmbedder` + `CoarseRetrievalClient` + `KeyframeFetcher` + `OpenAIPicker` implementations
- **Phase 3d** docker-compose wiring + Aircloud container provisioning
- **Phase 3a** pipeline lib — separate PR on `heimdex-media-pipelines` (#4) — depends on the contract shapes here for the worker to wire up

## Cross-repo refs

- Plan: `dev-heimdex-for-livecommerce/.claude/plans/shorts-auto-product-v2.md` §6.2
- Pipeline lib (Phase 3a): heimdex-media-pipelines#4 (`feat/product-track-pipeline`)
- Contracts already shipped: `heimdex_media_contracts.product` v0.13.0 (Phase 0)

## Test plan

- [ ] CI passes (no test changes touch the allowlist; CI just runs the existing allowlist)
- [ ] Phase 3c worker, when it lands, hits these endpoints with a real SigLIP2 embedding + scene_ids and gets sane results on staging devorg