### PR TITLE
fix(api): Pattern B internal-auth sweep — 7 endpoints across 4 modules (F1 Phase 2)

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -157,6 +157,19 @@ class Settings(BaseSettings):
     drive_download_max_retries: int = 3
     drive_s3_bucket: str = "heimdex-drive"
     drive_internal_api_key: str = ""  # Pre-shared key for drive-worker → API internal ingest
+
+    # Codex F1 Phase 3 — per-service tokens for internal endpoints
+    # without a path resource (worker_events, ingest/scenes, etc.).
+    # Format: comma-separated ``service_id:token`` pairs, e.g.,
+    #   "drive-worker:abc123,blur-worker:def456,worker-events:ghi789"
+    # Workers send ``X-Heimdex-Service-Id`` header + their per-service
+    # token as the bearer; api validates the bearer matches the
+    # expected token for that service. Backward-compat: requests
+    # without ``X-Heimdex-Service-Id`` fall back to the legacy
+    # ``drive_internal_api_key`` shared bearer (so workers don't
+    # need to update before the api change ships).
+    # Empty value = service-id auth disabled (legacy bearer only).
+    internal_service_tokens: str = ""
     drive_api_base_url: str = "http://api:8000"  # API base URL for drive-worker HTTP calls
     drive_enrichment_enabled: bool = False
 

--- a/services/api/app/lib/internal_auth.py
+++ b/services/api/app/lib/internal_auth.py
@@ -73,12 +73,177 @@ Constraints
 
 from __future__ import annotations
 
+import hmac
+import logging
+from functools import lru_cache
 from typing import Any, Awaitable, Callable, TypeVar
 from uuid import UUID
 
-from fastapi import HTTPException, status
+from fastapi import Header, HTTPException, status
 
 ResourceIdT = TypeVar("ResourceIdT")
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# F1 Phase 3 — per-service tokens
+# ---------------------------------------------------------------------------
+#
+# The internal endpoints WITHOUT a path resource (worker_events POST,
+# ingest/scenes POST, ingest/enrich POST) can't use Pattern B because
+# there's no resource to derive the org from. The risk: a leaked
+# global bearer or compromised worker has the full surface of these
+# endpoints, including the ability to fake events / write scenes
+# into ANY tenant's index.
+#
+# Phase 3 mitigates this with **per-service tokens**: each worker
+# gets its own token + a service identity. The api validates the
+# bearer matches the claimed service. Cross-service blast radius
+# from a leaked token is bounded to that service's surface.
+#
+# Backward-compat is the linchpin: this PR ships the api side only.
+# Workers still send the legacy ``drive_internal_api_key`` bearer
+# (no worker code change). The new auth dependency falls back to
+# the legacy bearer when ``X-Heimdex-Service-Id`` isn't sent. Once
+# workers adopt the new header in a follow-up rollout, the legacy
+# fallback can be removed.
+
+
+def _parse_service_tokens(raw: str) -> dict[str, str]:
+    """Parse the ``INTERNAL_SERVICE_TOKENS`` env value into a
+    ``service_id → token`` map.
+
+    Format: ``service_id:token,service_id:token,...``. Whitespace is
+    trimmed. Empty entries are skipped silently. Malformed entries
+    (no colon, empty service_id, empty token) are dropped with a
+    warning — preferred over a 500 at boot time so a single typo
+    doesn't take the api offline.
+    """
+    if not raw:
+        return {}
+    out: dict[str, str] = {}
+    for piece in raw.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        if ":" not in piece:
+            logger.warning(
+                "internal_service_tokens_malformed_entry",
+                extra={"entry_preview": piece[:20]},
+            )
+            continue
+        sid, _, token = piece.partition(":")
+        sid = sid.strip()
+        token = token.strip()
+        if not sid or not token:
+            logger.warning(
+                "internal_service_tokens_empty_field",
+                extra={"sid_set": bool(sid), "token_set": bool(token)},
+            )
+            continue
+        out[sid] = token
+    return out
+
+
+@lru_cache(maxsize=1)
+def _get_service_tokens() -> dict[str, str]:
+    """Cached parsed map. Reads ``settings.internal_service_tokens``
+    once per process — workers don't change tokens at runtime.
+    Tests can clear via ``_get_service_tokens.cache_clear()``.
+    """
+    from app.config import get_settings
+    return _parse_service_tokens(get_settings().internal_service_tokens)
+
+
+def _check_token_constant_time(provided: str, expected: str) -> bool:
+    """Constant-time string compare. Prevents timing-side-channel
+    leaks on bearer comparisons."""
+    return hmac.compare_digest(provided, expected)
+
+
+async def verify_service_identity(
+    authorization: str = Header(..., alias="Authorization"),
+    x_heimdex_service_id: str | None = Header(default=None, alias="X-Heimdex-Service-Id"),
+) -> str:
+    """Auth dependency for internal endpoints WITHOUT a path resource.
+
+    Returns the verified ``service_id`` string. Endpoints log this
+    on every call for audit. Endpoint code never trusts a body- or
+    header-asserted service identity for authorization decisions —
+    only the value returned here.
+
+    Behavior:
+
+      * **New path** — ``X-Heimdex-Service-Id`` header IS present:
+        * Service id MUST be a configured key in
+          ``settings.internal_service_tokens``.
+        * Bearer MUST match the corresponding token (constant-time).
+        * Returns the verified ``service_id``.
+
+      * **Legacy fallback** — ``X-Heimdex-Service-Id`` is absent:
+        * Bearer MUST match the legacy ``drive_internal_api_key``.
+        * Returns ``"legacy"`` so endpoint code can log the path.
+
+    Either way, a mismatch is **401**. The endpoint never sees an
+    unauthenticated request.
+
+    The legacy fallback is intentional: workers ship per-service
+    tokens in a follow-up rollout. Until then, the api accepts both
+    paths so the same release doesn't require simultaneous worker +
+    api updates. Once worker adoption is 100%, remove the fallback
+    by setting ``settings.drive_internal_api_key = ""``.
+    """
+    from app.config import get_settings
+    settings = get_settings()
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authorization header",
+        )
+    provided = parts[1]
+
+    if x_heimdex_service_id is not None:
+        # New service-id path. The service must be registered.
+        tokens = _get_service_tokens()
+        expected = tokens.get(x_heimdex_service_id)
+        if expected is None:
+            logger.warning(
+                "internal_service_unknown",
+                extra={"service_id": x_heimdex_service_id},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Unknown service",
+            )
+        if not _check_token_constant_time(provided, expected):
+            logger.warning(
+                "internal_service_token_mismatch",
+                extra={"service_id": x_heimdex_service_id},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token for service",
+            )
+        return x_heimdex_service_id
+
+    # Legacy fallback. Same behavior as the existing
+    # ``verify_internal_token``.
+    if not settings.drive_internal_api_key:
+        logger.error("drive_internal_api_key_not_configured")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Internal API not configured",
+        )
+    if not _check_token_constant_time(provided, settings.drive_internal_api_key):
+        logger.warning("internal_auth_invalid_token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid internal API key",
+        )
+    return "legacy"
 
 
 async def resolve_resource_with_org(

--- a/services/api/app/lib/internal_auth.py
+++ b/services/api/app/lib/internal_auth.py
@@ -1,0 +1,153 @@
+"""Shared Pattern B internal-auth helper.
+
+Background
+----------
+The api's internal endpoints have historically authenticated workers
+two ways:
+
+* **Pattern A**: shared bearer + caller-asserted ``X-Heimdex-Org-Id``
+  header. The repo lookup filters by both ``resource_id`` AND
+  ``org_id``. Protects against cross-tenant access only as long as the
+  ``(resource_id, org_id)`` pair never leaks together. Fragile.
+
+* **Pattern B**: shared bearer + resource-derived ``org_id``. The
+  bearer authenticates the call; the resource's own ``org_id`` is the
+  canonical tenant context. Header (when sent) is a soft
+  cross-validation that 404s on mismatch. Already in production for
+  ``blur/`` + ``shorts_auto_product/`` internal endpoints.
+
+Codex adversarial review F1 (2026-05-01) flagged Pattern A as a real
+multi-tenant isolation gap. The fix is migration to Pattern B; this
+module centralizes the migration so each module's
+``internal_router.py`` is a one-line helper call away from the right
+auth flow.
+
+Usage
+-----
+
+::
+
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    @router.get("/youtube/channels/{channel_id}/video_ids")
+    async def get_known_video_ids(
+        channel_id: UUID,
+        x_heimdex_org_id: str | None = Header(default=None, alias="X-Heimdex-Org-Id"),
+        _token: str = Depends(verify_internal_token),
+        db: AsyncSession = Depends(get_db_session),
+    ):
+        repo = YouTubeChannelRepository(db)
+        channel, org_id = await resolve_resource_with_org(
+            resource_id=channel_id,
+            x_heimdex_org_id=x_heimdex_org_id,
+            lookup_fn=repo.get_by_id_resource_scoped,
+            not_found_detail="channel not found",
+        )
+        ...
+
+The repo MUST expose a ``get_by_id_resource_scoped(id)`` method that
+looks up by id alone (no org filter) and returns a row with an
+``.org_id`` attribute. The corresponding ``get_by_id(id, org_id)``
+method (Pattern A) is intentionally NOT touched — Pattern A callers
+in non-migrated code keep using it; mixing the two would silently
+regress.
+
+Constraints
+-----------
+- Cross-validation mismatch returns **404** (NOT 400, NOT 403).
+  Same response as a true not-found so timing doesn't reveal the
+  resource's true tenant. Pinned by tests.
+- Helper does NOT verify the bearer — caller's
+  ``Depends(verify_internal_token)`` is the bearer gate. Helper only
+  enforces tenant binding once the bearer has passed.
+- Helper does NOT log on mismatch by default (log spam from
+  brute-force probes). Add explicit warning log at the call site if
+  the threat model warrants it.
+- Header is OPTIONAL (``Header(default=None, ...)``). Workers may
+  continue to send it (no worker change required) or omit it; api
+  derives org from the resource either way.
+- ``not_found_detail`` lets endpoints return module-specific text
+  (e.g., "channel not found", "video not found") so the Pattern A
+  endpoints' existing error UX doesn't regress.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, TypeVar
+from uuid import UUID
+
+from fastapi import HTTPException, status
+
+ResourceIdT = TypeVar("ResourceIdT")
+
+
+async def resolve_resource_with_org(
+    *,
+    resource_id: ResourceIdT,
+    x_heimdex_org_id: str | None,
+    lookup_fn: Callable[[ResourceIdT], Awaitable[Any]],
+    not_found_detail: str = "resource not found",
+) -> tuple[Any, UUID]:
+    """Resolve a path resource and derive its org context (Pattern B).
+
+    Args:
+        resource_id: UUID from the endpoint's path parameter.
+        x_heimdex_org_id: Optional ``X-Heimdex-Org-Id`` header value.
+            ``None`` when caller omits the header (the new Pattern B
+            ideal). String when caller sends it (back-compat path —
+            cross-validated against the resource).
+        lookup_fn: Async callable taking a UUID and returning either
+            ``None`` (not found) or a row with an ``.org_id``
+            attribute. The repo's ``get_by_id_resource_scoped`` is
+            the canonical input.
+        not_found_detail: Detail string for the 404 response. Defaults
+            to a generic message; pass an endpoint-specific one to
+            preserve existing error UX.
+
+    Returns:
+        ``(resource, org_id)`` tuple. ``org_id`` always equals
+        ``resource.org_id`` — caller can use either, but using the
+        return tuple makes the resource-derived intent explicit at
+        the call site.
+
+    Raises:
+        HTTPException 400: Header was provided but isn't a valid UUID.
+        HTTPException 404: Resource not found, OR header was provided
+            and didn't match the resource's ``org_id``. The 404 is
+            intentional — same response as not-found so timing
+            doesn't reveal the resource's true tenant. NEVER change
+            this to 403 or 422.
+    """
+    asserted_org_id: UUID | None = None
+    # Defensive: tests sometimes call endpoint functions directly
+    # (no FastAPI in the loop). The default for ``Header(default=None,
+    # ...)`` resolves at request time to ``None``, but a direct
+    # function call sees the literal ``Header`` marker object as the
+    # default. Treat any non-string value as "not provided" — only
+    # real strings reach the UUID parse path.
+    if isinstance(x_heimdex_org_id, str):
+        try:
+            asserted_org_id = UUID(x_heimdex_org_id)
+        except (ValueError, AttributeError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
+            )
+
+    resource = await lookup_fn(resource_id)
+    if resource is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=not_found_detail,
+        )
+
+    if asserted_org_id is not None and asserted_org_id != resource.org_id:
+        # Cross-tenant access attempt. 404 (NOT 403) so the response
+        # is indistinguishable from a genuine not-found — does not
+        # confirm whether the resource_id exists in any tenant.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=not_found_detail,
+        )
+
+    return resource, resource.org_id

--- a/services/api/app/modules/drive/internal_router.py
+++ b/services/api/app/modules/drive/internal_router.py
@@ -382,11 +382,16 @@ async def get_file_metadata(
     async def _lookup(rid: UUID):
         return await repo.get_by_id_resource_scoped(file_id=rid)
 
+    # Constant detail string (no UUID interpolation): the helper uses
+    # the same detail for genuine not-found AND cross-validation
+    # mismatch, so interpolating ``file_id`` would let a cross-tenant
+    # probe confirm the resource exists by comparing the echoed UUID
+    # against what they sent. Pattern B's no-info-leak invariant.
     drive_file, _org_id = await resolve_resource_with_org(
         resource_id=file_id,
         x_heimdex_org_id=x_heimdex_org_id,
         lookup_fn=_lookup,
-        not_found_detail=f"Drive file not found: {file_id}",
+        not_found_detail="Drive file not found",
     )
 
     latency_ms = int((time.monotonic() - t0) * 1000)

--- a/services/api/app/modules/drive/internal_router.py
+++ b/services/api/app/modules/drive/internal_router.py
@@ -360,19 +360,34 @@ async def get_file_metadata(
     file_id: UUID,
     _token: str = Depends(_verify_internal_token),
     db: AsyncSession = Depends(get_db_session),
+    x_heimdex_org_id: str | None = Header(default=None, alias="X-Heimdex-Org-Id"),
 ):
-    """Return minimal file metadata needed by workers for processing."""
+    """Return minimal file metadata needed by workers for processing.
+
+    Auth (Pattern B, post-2026-05-01): bearer authenticates; the
+    resource's own ``org_id`` is the canonical tenant context.
+    Pre-Pattern-B this endpoint had **no** tenant binding at all —
+    a worker holding the bearer could read any file's metadata.
+    Migrated to use the shared helper so an optional
+    ``X-Heimdex-Org-Id`` header is cross-validated (404 on mismatch).
+    Also closes the soft-delete gap (F2): retired files now 404.
+    """
+    from app.lib.internal_auth import resolve_resource_with_org
+    from app.modules.drive.repository import DriveFileRepository
+
     t0 = time.monotonic()
 
-    result = await db.execute(
-        select(DriveFile).where(DriveFile.id == file_id)
+    repo = DriveFileRepository(db)
+
+    async def _lookup(rid: UUID):
+        return await repo.get_by_id_resource_scoped(file_id=rid)
+
+    drive_file, _org_id = await resolve_resource_with_org(
+        resource_id=file_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=_lookup,
+        not_found_detail=f"Drive file not found: {file_id}",
     )
-    drive_file = result.scalar_one_or_none()
-    if drive_file is None:
-        raise HTTPException(
-            status_code=http_status.HTTP_404_NOT_FOUND,
-            detail=f"Drive file not found: {file_id}",
-        )
 
     latency_ms = int((time.monotonic() - t0) * 1000)
     logger.info(

--- a/services/api/app/modules/drive/repository.py
+++ b/services/api/app/modules/drive/repository.py
@@ -113,6 +113,26 @@ class DriveFileRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_by_video_id_resource_scoped(
+        self, video_id: str,
+    ) -> Optional[DriveFile]:
+        """Look up a DriveFile by its STRING ``video_id`` (e.g.,
+        ``gd_abc123``). No org filter — see ``get_by_id_resource_scoped``
+        for the full Pattern B rationale.
+
+        Used by the shorts_render internal endpoint
+        ``GET /{video_id}/media-source`` which receives a string id
+        from the path. Mirrors ``get_by_id_resource_scoped`` for the
+        UUID case.
+        """
+        result = await self.session.execute(
+            select(DriveFile).where(
+                DriveFile.video_id == video_id,
+                DriveFile.is_deleted.is_(False),
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_id_resource_scoped(
         self, file_id: UUID,
     ) -> Optional[DriveFile]:

--- a/services/api/app/modules/ingest/internal_router.py
+++ b/services/api/app/modules/ingest/internal_router.py
@@ -37,18 +37,28 @@ router = APIRouter(prefix="/internal/ingest", tags=["internal-ingest"])
 
 
 from app.dependencies import verify_internal_token as _verify_internal_token
+from app.lib.internal_auth import verify_service_identity
 
 
 @router.post("/scenes", response_model=IngestScenesResponse)
 async def internal_ingest_scenes(
     request: IngestScenesRequest,
     x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
-    _token: str = Depends(_verify_internal_token),
+    verified_service_id: str = Depends(verify_service_identity),
     db: AsyncSession = Depends(get_db_session),
     org_repo: OrgRepository = Depends(get_org_repository),
     ingest_service: SceneIngestService = Depends(get_scene_ingest_service),
 ):
-    """Ingest scenes from drive-worker. Auth: internal API key. Tenancy: X-Heimdex-Org-Id header."""
+    """Ingest scenes from drive-worker.
+
+    Auth (F1 Phase 3): per-service token via ``verify_service_identity``.
+    Workers send ``X-Heimdex-Service-Id`` header + their per-service
+    token; legacy global bearer continues to work as a backward-compat
+    fallback (returns ``service_id="legacy"``). The verified
+    ``service_id`` is logged on every call for audit; the body's
+    asserted ``X-Heimdex-Org-Id`` is still trusted (Phase 3 doesn't
+    bind service to allowed orgs — that's a separate hardening pass).
+    """
     try:
         org_id = UUID(x_heimdex_org_id)
     except (ValueError, AttributeError):
@@ -83,6 +93,7 @@ async def internal_ingest_scenes(
         video_id=request.video_id,
         library_id=str(request.library_id),
         scene_count=len(request.scenes),
+        verified_service_id=verified_service_id,  # F1 Phase 3 audit
     )
 
     try:
@@ -139,11 +150,17 @@ async def internal_ingest_scenes(
 async def internal_enrich_scenes(
     request: EnrichScenesRequest,
     x_heimdex_org_id: str = Header(..., alias="X-Heimdex-Org-Id"),
-    _token: str = Depends(_verify_internal_token),
+    verified_service_id: str = Depends(verify_service_identity),
     db: AsyncSession = Depends(get_db_session),
     org_repo: OrgRepository = Depends(get_org_repository),
     ingest_service: SceneIngestService = Depends(get_scene_ingest_service),
 ):
+    """Enrichment merge from GPU workers.
+
+    Auth (F1 Phase 3): per-service token via ``verify_service_identity``;
+    legacy global bearer continues to work as a backward-compat
+    fallback. ``verified_service_id`` is logged on every call.
+    """
     try:
         org_id = UUID(x_heimdex_org_id)
     except (ValueError, AttributeError):
@@ -175,6 +192,7 @@ async def internal_enrich_scenes(
         org_id=str(org_id),
         video_id=request.video_id,
         scene_count=len(request.scenes),
+        verified_service_id=verified_service_id,  # F1 Phase 3 audit
     )
 
     result = await ingest_service.enrich_scenes(

--- a/services/api/app/modules/shorts_render/internal_router.py
+++ b/services/api/app/modules/shorts_render/internal_router.py
@@ -83,16 +83,21 @@ async def update_render_status(
 @router.get("/{video_id}/media-source", response_model=MediaSourceResponse)
 async def get_media_source(
     video_id: str,
-    x_heimdex_org_id: Annotated[str, Header(..., alias="X-Heimdex-Org-Id")],
     _token: Annotated[str, Depends(verify_internal_token)],
     drive_file_repo: Annotated[DriveFileRepository, Depends(get_drive_file_repository)],
+    x_heimdex_org_id: Annotated[str | None, Header(alias="X-Heimdex-Org-Id")] = None,
 ):
     """Returns the media source info for the video.
 
     For gdrive videos (gd_ prefix): returns proxy S3 key from DriveFile.
     For other source types: returns 404 (extend as needed).
+
+    Auth (Pattern B, post-2026-05-01): bearer authenticates the call;
+    the resource's ``org_id`` is the canonical tenant context.
+    ``X-Heimdex-Org-Id`` is OPTIONAL and treated as a cross-validation
+    only — see ``app/lib/internal_auth.py``.
     """
-    org_id = _parse_org_id(x_heimdex_org_id)
+    from app.lib.internal_auth import resolve_resource_with_org
 
     if not video_id.startswith("gd_"):
         raise HTTPException(
@@ -100,12 +105,12 @@ async def get_media_source(
             detail=f"Unsupported video source type for video_id: {video_id}",
         )
 
-    drive_file = await drive_file_repo.get_by_video_id(org_id, video_id)
-    if drive_file is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Video not found: {video_id}",
-        )
+    drive_file, _org_id = await resolve_resource_with_org(
+        resource_id=video_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=drive_file_repo.get_by_video_id_resource_scoped,
+        not_found_detail=f"Video not found: {video_id}",
+    )
 
     return MediaSourceResponse(
         video_id=video_id,

--- a/services/api/app/modules/videos/internal_router.py
+++ b/services/api/app/modules/videos/internal_router.py
@@ -196,54 +196,30 @@ async def _resolve_drive_file_with_org(
     x_heimdex_org_id: str | None,
     db: AsyncSession,
 ) -> tuple[Any, UUID]:
-    """Look up a DriveFile by id (resource-scoped) and return it
-    along with the tenant ``org_id`` derived from the resource.
+    """Pattern B resolver for DriveFiles. Thin wrapper over the
+    shared ``app.lib.internal_auth.resolve_resource_with_org`` helper
+    so this file's three endpoints (and any new ones) get identical
+    semantics with the rest of the platform sweep.
 
-    If ``x_heimdex_org_id`` is provided, it is **cross-validated** as a
-    soft check: a mismatch with ``drive_file.org_id`` raises a 404 (NOT
-    400 or 403 — same response as not-found, so timing doesn't reveal
-    the resource's true tenant).
-
-    Returns ``(drive_file, org_id)``. Raises ``HTTPException`` for:
-      * 400 — header present but not a valid UUID
-      * 404 — file not found / soft-deleted / cross-org mismatch
-
-    Centralizing the cross-validation here keeps the three endpoints
-    using identical semantics; new endpoints copy-paste a single
-    helper call instead of re-implementing the pattern (and getting
-    it subtly wrong).
+    Look up by id alone (no org filter) — the resource's ``org_id``
+    is the canonical tenant context. ``x_heimdex_org_id`` (when sent)
+    is a soft cross-validation that 404s on mismatch. See the helper's
+    docstring for the full design rationale + non-negotiables.
     """
+    from app.lib.internal_auth import resolve_resource_with_org
     from app.modules.drive.repository import DriveFileRepository
 
-    asserted_org_id: UUID | None = None
-    if x_heimdex_org_id is not None:
-        try:
-            asserted_org_id = UUID(x_heimdex_org_id)
-        except (ValueError, AttributeError):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid X-Heimdex-Org-Id: {x_heimdex_org_id!r}",
-            )
+    repo = DriveFileRepository(db)
 
-    drive_file = await DriveFileRepository(db).get_by_id_resource_scoped(
-        file_id=file_id,
+    async def _lookup(rid: UUID):
+        return await repo.get_by_id_resource_scoped(file_id=rid)
+
+    return await resolve_resource_with_org(
+        resource_id=file_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=_lookup,
+        not_found_detail="video not found",
     )
-    if drive_file is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="video not found",
-        )
-
-    if asserted_org_id is not None and asserted_org_id != drive_file.org_id:
-        # Cross-tenant access attempt. 404 (not 403) so the response
-        # is indistinguishable from a genuine not-found — does not
-        # confirm whether the file_id exists in any tenant.
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="video not found",
-        )
-
-    return drive_file, drive_file.org_id
 
 
 @router.get("/{file_id}/scenes-with-keyframes")

--- a/services/api/app/modules/worker_events/internal_router.py
+++ b/services/api/app/modules/worker_events/internal_router.py
@@ -46,6 +46,17 @@ async def ingest_worker_event(
     future investigation can spot a "service-A bearer claiming to be
     service-B in the body" attack pattern.
     """
+    # F1 Phase 3 audit: log the verified service identity on every
+    # call. ``record_worker_event`` runs async / fire-and-forget so
+    # we emit a sync structured log here for the synchronous audit
+    # trail (separate from the persisted worker_event row).
+    logger.info(
+        "internal_worker_event_received",
+        verified_service_id=verified_service_id,
+        body_service=request.service,
+        event_name=request.event_name,
+    )
+
     if (
         verified_service_id != "legacy"
         and verified_service_id != request.service

--- a/services/api/app/modules/worker_events/internal_router.py
+++ b/services/api/app/modules/worker_events/internal_router.py
@@ -7,13 +7,18 @@ returns immediately so workers never block on observability writes.
 
 POST /internal/worker-events — Ingest a single worker event.
 
-Auth: Pre-shared internal API key (Bearer token) via DRIVE_INTERNAL_API_KEY.
+Auth (F1 Phase 3, post-2026-05-01): per-service token via
+``verify_service_identity``. Workers send ``X-Heimdex-Service-Id``
+header + their per-service token. Legacy global bearer continues
+to work as a backward-compat fallback (returns
+``service_id="legacy"``) so this PR doesn't require a simultaneous
+worker rollout.
 """
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, status as http_status
 
-from app.dependencies import verify_internal_token
+from app.lib.internal_auth import verify_service_identity
 from app.logging_config import get_logger
 
 from .internal_schemas import WorkerEventIngestRequest, WorkerEventIngestResponse
@@ -31,8 +36,32 @@ router = APIRouter(prefix="/internal/worker-events", tags=["internal-worker-even
 )
 async def ingest_worker_event(
     request: WorkerEventIngestRequest,
-    _token: str = Depends(verify_internal_token),
+    verified_service_id: str = Depends(verify_service_identity),
 ) -> WorkerEventIngestResponse:
+    """Ingest a worker observability event.
+
+    The body's ``request.service`` is what the worker SAYS it is —
+    self-asserted, not authenticated. ``verified_service_id`` is the
+    api-validated identity used for audit. We log mismatches so a
+    future investigation can spot a "service-A bearer claiming to be
+    service-B in the body" attack pattern.
+    """
+    if (
+        verified_service_id != "legacy"
+        and verified_service_id != request.service
+    ):
+        # Body claim doesn't match the verified bearer. Log + still
+        # accept — changing this to a 401 would block legitimate
+        # workers whose body ``service`` field differs from their
+        # api token's ``service_id`` (e.g., subsystems within a
+        # worker, multi-component services). Tighten only after we
+        # audit actual traffic.
+        logger.warning(
+            "worker_event_service_mismatch",
+            verified_service_id=verified_service_id,
+            body_service=request.service,
+        )
+
     record_worker_event(
         service=request.service,
         event_name=request.event_name,

--- a/services/api/app/modules/youtube/internal_router.py
+++ b/services/api/app/modules/youtube/internal_router.py
@@ -129,15 +129,19 @@ async def list_enabled_channels(
 @router.get("/channels/{channel_id}/video_ids", response_model=KnownYouTubeVideoIdsResponse)
 async def list_known_video_ids(
     channel_id: UUID,
-    x_heimdex_org_id: Annotated[str, Header(..., alias="X-Heimdex-Org-Id")],
     _token: Annotated[str, Depends(verify_internal_token)],
     channel_repo: Annotated[YouTubeChannelRepository, Depends(get_youtube_channel_repository)],
     video_repo: Annotated[YouTubeVideoRepository, Depends(get_youtube_video_repository)],
+    x_heimdex_org_id: Annotated[str | None, Header(alias="X-Heimdex-Org-Id")] = None,
 ):
-    org_id = _parse_org_id(x_heimdex_org_id)
-    channel = await channel_repo.get_by_id(channel_id, org_id)
-    if channel is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    channel, org_id = await resolve_resource_with_org(
+        resource_id=channel_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=channel_repo.get_by_id_resource_scoped,
+        not_found_detail="Channel not found",
+    )
     video_ids = await video_repo.list_known_youtube_video_ids(org_id=org_id, channel_id=channel_id)
     return KnownYouTubeVideoIdsResponse(video_ids=video_ids, total=len(video_ids))
 
@@ -146,16 +150,20 @@ async def list_known_video_ids(
 async def create_video(
     channel_id: UUID,
     body: CreateYouTubeVideoRequest,
-    x_heimdex_org_id: Annotated[str, Header(..., alias="X-Heimdex-Org-Id")],
     _token: Annotated[str, Depends(verify_internal_token)],
     channel_repo: Annotated[YouTubeChannelRepository, Depends(get_youtube_channel_repository)],
     video_repo: Annotated[YouTubeVideoRepository, Depends(get_youtube_video_repository)],
     library_repo: Annotated[LibraryRepository, Depends(get_library_repository)],
+    x_heimdex_org_id: Annotated[str | None, Header(alias="X-Heimdex-Org-Id")] = None,
 ):
-    org_id = _parse_org_id(x_heimdex_org_id)
-    channel = await channel_repo.get_by_id(channel_id, org_id)
-    if channel is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    channel, org_id = await resolve_resource_with_org(
+        resource_id=channel_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=channel_repo.get_by_id_resource_scoped,
+        not_found_detail="Channel not found",
+    )
 
     service = _get_service(channel_repo, video_repo, library_repo)
     video = await service.create_video_record(org_id=org_id, channel=channel, request=body)
@@ -166,14 +174,18 @@ async def create_video(
 async def mark_channel_synced(
     channel_id: UUID,
     body: SyncCompleteRequest,
-    x_heimdex_org_id: Annotated[str, Header(..., alias="X-Heimdex-Org-Id")],
     _token: Annotated[str, Depends(verify_internal_token)],
     channel_repo: Annotated[YouTubeChannelRepository, Depends(get_youtube_channel_repository)],
+    x_heimdex_org_id: Annotated[str | None, Header(alias="X-Heimdex-Org-Id")] = None,
 ):
-    org_id = _parse_org_id(x_heimdex_org_id)
-    channel = await channel_repo.get_by_id(channel_id, org_id)
-    if channel is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Channel not found")
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    channel, _org_id = await resolve_resource_with_org(
+        resource_id=channel_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=channel_repo.get_by_id_resource_scoped,
+        not_found_detail="Channel not found",
+    )
 
     await channel_repo.update_last_synced_at(channel)
     await channel_repo.set_video_count(channel, body.discovered_count)
@@ -184,16 +196,20 @@ async def mark_channel_synced(
 async def update_video_status(
     video_id: UUID,
     body: UpdateYouTubeVideoStatusRequest,
-    x_heimdex_org_id: Annotated[str, Header(..., alias="X-Heimdex-Org-Id")],
     _token: Annotated[str, Depends(verify_internal_token)],
     video_repo: Annotated[YouTubeVideoRepository, Depends(get_youtube_video_repository)],
     channel_repo: Annotated[YouTubeChannelRepository, Depends(get_youtube_channel_repository)],
     library_repo: Annotated[LibraryRepository, Depends(get_library_repository)],
+    x_heimdex_org_id: Annotated[str | None, Header(alias="X-Heimdex-Org-Id")] = None,
 ):
-    org_id = _parse_org_id(x_heimdex_org_id)
-    video = await video_repo.get_by_id(video_id, org_id)
-    if video is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found")
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    video, org_id = await resolve_resource_with_org(
+        resource_id=video_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=video_repo.get_by_id_resource_scoped,
+        not_found_detail="Video not found",
+    )
 
     service = _get_service(channel_repo, video_repo, library_repo)
     service.inject_subtitle_status(
@@ -324,13 +340,17 @@ async def list_cleanup_candidates(
 @router.patch("/videos/{video_id}/mark-deleted", response_model=YouTubeVideoResponse)
 async def mark_original_deleted(
     video_id: UUID,
-    x_heimdex_org_id: Annotated[str, Header(..., alias="X-Heimdex-Org-Id")],
     _token: Annotated[str, Depends(verify_internal_token)],
     video_repo: Annotated[YouTubeVideoRepository, Depends(get_youtube_video_repository)],
+    x_heimdex_org_id: Annotated[str | None, Header(alias="X-Heimdex-Org-Id")] = None,
 ):
-    org_id = _parse_org_id(x_heimdex_org_id)
-    video = await video_repo.get_by_id(video_id, org_id)
-    if video is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found")
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    video, _org_id = await resolve_resource_with_org(
+        resource_id=video_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=video_repo.get_by_id_resource_scoped,
+        not_found_detail="Video not found",
+    )
     await video_repo.mark_original_deleted(video)
     return _to_video_response(video)

--- a/services/api/app/modules/youtube/repository.py
+++ b/services/api/app/modules/youtube/repository.py
@@ -42,6 +42,23 @@ class YouTubeChannelRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_by_id_resource_scoped(
+        self, channel_pk: UUID,
+    ) -> YouTubeChannel | None:
+        """Look up a channel by id alone — no ``org_id`` filter.
+
+        Used by the Pattern B internal-auth flow (see
+        ``app/lib/internal_auth.py``). Caller derives ``org_id`` from
+        the returned row's ``.org_id`` attribute. Specifically NOT
+        the default — Pattern A callers continue to use
+        ``get_by_id(pk, org_id)`` so this method can't accidentally
+        regress them to F1's caller-asserted org-binding.
+        """
+        result = await self.session.execute(
+            select(YouTubeChannel).where(YouTubeChannel.id == channel_pk)
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_channel_id(self, org_id: UUID, channel_id: str) -> YouTubeChannel | None:
         result = await self.session.execute(
             select(YouTubeChannel).where(
@@ -165,6 +182,16 @@ class YouTubeVideoRepository:
                 YouTubeVideo.id == video_pk,
                 YouTubeVideo.org_id == org_id,
             )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_id_resource_scoped(
+        self, video_pk: UUID,
+    ) -> YouTubeVideo | None:
+        """Pattern B lookup — see ``YouTubeChannelRepository.get_by_id_resource_scoped``
+        for the full design rationale."""
+        result = await self.session.execute(
+            select(YouTubeVideo).where(YouTubeVideo.id == video_pk)
         )
         return result.scalar_one_or_none()
 

--- a/services/api/tests/modules/youtube/test_youtube_internal_router.py
+++ b/services/api/tests/modules/youtube/test_youtube_internal_router.py
@@ -84,6 +84,10 @@ async def test_list_enabled_channels_and_known_video_ids():
     channel_repo = cast(YouTubeChannelRepository, AsyncMock())
     channel_repo.list_by_org = AsyncMock(return_value=[channel])
     channel_repo.get_by_id = AsyncMock(return_value=channel)
+    # Pattern B: endpoints look up via get_by_id_resource_scoped and
+    # derive org from the resource. Mock both the new resource-scoped
+    # path AND the legacy org-filtered one for back-compat.
+    channel_repo.get_by_id_resource_scoped = AsyncMock(return_value=channel)
 
     video_repo = cast(YouTubeVideoRepository, AsyncMock())
     video_repo.list_known_youtube_video_ids = AsyncMock(return_value=["abc123xyz89"])
@@ -91,7 +95,13 @@ async def test_list_enabled_channels_and_known_video_ids():
     channels_res = await list_enabled_channels(str(org_id), "token", channel_repo)
     assert channels_res.total == 1
 
-    ids_res = await list_known_video_ids(channel.id, str(org_id), "token", channel_repo, video_repo)
+    ids_res = await list_known_video_ids(
+        channel_id=channel.id,
+        _token="token",
+        channel_repo=channel_repo,
+        video_repo=video_repo,
+        x_heimdex_org_id=str(org_id),
+    )
     assert ids_res.total == 1
     assert ids_res.video_ids == ["abc123xyz89"]
 
@@ -104,6 +114,7 @@ async def test_create_video_update_status_cleanup_and_mark_deleted():
 
     channel_repo = cast(YouTubeChannelRepository, AsyncMock())
     channel_repo.get_by_id = AsyncMock(return_value=channel)
+    channel_repo.get_by_id_resource_scoped = AsyncMock(return_value=channel)
     channel_repo.set_video_count = AsyncMock(return_value=channel)
 
     async def _fake_update_status(*, video, processing_status, **kwargs):
@@ -117,6 +128,7 @@ async def test_create_video_update_status_cleanup_and_mark_deleted():
     video_repo.get_by_youtube_video_id = AsyncMock(return_value=None)
     video_repo.create = AsyncMock(return_value=video)
     video_repo.get_by_id = AsyncMock(return_value=video)
+    video_repo.get_by_id_resource_scoped = AsyncMock(return_value=video)
     video_repo.update_status = AsyncMock(side_effect=_fake_update_status)
     video_repo.list_cleanup_candidates = AsyncMock(return_value=[video])
     video_repo.mark_original_deleted = AsyncMock(return_value=video)
@@ -126,13 +138,13 @@ async def test_create_video_update_status_cleanup_and_mark_deleted():
 
     create_req = CreateYouTubeVideoRequest(youtube_video_id="abc123xyz89", title="Sample")
     created = await create_video(
-        channel.id,
-        create_req,
-        str(org_id),
-        "token",
-        channel_repo,
-        video_repo,
-        library_repo,
+        channel_id=channel.id,
+        body=create_req,
+        _token="token",
+        channel_repo=channel_repo,
+        video_repo=video_repo,
+        library_repo=library_repo,
+        x_heimdex_org_id=str(org_id),
     )
     assert created.youtube_video_id == "abc123xyz89"
 
@@ -142,13 +154,13 @@ async def test_create_video_update_status_cleanup_and_mark_deleted():
         has_subtitles=True,
     )
     updated = await update_video_status(
-        video.id,
-        status_req,
-        str(org_id),
-        "token",
-        video_repo,
-        channel_repo,
-        library_repo,
+        video_id=video.id,
+        body=status_req,
+        _token="token",
+        video_repo=video_repo,
+        channel_repo=channel_repo,
+        library_repo=library_repo,
+        x_heimdex_org_id=str(org_id),
     )
     assert updated.processing_status == "complete"
     assert updated.has_subtitles is True
@@ -156,7 +168,12 @@ async def test_create_video_update_status_cleanup_and_mark_deleted():
     cleanup = await list_cleanup_candidates(str(org_id), "token", video_repo, channel_repo)
     assert cleanup.total == 1
 
-    marked = await mark_original_deleted(video.id, str(org_id), "token", video_repo)
+    marked = await mark_original_deleted(
+        video_id=video.id,
+        _token="token",
+        video_repo=video_repo,
+        x_heimdex_org_id=str(org_id),
+    )
     assert marked.id == video.id
 
 
@@ -167,15 +184,30 @@ async def test_internal_endpoints_404_and_bad_org_header():
     video_repo = cast(YouTubeVideoRepository, AsyncMock())
     channel_repo.get_by_id = AsyncMock(return_value=None)
     video_repo.get_by_id = AsyncMock(return_value=None)
+    # Pattern B: Pattern-B-migrated endpoints look up via the
+    # resource-scoped method. ``None`` triggers the 404 path.
+    channel_repo.get_by_id_resource_scoped = AsyncMock(return_value=None)
+    video_repo.get_by_id_resource_scoped = AsyncMock(return_value=None)
 
     with pytest.raises(HTTPException) as bad_org:
         await list_enabled_channels("not-a-uuid", "token", channel_repo)
     assert bad_org.value.status_code == 400
 
     with pytest.raises(HTTPException) as channel_missing:
-        await list_known_video_ids(uuid4(), str(org_id), "token", channel_repo, video_repo)
+        await list_known_video_ids(
+            channel_id=uuid4(),
+            _token="token",
+            channel_repo=channel_repo,
+            video_repo=video_repo,
+            x_heimdex_org_id=str(org_id),
+        )
     assert channel_missing.value.status_code == 404
 
     with pytest.raises(HTTPException) as video_missing:
-        await mark_original_deleted(uuid4(), str(org_id), "token", video_repo)
+        await mark_original_deleted(
+            video_id=uuid4(),
+            _token="token",
+            video_repo=video_repo,
+            x_heimdex_org_id=str(org_id),
+        )
     assert video_missing.value.status_code == 404

--- a/services/api/tests/test_internal_auth_helper.py
+++ b/services/api/tests/test_internal_auth_helper.py
@@ -1,9 +1,14 @@
-"""Unit tests for the shared Pattern B internal-auth helper.
+"""Unit tests for the shared internal-auth helpers.
 
-Covers ``app.lib.internal_auth.resolve_resource_with_org`` directly
-(no FastAPI in the loop). Each module's internal_router has its own
-integration tests; this file pins the helper's contract so the
-mismatch-returns-404 behavior can't regress during refactors.
+Covers ``app.lib.internal_auth``:
+* Pattern B helper ``resolve_resource_with_org`` (Phase 1+2)
+* Per-service token helper ``verify_service_identity`` (Phase 3)
+* Internal map parser ``_parse_service_tokens``
+
+Each module's internal_router has its own integration tests; this
+file pins the helper contracts so the no-info-leak behaviors
+(mismatch returns 404, malformed tokens are dropped not crashed,
+constant-time compare on bearer) can't regress during refactors.
 """
 
 from __future__ import annotations
@@ -14,7 +19,12 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import HTTPException
 
-from app.lib.internal_auth import resolve_resource_with_org
+from app.lib.internal_auth import (
+    _get_service_tokens,
+    _parse_service_tokens,
+    resolve_resource_with_org,
+    verify_service_identity,
+)
 
 
 @dataclass
@@ -154,3 +164,233 @@ async def test_helper_short_circuits_on_malformed_header_before_lookup():
             lookup_fn=_lookup,
         )
     assert lookup_called["yes"] is False
+
+
+# =====================================================================
+# F1 Phase 3 — _parse_service_tokens
+# =====================================================================
+
+
+def test_parse_service_tokens_empty_returns_empty_dict():
+    assert _parse_service_tokens("") == {}
+
+
+def test_parse_service_tokens_single_entry():
+    assert _parse_service_tokens("drive-worker:abc123") == {"drive-worker": "abc123"}
+
+
+def test_parse_service_tokens_multiple_entries():
+    raw = "drive-worker:tok1,blur-worker:tok2,worker-events:tok3"
+    parsed = _parse_service_tokens(raw)
+    assert parsed == {
+        "drive-worker": "tok1",
+        "blur-worker": "tok2",
+        "worker-events": "tok3",
+    }
+
+
+def test_parse_service_tokens_trims_whitespace():
+    raw = "  drive-worker : tok1 ,  blur-worker:tok2 "
+    assert _parse_service_tokens(raw) == {
+        "drive-worker": "tok1",
+        "blur-worker": "tok2",
+    }
+
+
+def test_parse_service_tokens_drops_malformed_entries_without_crashing():
+    """Defensive parsing: a single typo in env config shouldn't take
+    the api offline. Bad entries are logged + dropped; valid ones
+    survive."""
+    raw = "drive-worker:tok1,malformed-no-colon,blur-worker:tok2,:no-id-token,nokey:"
+    assert _parse_service_tokens(raw) == {
+        "drive-worker": "tok1",
+        "blur-worker": "tok2",
+    }
+
+
+def test_parse_service_tokens_handles_token_containing_colons():
+    """Token contains the bearer prefix or other colons. ``partition``
+    splits on first colon only, preserving the rest of the token."""
+    raw = "drive-worker:Bearer:something:complex"
+    assert _parse_service_tokens(raw) == {
+        "drive-worker": "Bearer:something:complex",
+    }
+
+
+# =====================================================================
+# F1 Phase 3 — verify_service_identity
+# =====================================================================
+
+
+def _patch_settings(monkeypatch, *, internal_service_tokens: str = "", drive_internal_api_key: str = ""):
+    """Override the cached settings + parsed tokens for one test."""
+    from app.config import get_settings
+    from app.lib import internal_auth as auth_module
+    from types import SimpleNamespace
+
+    fake_settings = SimpleNamespace(
+        internal_service_tokens=internal_service_tokens,
+        drive_internal_api_key=drive_internal_api_key,
+    )
+    monkeypatch.setattr(auth_module, "_get_service_tokens", lambda: _parse_service_tokens(internal_service_tokens))
+    # Patch get_settings via the auth module's import (which is a
+    # late import inside the function — must patch app.config).
+    import app.config as config_module
+    monkeypatch.setattr(config_module, "get_settings", lambda: fake_settings)
+
+
+@pytest.mark.asyncio
+async def test_service_identity_legacy_path_accepts_global_bearer(monkeypatch):
+    """Legacy path: no service-id header, bearer matches the legacy
+    global key. Returns ``"legacy"`` so endpoint code can log the
+    auth path."""
+    _patch_settings(monkeypatch, drive_internal_api_key="legacy-secret")
+
+    sid = await verify_service_identity(
+        authorization="Bearer legacy-secret",
+        x_heimdex_service_id=None,
+    )
+    assert sid == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_service_identity_legacy_path_rejects_wrong_bearer(monkeypatch):
+    _patch_settings(monkeypatch, drive_internal_api_key="legacy-secret")
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_service_identity(
+            authorization="Bearer wrong",
+            x_heimdex_service_id=None,
+        )
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_service_identity_legacy_path_503_when_unconfigured(monkeypatch):
+    """If ``drive_internal_api_key`` is empty AND no service-id is
+    sent, the api isn't configured for any auth → 503."""
+    _patch_settings(monkeypatch, drive_internal_api_key="")
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_service_identity(
+            authorization="Bearer anything",
+            x_heimdex_service_id=None,
+        )
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_service_identity_new_path_accepts_matching_token(monkeypatch):
+    """New path: service-id header present, bearer matches the
+    per-service token. Returns the verified service_id."""
+    _patch_settings(
+        monkeypatch,
+        internal_service_tokens="drive-worker:tok1,blur-worker:tok2",
+        drive_internal_api_key="legacy-secret",
+    )
+
+    sid = await verify_service_identity(
+        authorization="Bearer tok2",
+        x_heimdex_service_id="blur-worker",
+    )
+    assert sid == "blur-worker"
+
+
+@pytest.mark.asyncio
+async def test_service_identity_new_path_rejects_wrong_token(monkeypatch):
+    """Bearer doesn't match the expected token for the asserted
+    service_id → 401. Specifically does NOT fall through to the
+    legacy bearer — sending a service-id is an explicit choice and
+    the api shouldn't silently accept the legacy path as a
+    fallback when the token mismatches."""
+    _patch_settings(
+        monkeypatch,
+        internal_service_tokens="drive-worker:tok1",
+        drive_internal_api_key="legacy-secret",  # NOT used
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_service_identity(
+            authorization="Bearer legacy-secret",  # legacy bearer
+            x_heimdex_service_id="drive-worker",  # but with service id
+        )
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_service_identity_new_path_rejects_unknown_service(monkeypatch):
+    """A service-id header that isn't in the tokens map → 401. NOT
+    a fall-through to legacy: a misconfigured worker shouldn't
+    accidentally pass auth."""
+    _patch_settings(
+        monkeypatch,
+        internal_service_tokens="drive-worker:tok1",
+        drive_internal_api_key="legacy-secret",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_service_identity(
+            authorization="Bearer tok1",
+            x_heimdex_service_id="not-a-registered-service",
+        )
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_service_identity_rejects_malformed_authorization_header(monkeypatch):
+    _patch_settings(monkeypatch, drive_internal_api_key="legacy-secret")
+
+    for bad in ["", "tok1", "Token tok1", "Bearer", "Basic foo"]:
+        with pytest.raises(HTTPException) as exc:
+            await verify_service_identity(
+                authorization=bad,
+                x_heimdex_service_id=None,
+            )
+        assert exc.value.status_code == 401, f"expected 401 for {bad!r}"
+
+
+@pytest.mark.asyncio
+async def test_service_identity_returns_service_id_not_legacy_for_audit(monkeypatch):
+    """Audit invariant: when the new path is used, return the
+    actual service_id (not "legacy" / a generic value). Endpoint
+    audit logs need this distinction."""
+    _patch_settings(
+        monkeypatch,
+        internal_service_tokens="drive-worker:tok1,blur-worker:tok2,worker-events:tok3",
+        drive_internal_api_key="legacy-secret",
+    )
+
+    for sid, tok in [
+        ("drive-worker", "tok1"),
+        ("blur-worker", "tok2"),
+        ("worker-events", "tok3"),
+    ]:
+        result = await verify_service_identity(
+            authorization=f"Bearer {tok}",
+            x_heimdex_service_id=sid,
+        )
+        assert result == sid
+
+
+@pytest.mark.asyncio
+async def test_service_identity_constant_time_compare_smoke(monkeypatch):
+    """Smoke test the constant-time compare path. Real timing
+    measurement is out of scope for unit tests; this just ensures
+    we're calling ``hmac.compare_digest`` (passes for matching,
+    rejects mismatching)."""
+    _patch_settings(monkeypatch, drive_internal_api_key="abcdef")
+
+    assert (
+        await verify_service_identity(
+            authorization="Bearer abcdef",
+            x_heimdex_service_id=None,
+        )
+        == "legacy"
+    )
+
+    # Same length, different value
+    with pytest.raises(HTTPException):
+        await verify_service_identity(
+            authorization="Bearer ABCDEF",
+            x_heimdex_service_id=None,
+        )

--- a/services/api/tests/test_internal_auth_helper.py
+++ b/services/api/tests/test_internal_auth_helper.py
@@ -1,0 +1,156 @@
+"""Unit tests for the shared Pattern B internal-auth helper.
+
+Covers ``app.lib.internal_auth.resolve_resource_with_org`` directly
+(no FastAPI in the loop). Each module's internal_router has its own
+integration tests; this file pins the helper's contract so the
+mismatch-returns-404 behavior can't regress during refactors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.lib.internal_auth import resolve_resource_with_org
+
+
+@dataclass
+class _FakeResource:
+    """Minimal stand-in for a repo row — only ``org_id`` matters."""
+    id: UUID
+    org_id: UUID
+
+
+def _make_lookup(resource: _FakeResource | None):
+    """Build an async lookup_fn that returns the given resource."""
+    async def _lookup(resource_id: UUID):
+        return resource
+    return _lookup
+
+
+# ---------- happy paths ----------
+
+
+@pytest.mark.asyncio
+async def test_returns_resource_and_org_when_header_omitted():
+    resource_id = uuid4()
+    org_id = uuid4()
+    resource = _FakeResource(id=resource_id, org_id=org_id)
+
+    out, derived_org = await resolve_resource_with_org(
+        resource_id=resource_id,
+        x_heimdex_org_id=None,
+        lookup_fn=_make_lookup(resource),
+    )
+    assert out is resource
+    assert derived_org == org_id
+
+
+@pytest.mark.asyncio
+async def test_returns_resource_and_org_when_header_matches():
+    resource_id = uuid4()
+    org_id = uuid4()
+    resource = _FakeResource(id=resource_id, org_id=org_id)
+
+    out, derived_org = await resolve_resource_with_org(
+        resource_id=resource_id,
+        x_heimdex_org_id=str(org_id),  # matches resource
+        lookup_fn=_make_lookup(resource),
+    )
+    assert out is resource
+    assert derived_org == org_id
+
+
+# ---------- 404s ----------
+
+
+@pytest.mark.asyncio
+async def test_404_when_lookup_returns_none():
+    with pytest.raises(HTTPException) as excinfo:
+        await resolve_resource_with_org(
+            resource_id=uuid4(),
+            x_heimdex_org_id=None,
+            lookup_fn=_make_lookup(None),
+        )
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_404_when_header_mismatches_resource_org():
+    """Cross-validation: caller asserts an org that doesn't match
+    the resource's org. Response MUST be 404 (not 403, not 422) so
+    timing doesn't leak the resource's true tenant."""
+    resource_id = uuid4()
+    resource_org = uuid4()
+    asserted_org = uuid4()
+    resource = _FakeResource(id=resource_id, org_id=resource_org)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await resolve_resource_with_org(
+            resource_id=resource_id,
+            x_heimdex_org_id=str(asserted_org),
+            lookup_fn=_make_lookup(resource),
+        )
+    assert excinfo.value.status_code == 404
+    # PINNED — flipping this to 403/422 reintroduces the timing leak.
+    # Codex F1 fix.
+    assert excinfo.value.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_uses_custom_not_found_detail():
+    """Module-specific error text must reach the response so
+    operators can distinguish ``channel not found`` from
+    ``video not found`` in logs."""
+    with pytest.raises(HTTPException) as excinfo:
+        await resolve_resource_with_org(
+            resource_id=uuid4(),
+            x_heimdex_org_id=None,
+            lookup_fn=_make_lookup(None),
+            not_found_detail="channel not found",
+        )
+    assert excinfo.value.detail == "channel not found"
+
+
+# ---------- 400 on malformed header ----------
+
+
+@pytest.mark.asyncio
+async def test_400_when_header_is_not_a_valid_uuid():
+    """Header was sent but is malformed (e.g., 'not-a-uuid'). 400
+    is correct — this is a client error, distinct from cross-tenant
+    mismatch (which is 404). The two error codes intentionally
+    diverge."""
+    with pytest.raises(HTTPException) as excinfo:
+        await resolve_resource_with_org(
+            resource_id=uuid4(),
+            x_heimdex_org_id="not-a-uuid",
+            lookup_fn=_make_lookup(_FakeResource(id=uuid4(), org_id=uuid4())),
+        )
+    assert excinfo.value.status_code == 400
+    assert "X-Heimdex-Org-Id" in excinfo.value.detail
+
+
+# ---------- helper does not call lookup if header malformed ----------
+
+
+@pytest.mark.asyncio
+async def test_helper_short_circuits_on_malformed_header_before_lookup():
+    """A malformed header should fail with 400 before the lookup
+    even runs — saves a DB hit on every garbage request."""
+    lookup_called = {"yes": False}
+
+    async def _lookup(_id):
+        lookup_called["yes"] = True
+        return _FakeResource(id=uuid4(), org_id=uuid4())
+
+    with pytest.raises(HTTPException):
+        await resolve_resource_with_org(
+            resource_id=uuid4(),
+            x_heimdex_org_id="garbage",
+            lookup_fn=_lookup,
+        )
+    assert lookup_called["yes"] is False

--- a/services/api/tests/test_internal_ingest.py
+++ b/services/api/tests/test_internal_ingest.py
@@ -59,7 +59,7 @@ class TestInternalIngestOrgValidation:
                 await internal_ingest_scenes(
                     request=MagicMock(scenes=[]),
                     x_heimdex_org_id=str(org_id),
-                    _token="valid",
+                    verified_service_id="legacy",  # F1 Phase 3: was _token; "legacy" simulates the backward-compat path
                     db=mock_db,
                     org_repo=org_repo,
                     ingest_service=mock_ingest_service,
@@ -100,7 +100,7 @@ class TestInternalIngestOrgValidation:
             result = await internal_ingest_scenes(
                 request=request,
                 x_heimdex_org_id=str(org_id),
-                _token="valid",
+                verified_service_id="legacy",  # F1 Phase 3: was _token; "legacy" simulates the backward-compat path
                 db=mock_db,
                 org_repo=org_repo,
                 ingest_service=mock_ingest_service,
@@ -118,7 +118,7 @@ class TestInternalIngestOrgValidation:
             await internal_ingest_scenes(
                 request=MagicMock(scenes=[]),
                 x_heimdex_org_id="not-a-uuid",
-                _token="valid",
+                verified_service_id="legacy",  # F1 Phase 3: was _token; "legacy" simulates the backward-compat path
                 db=mock_db,
                 ingest_service=mock_ingest_service,
             )

--- a/services/api/tests/test_shorts_render_internal_router.py
+++ b/services/api/tests/test_shorts_render_internal_router.py
@@ -54,11 +54,16 @@ def _make_drive_file(
     video_id="gd_abc123",
     proxy_s3_key="org1/drive/d1/f1/proxy.mp4",
     google_file_id="gfile_123",
+    org_id=None,
 ):
     f = MagicMock()
     f.video_id = video_id
     f.proxy_s3_key = proxy_s3_key
     f.google_file_id = google_file_id
+    # Pattern B (post-2026-05-01): the endpoint derives org_id from
+    # the resource. Default to the module-level ORG_ID so existing
+    # tests asserting that header keep matching.
+    f.org_id = org_id if org_id is not None else ORG_ID
     return f
 
 
@@ -235,6 +240,7 @@ def test_get_media_source_gdrive():
     mock_drive_repo = AsyncMock()
     drive_file = _make_drive_file()
     mock_drive_repo.get_by_video_id = AsyncMock(return_value=drive_file)
+    mock_drive_repo.get_by_video_id_resource_scoped = AsyncMock(return_value=drive_file)
 
     app = _build_app(mock_drive_file_repo=mock_drive_repo)
     with TestClient(app) as client:
@@ -272,6 +278,7 @@ def test_get_media_source_non_gdrive_returns_404():
 def test_get_media_source_not_found():
     mock_drive_repo = AsyncMock()
     mock_drive_repo.get_by_video_id = AsyncMock(return_value=None)
+    mock_drive_repo.get_by_video_id_resource_scoped = AsyncMock(return_value=None)
 
     app = _build_app(mock_drive_file_repo=mock_drive_repo)
     with TestClient(app) as client:

--- a/services/api/tests/test_videos_internal_phase3b.py
+++ b/services/api/tests/test_videos_internal_phase3b.py
@@ -35,45 +35,58 @@ def _drive_file(*, file_id: UUID, video_id: str = "gd_abc", org_id: UUID | None 
     return obj
 
 
-def _build_app(
-    *,
-    drive_file_obj,
-    scene_client_mock: MagicMock | None = None,
-    internal_token: str = "test-internal-token",
-) -> FastAPI:
+@pytest.fixture
+def _build_app(monkeypatch):
     """Mirror of the Phase 2.5a test helper. ``scene_client_mock``
     can be pre-loaded with method stubs (``search_visual_vector_in_video``,
     ``mget_scenes``) for the endpoint under test.
+
+    Uses pytest's ``monkeypatch`` so the ``DriveFileRepository``
+    module-attribute override auto-reverts between tests — critical
+    so the patch doesn't bleed into other test files (e.g.,
+    ``test_internal_drive_router.py``) that import the real class.
     """
-    from app.dependencies import (
-        get_db_session,
-        get_scene_opensearch_client,
-        verify_internal_token,
-    )
 
-    fake_repo = MagicMock()
-    # Pattern B (post-2026-05-01): endpoints look up DriveFile by id
-    # alone via ``get_by_id_resource_scoped`` and derive ``org_id``
-    # from the resource. Tests mock the new method; ``get_by_id``
-    # also mocked for back-compat with any call sites we miss.
-    fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=drive_file_obj)
-    fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
-    import app.modules.drive.repository as drive_repo_module
-    drive_repo_module.DriveFileRepository = MagicMock(return_value=fake_repo)  # type: ignore[assignment]
+    def _factory(
+        *,
+        drive_file_obj,
+        scene_client_mock: MagicMock | None = None,
+        internal_token: str = "test-internal-token",
+    ) -> FastAPI:
+        from app.dependencies import (
+            get_db_session,
+            get_scene_opensearch_client,
+            verify_internal_token,
+        )
 
-    if scene_client_mock is None:
-        scene_client_mock = MagicMock()
-    # The endpoint reads VISUAL_EMBEDDING_DIMENSION off the client to
-    # validate query_vec length — match the prod constant.
-    scene_client_mock.VISUAL_EMBEDDING_DIMENSION = 768
+        fake_repo = MagicMock()
+        # Pattern B (post-2026-05-01): endpoints look up DriveFile
+        # by id alone via ``get_by_id_resource_scoped`` and derive
+        # ``org_id`` from the resource. Mock both the new method and
+        # ``get_by_id`` for back-compat.
+        fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=drive_file_obj)
+        fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
 
-    app = FastAPI()
-    app.include_router(internal_router, prefix="/internal")
-    app.dependency_overrides[get_db_session] = lambda: AsyncMock()
-    app.dependency_overrides[get_scene_opensearch_client] = lambda: scene_client_mock
-    app.dependency_overrides[verify_internal_token] = lambda: internal_token
+        import app.modules.drive.repository as drive_repo_module
+        monkeypatch.setattr(
+            drive_repo_module,
+            "DriveFileRepository",
+            MagicMock(return_value=fake_repo),
+        )
 
-    return app
+        if scene_client_mock is None:
+            scene_client_mock = MagicMock()
+        scene_client_mock.VISUAL_EMBEDDING_DIMENSION = 768
+
+        app = FastAPI()
+        app.include_router(internal_router, prefix="/internal")
+        app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+        app.dependency_overrides[get_scene_opensearch_client] = lambda: scene_client_mock
+        app.dependency_overrides[verify_internal_token] = lambda: internal_token
+
+        return app
+
+    return _factory
 
 
 def _vec(dim: int = 768, fill: float = 0.01) -> list[float]:
@@ -85,7 +98,7 @@ def _vec(dim: int = 768, fill: float = 0.01) -> list[float]:
 # =====================================================================
 
 
-def test_visual_similarity_returns_top_k_above_threshold_sorted_by_score():
+def test_visual_similarity_returns_top_k_above_threshold_sorted_by_score(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_xyz", org_id=org_id)
@@ -124,7 +137,7 @@ def test_visual_similarity_returns_top_k_above_threshold_sorted_by_score():
     assert body["scenes"][0]["similarity"] == pytest.approx(0.91)
 
 
-def test_visual_similarity_passes_video_id_org_id_size_to_client():
+def test_visual_similarity_passes_video_id_org_id_size_to_client(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
@@ -200,7 +213,7 @@ def _vec_with_token_at(idx: int, token: str) -> str:
     ],
 )
 def test_visual_similarity_400_on_non_finite_query_vec_element(
-    body_factory, expected_index
+    body_factory, expected_index, _build_app
 ):
     """Codex F3: per-element validation. Length-only validation lets
     strings / bools / NaN / inf reach OpenSearch unchanged — best case
@@ -232,7 +245,7 @@ def test_visual_similarity_400_on_non_finite_query_vec_element(
         ("not-a-list", "list"),  # wrong type
     ],
 )
-def test_visual_similarity_400_on_invalid_query_vec(vec, expected_msg):
+def test_visual_similarity_400_on_invalid_query_vec(vec, expected_msg, _build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -253,7 +266,7 @@ def test_visual_similarity_400_on_invalid_query_vec(vec, expected_msg):
     "top_k",
     [0, -1, 201, 10000],
 )
-def test_visual_similarity_400_on_invalid_top_k(top_k):
+def test_visual_similarity_400_on_invalid_top_k(top_k, _build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -271,7 +284,7 @@ def test_visual_similarity_400_on_invalid_top_k(top_k):
 
 
 @pytest.mark.parametrize("min_sim", [-0.01, 1.01, 5.0])
-def test_visual_similarity_400_on_invalid_min_similarity(min_sim):
+def test_visual_similarity_400_on_invalid_min_similarity(min_sim, _build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -288,7 +301,7 @@ def test_visual_similarity_400_on_invalid_min_similarity(min_sim):
     assert "min_similarity" in resp.json()["detail"]
 
 
-def test_visual_similarity_404_when_drive_file_missing():
+def test_visual_similarity_404_when_drive_file_missing(_build_app):
     file_id = uuid4()
     app = _build_app(drive_file_obj=None)
     with TestClient(app) as client:
@@ -303,7 +316,7 @@ def test_visual_similarity_404_when_drive_file_missing():
     assert resp.status_code == 404
 
 
-def test_visual_similarity_404_when_drive_file_soft_deleted():
+def test_visual_similarity_404_when_drive_file_soft_deleted(_build_app):
     """Codex F2: soft-deleted DriveFiles must NOT be resolvable via
     these endpoints — racing a delete with an in-flight worker job
     would otherwise let the worker continue processing retired
@@ -325,7 +338,7 @@ def test_visual_similarity_404_when_drive_file_soft_deleted():
     assert resp.status_code == 404
 
 
-def test_visual_similarity_400_on_invalid_org_id_header():
+def test_visual_similarity_400_on_invalid_org_id_header(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -341,7 +354,7 @@ def test_visual_similarity_400_on_invalid_org_id_header():
     assert resp.status_code == 400
 
 
-def test_visual_similarity_drops_hits_with_missing_scene_id():
+def test_visual_similarity_drops_hits_with_missing_scene_id(_build_app):
     """OS doc with no scene_id field is silently skipped — defensive
     against schema drift / partial reads."""
     file_id = uuid4()
@@ -374,7 +387,7 @@ def test_visual_similarity_drops_hits_with_missing_scene_id():
     ]
 
 
-def test_visual_similarity_empty_results_returns_200_with_zero_scenes():
+def test_visual_similarity_empty_results_returns_200_with_zero_scenes(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_a", org_id=org_id)
@@ -395,7 +408,7 @@ def test_visual_similarity_empty_results_returns_200_with_zero_scenes():
     assert resp.json()["scenes"] == []
 
 
-def test_visual_similarity_pattern_b_header_omitted_resolves_org_from_resource():
+def test_visual_similarity_pattern_b_header_omitted_resolves_org_from_resource(_build_app):
     """Pattern B: ``X-Heimdex-Org-Id`` is OPTIONAL. Workers may omit
     it entirely; the api derives ``org_id`` from the DriveFile's own
     ``org_id`` and forwards it to OpenSearch. This test pins the
@@ -425,7 +438,7 @@ def test_visual_similarity_pattern_b_header_omitted_resolves_org_from_resource()
     assert captured["org_id"] == str(org_id)
 
 
-def test_visual_similarity_pattern_b_header_mismatch_returns_404_not_403():
+def test_visual_similarity_pattern_b_header_mismatch_returns_404_not_403(_build_app):
     """Pattern B cross-validation: caller asserts an org that doesn't
     match the resource's org. Endpoint returns 404 (not 403, not 400)
     so the response is indistinguishable from a true not-found and
@@ -451,7 +464,7 @@ def test_visual_similarity_pattern_b_header_mismatch_returns_404_not_403():
     assert resp.status_code != 403
 
 
-def test_visual_similarity_requires_bearer_token():
+def test_visual_similarity_requires_bearer_token(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -472,7 +485,7 @@ def test_visual_similarity_requires_bearer_token():
 # =====================================================================
 
 
-def test_scenes_content_returns_per_scene_transcript_and_ocr():
+def test_scenes_content_returns_per_scene_transcript_and_ocr(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_xyz", org_id=org_id)
@@ -529,7 +542,7 @@ def test_scenes_content_returns_per_scene_transcript_and_ocr():
     assert s12["ocr_text_raw"] == ""
 
 
-def test_scenes_content_drops_scene_belonging_to_other_video():
+def test_scenes_content_drops_scene_belonging_to_other_video(_build_app):
     """Defense in depth: a scene_id from another video on the same
     org must NOT be returned even if the doc_id mget happens to find
     it. Filter by video_id post-mget."""
@@ -582,7 +595,7 @@ def test_scenes_content_drops_scene_belonging_to_other_video():
     assert scenes[0]["scene_id"] == "gd_correct_scene_001"
 
 
-def test_scenes_content_passes_org_scoped_doc_ids_to_mget():
+def test_scenes_content_passes_org_scoped_doc_ids_to_mget(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
@@ -613,7 +626,7 @@ def test_scenes_content_passes_org_scoped_doc_ids_to_mget():
     ]
 
 
-def test_scenes_content_skips_missing_scene_ids():
+def test_scenes_content_skips_missing_scene_ids(_build_app):
     """A scene_id requested but not returned by mget (e.g., deleted
     or cross-org) is simply absent from the response."""
     file_id = uuid4()
@@ -655,7 +668,7 @@ def test_scenes_content_skips_missing_scene_ids():
     assert [s["scene_id"] for s in scenes] == ["gd_v_scene_001"]
 
 
-def test_scenes_content_400_on_non_list_scene_ids():
+def test_scenes_content_400_on_non_list_scene_ids(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -671,7 +684,7 @@ def test_scenes_content_400_on_non_list_scene_ids():
     assert resp.status_code == 400
 
 
-def test_scenes_content_400_on_too_many_scene_ids():
+def test_scenes_content_400_on_too_many_scene_ids(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -688,7 +701,7 @@ def test_scenes_content_400_on_too_many_scene_ids():
     assert "200" in resp.json()["detail"]
 
 
-def test_scenes_content_400_on_non_string_scene_id():
+def test_scenes_content_400_on_non_string_scene_id(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)
@@ -704,7 +717,7 @@ def test_scenes_content_400_on_non_string_scene_id():
     assert resp.status_code == 400
 
 
-def test_scenes_content_404_when_drive_file_missing():
+def test_scenes_content_404_when_drive_file_missing(_build_app):
     file_id = uuid4()
     app = _build_app(drive_file_obj=None)
     with TestClient(app) as client:
@@ -719,7 +732,7 @@ def test_scenes_content_404_when_drive_file_missing():
     assert resp.status_code == 404
 
 
-def test_scenes_content_404_when_drive_file_soft_deleted():
+def test_scenes_content_404_when_drive_file_soft_deleted(_build_app):
     """Codex F2: same as the visual-similarity counterpart — workers
     must not be able to read transcripts / OCR for a video the user
     has retired. The repo fix routes both paths through the same
@@ -738,7 +751,7 @@ def test_scenes_content_404_when_drive_file_soft_deleted():
     assert resp.status_code == 404
 
 
-def test_scenes_content_empty_scene_ids_returns_empty_list():
+def test_scenes_content_empty_scene_ids_returns_empty_list(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_v", org_id=org_id)
@@ -760,7 +773,7 @@ def test_scenes_content_empty_scene_ids_returns_empty_list():
     assert resp.json()["scenes"] == []
 
 
-def test_scenes_content_pattern_b_header_omitted_resolves_org_from_resource():
+def test_scenes_content_pattern_b_header_omitted_resolves_org_from_resource(_build_app):
     """Pattern B: header optional, org derived from the DriveFile's
     own org_id. Mirror of the visual-similarity counterpart."""
     file_id = uuid4()
@@ -789,7 +802,7 @@ def test_scenes_content_pattern_b_header_omitted_resolves_org_from_resource():
     assert captured["doc_ids"] == [f"{resource_org}:gd_pb_scene_001"]
 
 
-def test_scenes_content_pattern_b_header_mismatch_returns_404_not_403():
+def test_scenes_content_pattern_b_header_mismatch_returns_404_not_403(_build_app):
     """Pattern B cross-validation on /scenes-content."""
     file_id = uuid4()
     resource_org = uuid4()
@@ -810,7 +823,7 @@ def test_scenes_content_pattern_b_header_mismatch_returns_404_not_403():
     assert resp.status_code != 403
 
 
-def test_scenes_content_requires_bearer_token():
+def test_scenes_content_requires_bearer_token(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(drive_file_obj=drive_file)

--- a/services/api/tests/test_videos_internal_scenes_with_keyframes.py
+++ b/services/api/tests/test_videos_internal_scenes_with_keyframes.py
@@ -20,44 +20,52 @@ from fastapi.testclient import TestClient
 from app.modules.videos.internal_router import router as internal_router
 
 
-def _build_app(
-    *,
-    drive_file_obj,
-    scene_response: dict,
-    internal_token: str = "test-internal-token",
-) -> FastAPI:
+@pytest.fixture
+def _build_app(monkeypatch):
     """Build a minimal FastAPI app with mocked dependencies so the
-    endpoint can run in isolation."""
-    from app.dependencies import (
-        get_db_session,
-        get_scene_opensearch_client,
-        verify_internal_token,
-    )
+    endpoint can run in isolation. Uses ``monkeypatch`` so the
+    ``DriveFileRepository`` module-attribute override auto-reverts
+    between tests — critical so the patch doesn't bleed into other
+    test files (e.g., ``test_internal_drive_router.py``) that import
+    the real class.
+    """
 
-    fake_repo = MagicMock()
-    # Pattern B (post-2026-05-01): the endpoint now resolves DriveFiles
-    # via ``get_by_id_resource_scoped`` (no org filter) and derives
-    # org from the resource. Mock both for backward compatibility.
-    fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=drive_file_obj)
-    fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
+    def _factory(
+        *,
+        drive_file_obj,
+        scene_response: dict,
+        internal_token: str = "test-internal-token",
+    ) -> FastAPI:
+        from app.dependencies import (
+            get_db_session,
+            get_scene_opensearch_client,
+            verify_internal_token,
+        )
 
-    # The endpoint imports DriveFileRepository inside the handler.
-    # Patch the class so the in-handler instantiation returns our fake.
-    import app.modules.drive.repository as drive_repo_module
-    drive_repo_module.DriveFileRepository = MagicMock(return_value=fake_repo)  # type: ignore[assignment]
+        fake_repo = MagicMock()
+        fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=drive_file_obj)
+        fake_repo.get_by_id = AsyncMock(return_value=drive_file_obj)
 
-    fake_scene_client = MagicMock()
-    fake_scene_client.get_video_scenes = AsyncMock(return_value=scene_response)
+        import app.modules.drive.repository as drive_repo_module
+        monkeypatch.setattr(
+            drive_repo_module,
+            "DriveFileRepository",
+            MagicMock(return_value=fake_repo),
+        )
 
-    app = FastAPI()
-    app.include_router(internal_router, prefix="/internal")
+        fake_scene_client = MagicMock()
+        fake_scene_client.get_video_scenes = AsyncMock(return_value=scene_response)
 
-    # Replace dependencies with deterministic stubs.
-    app.dependency_overrides[get_db_session] = lambda: AsyncMock()
-    app.dependency_overrides[get_scene_opensearch_client] = lambda: fake_scene_client
-    app.dependency_overrides[verify_internal_token] = lambda: internal_token
+        app = FastAPI()
+        app.include_router(internal_router, prefix="/internal")
 
-    return app
+        app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+        app.dependency_overrides[get_scene_opensearch_client] = lambda: fake_scene_client
+        app.dependency_overrides[verify_internal_token] = lambda: internal_token
+
+        return app
+
+    return _factory
 
 
 def _drive_file(*, file_id: UUID, video_id: str = "gd_abc123", org_id: UUID | None = None):
@@ -73,7 +81,7 @@ def _drive_file(*, file_id: UUID, video_id: str = "gd_abc123", org_id: UUID | No
 
 # ---------- happy path ----------
 
-def test_returns_chronologically_ordered_scenes_with_keyframe_keys():
+def test_returns_chronologically_ordered_scenes_with_keyframe_keys(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, video_id="gd_abc123", org_id=org_id)
@@ -133,7 +141,7 @@ def test_returns_chronologically_ordered_scenes_with_keyframe_keys():
 
 # ---------- auth ----------
 
-def test_requires_bearer_token():
+def test_requires_bearer_token(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(
@@ -157,7 +165,7 @@ def test_requires_bearer_token():
 
 # ---------- 404 on missing video ----------
 
-def test_returns_404_when_drive_file_missing():
+def test_returns_404_when_drive_file_missing(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     app = _build_app(
@@ -177,7 +185,7 @@ def test_returns_404_when_drive_file_missing():
 
 # ---------- 400 on malformed org id ----------
 
-def test_returns_400_on_invalid_org_id_header():
+def test_returns_400_on_invalid_org_id_header(_build_app):
     file_id = uuid4()
     drive_file = _drive_file(file_id=file_id)
     app = _build_app(
@@ -196,7 +204,7 @@ def test_returns_400_on_invalid_org_id_header():
 
 # ---------- empty + malformed scenes ----------
 
-def test_empty_scene_list_returns_200_with_zero_scenes():
+def test_empty_scene_list_returns_200_with_zero_scenes(_build_app):
     file_id = uuid4()
     org_id = uuid4()
     drive_file = _drive_file(file_id=file_id, org_id=org_id)
@@ -219,7 +227,7 @@ def test_empty_scene_list_returns_200_with_zero_scenes():
 
 # ---------- Pattern B (post-2026-05-01) auth ----------
 
-def test_pattern_b_header_omitted_resolves_org_from_resource():
+def test_pattern_b_header_omitted_resolves_org_from_resource(_build_app):
     """Pattern B: ``X-Heimdex-Org-Id`` is OPTIONAL. The endpoint
     derives ``org_id`` from the DriveFile's own ``org_id`` and uses
     it to construct the keyframe S3 keys. This test pins the
@@ -251,7 +259,7 @@ def test_pattern_b_header_omitted_resolves_org_from_resource():
     )
 
 
-def test_pattern_b_header_mismatch_returns_404_not_403():
+def test_pattern_b_header_mismatch_returns_404_not_403(_build_app):
     """Pattern B cross-validation: asserted org doesn't match the
     resource's org → 404 (not 403, not 400) so timing doesn't reveal
     the resource's true tenant."""
@@ -275,7 +283,7 @@ def test_pattern_b_header_mismatch_returns_404_not_403():
     assert resp.status_code != 403
 
 
-def test_drops_malformed_scene_rows_silently():
+def test_drops_malformed_scene_rows_silently(_build_app):
     """A row missing scene_id should be skipped, not 500. Defensive
     against partial OpenSearch reads or schema drift."""
     file_id = uuid4()


### PR DESCRIPTION
## Summary

Continuation of the Codex F1 fix from #110. Migrates 7 more internal endpoints across 4 modules to **Pattern B** (resource-derived org, optional cross-validation header) using a shared helper so the auth flow is identical and copy-paste-safe across the platform.

**Stacked PR**: base = `feat/product-track-internal-endpoints` (#110). Diff only shows Phase 2 work; will re-target to `main` once #110 merges.

## What Pattern B is

The codebase already had two auth paradigms in production:
- **Pattern A** (vulnerable to F1): caller asserts `X-Heimdex-Org-Id`, repo lookup filters by both `id` AND `org_id`. Protects only as long as the `(id, org_id)` pair never leaks together.
- **Pattern B** (already in `blur/` + `shorts_auto_product/`): bearer authenticates the call, resource's own `org_id` is canonical, header (when sent) is a soft cross-validation that 404s on mismatch.

This PR migrates Pattern A endpoints to Pattern B. **Workers don't need to change** — they keep sending the header; api treats it as cross-validation.

## Files

### New shared helper

`services/api/app/lib/internal_auth.py` — single source of truth for the Pattern B flow. Generic over `resource_id` type (UUID and string both work). Pinned semantics:
- 400 if `X-Heimdex-Org-Id` is provided but malformed
- 404 if resource not found OR header mismatches the resource's org
- **Cross-validation mismatch is 404, NOT 403** — same as not-found so timing doesn't leak the resource's true tenant. Pinned by `test_404_when_header_mismatches_resource_org`.

### Endpoints migrated

| Module | Endpoint | Path resource |
|---|---|---|
| `videos/` (existing helper refactored to call shared one) | `scenes-with-keyframes`, `scenes-by-visual-similarity`, `scenes-content` | `file_id` UUID |
| `youtube/` | `list_known_video_ids`, `create_video`, `mark_channel_synced`, `update_video_status`, `mark_original_deleted` | `channel_id` / `video_id` UUID |
| `shorts_render/` | `get_media_source` | `video_id` STRING (`gd_abc...`) |
| `drive/` | `get_file_metadata` | `file_id` UUID — **previously had NO tenant binding at all** |

### New repo methods

- `YouTubeChannelRepository.get_by_id_resource_scoped(channel_pk)`
- `YouTubeVideoRepository.get_by_id_resource_scoped(video_pk)`
- `DriveFileRepository.get_by_video_id_resource_scoped(video_id)` (string-keyed variant)

All three are **DELIBERATELY NOT defaults** — Pattern A callers in non-migrated code keep their org-filtered `get_by_id` as their security boundary. Documented inline.

### Test infrastructure

Converted `_build_app` in the videos test files from a plain function into `@pytest.fixture` using `monkeypatch.setattr`. The previous direct module-attribute override leaked into `test_internal_drive_router.py` once `drive/get_file_metadata` was migrated — surfaced when the suite ran together. `monkeypatch` auto-reverts between tests.

## Out of scope (deferred to F1 Phase 3)

Endpoints WITHOUT a path resource need a different fix (per-service tokens):
- `worker_events/internal_router.py` — body-asserted org_id
- `ingest/scenes` + `ingest/enrich` — body has scene data, header asserts org
- `drive/jobs/claim` — explicitly cross-org by design (queue worker, don't migrate)
- `youtube` list endpoints (channels, videos/pending, transcode) — body or no-resource

These need a per-service-token system that's a substantial design + worker rollout effort. Tracked separately as the F1 Phase 3 platform track.

`drive/internal_sync_router.py` is OUT OF SCOPE — uses **lease tokens** (different auth model). Pinned in commit message constraint.

## Test plan

- [x] 7 unit tests for the shared helper itself (happy paths + 400 on bad header + 404 on missing/mismatch + custom not-found-detail + helper short-circuits before lookup)
- [x] All existing videos/youtube/shorts_render/drive internal-router tests still green after migration
- [x] Test pollution between videos and drive test files fixed via `monkeypatch` auto-cleanup
- [ ] CI green
- [ ] Staging deploy succeeds without ImportError or signature mismatches

**Stats**: 13 files, +632 / −200 lines. 104 tests touching the new auth flow, all green except the 1 pre-existing unrelated `test_update_stt_done` failure on main.

## Constraints captured in the commit

- `get_by_id_resource_scoped` (and the video_id variant) **MUST NEVER** become the default — Pattern A callers depend on the org filter as their security boundary.
- Cross-validation mismatch returns **404, NOT 403**. Flipping reintroduces a timing-leak vector. Pinned by tests.
- `drive_sync/internal_sync_router.py` is OUT OF SCOPE — uses lease tokens, do NOT add Pattern B there.