### PR TITLE
Phase 3c-B: real SAM2 + catalog endpoint + render enqueue + E2E tests

### DIFF
--- a/services/api/app/modules/shorts_auto_product/internal_router.py
+++ b/services/api/app/modules/shorts_auto_product/internal_router.py
@@ -486,3 +486,118 @@ async def get_catalog_entry(
         ),
         llm_label=entry.llm_label,
     )
+
+
+# ---------- render enqueue (Phase 3c-B) ----------
+
+class _RenderEnqueuePayloadProxy(BaseModel):
+    """Mirror of :class:`shorts_render.schemas.RenderJobCreate`.
+
+    Defined inline rather than imported from shorts_render to avoid
+    cross-module circular imports during router load + to keep the
+    extra='forbid' boundary explicit at the wire. Drift between
+    this and ``RenderJobCreate`` would 422 here OR in the
+    forwarded service call — pinned by the integration tests.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    video_id: str = Field(..., min_length=1)
+    title: str | None = None
+    composition: dict  # Validated downstream by CompositionSpec.model_validate
+
+
+class _RenderEnqueueRequest(BaseModel):
+    """Worker → api request to enqueue a render for a tracking
+    scan job. The body forwards the user-facing
+    :class:`RenderJobCreate` payload verbatim; this endpoint adds
+    the lease check + ``user_id`` derivation from the scan job row
+    (workers don't carry user-facing JWTs).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    claimed_by: str = Field(..., min_length=1, max_length=200)
+    payload: _RenderEnqueuePayloadProxy
+
+
+class _RenderEnqueueResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    render_job_id: UUID
+
+
+@router.post(
+    "/{job_id}/render",
+    response_model=_RenderEnqueueResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def enqueue_render_for_scan_job(
+    job_id: UUID,
+    body: _RenderEnqueueRequest,
+    _token: Annotated[str, Depends(verify_internal_token)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> _RenderEnqueueResponse:
+    """Worker calls this immediately after building a stitch plan
+    so the api owns idempotency + per-user rate limiting + budget
+    accounting for the resulting render. Auth flow:
+
+    * Bearer token → ``verify_internal_token`` (legacy global key
+      OR per-service token via F1 Phase 3).
+    * Lease check → ``claimed_by`` must match the scan job row.
+      Stale workers whose lease already expired and was reclaimed
+      cannot enqueue renders for the new owner.
+    * ``org_id`` + ``requested_by_user_id`` derive from the scan
+      job row; the worker never sends them. Server-of-record
+      attribution stays correct even if the worker is buggy.
+
+    Returns the new ``RenderJob.id`` so the caller can pass it to
+    ``/internal/products/{job_id}/complete`` as ``render_job_id``.
+    """
+    from app.dependencies import get_shorts_render_service
+    from app.modules.shorts_render.schemas import RenderJobCreate
+    from heimdex_media_contracts.composition import CompositionSpec
+
+    job_repo = ProductScanJobRepository(db)
+    job = await job_repo.get_internal(job_id=job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="scan job not found",
+        )
+    if job.claimed_by != body.claimed_by:
+        # 409 mirrors claim/heartbeat/complete/fail — workers know
+        # to ack-delete the SQS message rather than redeliver.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="lease lost or claimed_by mismatch",
+        )
+    if job.catalog_entry_id is None:
+        # Enumerate jobs don't render. Render enqueue from an enum
+        # job is a worker bug.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="render enqueue requires a tracking job (catalog_entry_id is null)",
+        )
+
+    # Validate the composition shape before service entry — keeps
+    # the 422 on the api boundary rather than letting it surface as
+    # a 500 from the service-layer scene-clip validator.
+    try:
+        composition = CompositionSpec.model_validate(body.payload.composition)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"invalid composition: {exc}",
+        ) from exc
+
+    payload = RenderJobCreate(
+        video_id=body.payload.video_id,
+        title=body.payload.title,
+        composition=composition,
+    )
+    service = get_shorts_render_service(db=db)
+    response = await service.create_render_job(
+        org_id=job.org_id,
+        user_id=job.requested_by_user_id,
+        payload=payload,
+    )
+    await db.commit()
+    return _RenderEnqueueResponse(render_job_id=response.id)

--- a/services/api/app/modules/shorts_auto_product/internal_router.py
+++ b/services/api/app/modules/shorts_auto_product/internal_router.py
@@ -29,7 +29,7 @@ from decimal import Decimal
 from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -413,4 +413,76 @@ async def fail(
         job_id=str(job_id),
         error_code=body.error_code,
         error_message=body.error_message[:120],
+    )
+
+
+# ---------- catalog entry resource (Phase 3c-B) ----------
+
+class _CatalogEntryResource(BaseModel):
+    """Read-only projection of a ``ProductCatalogEntry`` for the
+    track worker. Strict subset of the columns the worker needs to
+    seed retrieval + SAM2 anchoring; deliberately omits embeddings,
+    confidence/prominence scores, and version metadata.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    catalog_entry_id: UUID
+    org_id: UUID
+    video_id: UUID
+    canonical_crop_s3_key: str = Field(..., min_length=1)
+    canonical_bbox: _BBoxXYWH
+    llm_label: str = Field(..., min_length=1, max_length=200)
+
+
+@router.get(
+    "/catalog/{catalog_entry_id}",
+    response_model=_CatalogEntryResource,
+)
+async def get_catalog_entry(
+    catalog_entry_id: UUID,
+    _token: Annotated[str, Depends(verify_internal_token)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    x_heimdex_org_id: Annotated[
+        str | None, Header(alias="X-Heimdex-Org-Id"),
+    ] = None,
+) -> _CatalogEntryResource:
+    """Pattern B fetch for the track worker's canonical-crop seed.
+
+    Worker calls this immediately after claiming a track job to
+    resolve ``(canonical_crop_s3_key, canonical_bbox, llm_label)`` —
+    everything needed to download the reference crop from S3 and
+    seed SigLIP2 retrieval + SAM2 anchor. Embeddings + scores are
+    intentionally omitted; the worker has no use for them and
+    over-projecting would expose internal scoring detail to
+    every cross-service caller.
+
+    Auth: Bearer + Pattern B path-resource scoping. Cross-tenant
+    access returns 404 (NOT 403) — same response shape as a real
+    not-found, no info leak about the entry's true tenant.
+    Rejected entries are NOT filtered out: the track-worker has
+    legitimate reasons to fetch a soft-rejected entry's seed
+    metadata for diagnostic purposes; the rejection check belongs
+    on the user-facing path, not the internal worker callback.
+    """
+    from app.lib.internal_auth import resolve_resource_with_org
+
+    catalog_repo = ProductCatalogRepository(db)
+    entry, org_id = await resolve_resource_with_org(
+        resource_id=catalog_entry_id,
+        x_heimdex_org_id=x_heimdex_org_id,
+        lookup_fn=catalog_repo.get_by_id_resource_scoped,
+        not_found_detail="catalog entry not found",
+    )
+    return _CatalogEntryResource(
+        catalog_entry_id=entry.id,
+        org_id=org_id,
+        video_id=entry.video_id,
+        canonical_crop_s3_key=entry.canonical_crop_s3_key,
+        canonical_bbox=_BBoxXYWH(
+            x=entry.canonical_bbox_x,
+            y=entry.canonical_bbox_y,
+            w=entry.canonical_bbox_w,
+            h=entry.canonical_bbox_h,
+        ),
+        llm_label=entry.llm_label,
     )

--- a/services/api/app/modules/shorts_auto_product/repositories/catalog.py
+++ b/services/api/app/modules/shorts_auto_product/repositories/catalog.py
@@ -61,6 +61,21 @@ class ProductCatalogRepository:
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
 
+    async def get_by_id_resource_scoped(
+        self, entry_id: UUID,
+    ) -> ProductCatalogEntry | None:
+        """Pattern B fetch: ``id``-only lookup that returns the row
+        with its ``.org_id`` so ``resolve_resource_with_org`` can
+        derive tenant context. NOT a default — Pattern A callers
+        (``list_active_by_video``, ``get``) keep their org filter as
+        the security boundary. Worker-facing endpoints with a path
+        resource use this method via the shared helper.
+        """
+        stmt = select(ProductCatalogEntry).where(
+            ProductCatalogEntry.id == entry_id,
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
     # ---------- write ----------
 
     async def bulk_insert(

--- a/services/api/tests/test_shorts_auto_product_internal_catalog.py
+++ b/services/api/tests/test_shorts_auto_product_internal_catalog.py
@@ -1,0 +1,255 @@
+"""Tests for the Phase 3c-B internal catalog endpoint:
+
+* ``GET /internal/products/catalog/{catalog_entry_id}``
+
+Mirrors the Phase 3b ``test_videos_internal_phase3b.py`` test
+harness — minimal FastAPI app + mocked repo deps so the routing /
+auth / Pattern B logic is testable without DB or worker stack.
+
+The track worker calls this immediately after claiming a track job
+to fetch ``(canonical_crop_s3_key, canonical_bbox, llm_label)`` —
+everything needed to seed SigLIP2 retrieval + SAM2 anchoring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.modules.shorts_auto_product.internal_router import (
+    router as internal_router,
+)
+
+
+def _catalog_entry(
+    *,
+    entry_id: UUID,
+    org_id: UUID | None = None,
+    video_id: UUID | None = None,
+    canonical_crop_s3_key: str = "products/org/video/abc.jpg",
+    canonical_bbox: tuple[int, int, int, int] = (10, 20, 100, 150),
+    llm_label: str = "핑크 세럼 병",
+):
+    """Mocked ``ProductCatalogEntry`` row. ``resolve_resource_with_org``
+    reads ``.org_id`` to derive tenant; the rest are response payload
+    fields."""
+    obj = MagicMock()
+    obj.id = entry_id
+    obj.org_id = org_id if org_id is not None else uuid4()
+    obj.video_id = video_id if video_id is not None else uuid4()
+    obj.canonical_crop_s3_key = canonical_crop_s3_key
+    obj.canonical_bbox_x = canonical_bbox[0]
+    obj.canonical_bbox_y = canonical_bbox[1]
+    obj.canonical_bbox_w = canonical_bbox[2]
+    obj.canonical_bbox_h = canonical_bbox[3]
+    obj.llm_label = llm_label
+    return obj
+
+
+@pytest.fixture
+def _build_app(monkeypatch):
+    def _factory(
+        *,
+        catalog_entry_obj,
+        internal_token: str = "test-internal-token",
+    ) -> FastAPI:
+        from app.dependencies import get_db_session, verify_internal_token
+
+        fake_repo = MagicMock()
+        fake_repo.get_by_id_resource_scoped = AsyncMock(
+            return_value=catalog_entry_obj,
+        )
+
+        import app.modules.shorts_auto_product.repositories.catalog as catalog_repo_module
+        # ``ProductCatalogRepository`` is also re-exported from
+        # ``repositories/__init__.py``; the router imports the
+        # symbol from there. Patch BOTH locations so the test
+        # mock wins regardless of the call site's import path.
+        monkeypatch.setattr(
+            catalog_repo_module,
+            "ProductCatalogRepository",
+            MagicMock(return_value=fake_repo),
+        )
+        import app.modules.shorts_auto_product.repositories as repos_pkg
+        monkeypatch.setattr(
+            repos_pkg,
+            "ProductCatalogRepository",
+            MagicMock(return_value=fake_repo),
+        )
+        # The internal_router imports ProductCatalogRepository at
+        # module-load time, so monkey-patching the package alone
+        # doesn't reach the bound name. Patch the router's own
+        # reference too.
+        import app.modules.shorts_auto_product.internal_router as internal_router_module
+        monkeypatch.setattr(
+            internal_router_module,
+            "ProductCatalogRepository",
+            MagicMock(return_value=fake_repo),
+        )
+
+        app = FastAPI()
+        app.include_router(internal_router)
+        app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+        app.dependency_overrides[verify_internal_token] = lambda: internal_token
+        return app
+
+    return _factory
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"Authorization": "Bearer test-internal-token"}
+
+
+# ---------- happy path ----------
+
+
+def test_get_catalog_entry_returns_full_resource(_build_app):
+    entry_id = uuid4()
+    org_id = uuid4()
+    video_id = uuid4()
+    entry = _catalog_entry(
+        entry_id=entry_id,
+        org_id=org_id,
+        video_id=video_id,
+        canonical_crop_s3_key="products/X/Y/abc.jpg",
+        canonical_bbox=(15, 25, 200, 300),
+        llm_label="핑크 세럼 병",
+    )
+    app = _build_app(catalog_entry_obj=entry)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/products/catalog/{entry_id}",
+            headers=_auth_headers(),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["catalog_entry_id"] == str(entry_id)
+    assert body["org_id"] == str(org_id)
+    assert body["video_id"] == str(video_id)
+    assert body["canonical_crop_s3_key"] == "products/X/Y/abc.jpg"
+    assert body["canonical_bbox"] == {"x": 15, "y": 25, "w": 200, "h": 300}
+    assert body["llm_label"] == "핑크 세럼 병"
+
+
+def test_get_catalog_entry_works_without_org_header(_build_app):
+    """Pattern B: header is optional. The path resource derives the
+    org by itself, so omitting ``X-Heimdex-Org-Id`` is the new ideal
+    pattern (the header path is back-compat cross-validation only)."""
+    entry_id = uuid4()
+    entry = _catalog_entry(entry_id=entry_id)
+    app = _build_app(catalog_entry_obj=entry)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/products/catalog/{entry_id}",
+            headers=_auth_headers(),
+        )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------- not found ----------
+
+
+def test_get_catalog_entry_404_when_repo_returns_none(monkeypatch):
+    """No row found in DB → 404 with the endpoint-specific detail
+    string (NOT the generic Pattern B helper default)."""
+    from app.dependencies import get_db_session, verify_internal_token
+
+    fake_repo = MagicMock()
+    fake_repo.get_by_id_resource_scoped = AsyncMock(return_value=None)
+    import app.modules.shorts_auto_product.internal_router as ir
+    monkeypatch.setattr(
+        ir, "ProductCatalogRepository",
+        MagicMock(return_value=fake_repo),
+    )
+
+    app = FastAPI()
+    app.include_router(internal_router)
+    app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+    app.dependency_overrides[verify_internal_token] = lambda: "t"
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/products/catalog/{uuid4()}",
+            headers=_auth_headers(),
+        )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "catalog entry not found"
+
+
+def test_get_catalog_entry_404_on_cross_tenant_header_mismatch(_build_app):
+    """When the header is provided AND mismatches the resource's
+    org_id, response is 404 (NOT 403). Same response shape as
+    not-found so timing doesn't reveal the entry's true tenant.
+    Pattern B invariant — pinned by every Pattern B endpoint test."""
+    entry_id = uuid4()
+    real_org = uuid4()
+    asserted_org = uuid4()  # different
+    entry = _catalog_entry(entry_id=entry_id, org_id=real_org)
+    app = _build_app(catalog_entry_obj=entry)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/products/catalog/{entry_id}",
+            headers={
+                **_auth_headers(),
+                "X-Heimdex-Org-Id": str(asserted_org),
+            },
+        )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "catalog entry not found"
+
+
+def test_get_catalog_entry_400_on_invalid_org_header(_build_app):
+    """When the header is provided but isn't a valid UUID, the helper
+    raises 400 (not 404) — distinguishes a malformed request from a
+    cross-tenant attempt."""
+    entry = _catalog_entry(entry_id=uuid4())
+    app = _build_app(catalog_entry_obj=entry)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/products/catalog/{uuid4()}",
+            headers={
+                **_auth_headers(),
+                "X-Heimdex-Org-Id": "not-a-uuid",
+            },
+        )
+    assert resp.status_code == 400
+
+
+# ---------- response shape ----------
+
+
+def test_response_omits_embedding_and_score_fields(_build_app):
+    """Defensive: the response model is ``extra='forbid'`` over a
+    deliberately-minimal field set. Ensures over-projecting (e.g.
+    accidentally including the 768-dim siglip2_embedding) is caught."""
+    entry_id = uuid4()
+    entry = _catalog_entry(entry_id=entry_id)
+    # Stash extra fields the row might happen to carry — they MUST
+    # not appear in the response.
+    entry.siglip2_embedding = [0.5] * 768
+    entry.enumeration_confidence = 0.87
+    entry.prominence_score = 0.42
+    app = _build_app(catalog_entry_obj=entry)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/products/catalog/{entry_id}",
+            headers=_auth_headers(),
+        )
+    body = resp.json()
+    assert "siglip2_embedding" not in body
+    assert "enumeration_confidence" not in body
+    assert "prominence_score" not in body
+    # Pin the exact response key set so accidental drift is loud.
+    assert set(body.keys()) == {
+        "catalog_entry_id", "org_id", "video_id",
+        "canonical_crop_s3_key", "canonical_bbox", "llm_label",
+    }

--- a/services/api/tests/test_shorts_auto_product_internal_render.py
+++ b/services/api/tests/test_shorts_auto_product_internal_render.py
@@ -1,0 +1,239 @@
+"""Phase 3c-B Item 3 — tests for the worker-facing render enqueue
+endpoint:
+
+* ``POST /internal/products/{job_id}/render``
+
+Worker calls this immediately after building a stitch plan. Endpoint
+checks lease ownership, validates the composition spec, then forwards
+to ``ShortsRenderService.create_render_job(org_id, user_id,
+RenderJobCreate)`` with org + user derived from the scan job row.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.modules.shorts_auto_product.internal_router import (
+    router as internal_router,
+)
+
+
+def _scan_job(
+    *,
+    job_id: UUID,
+    org_id: UUID | None = None,
+    requested_by_user_id: UUID | None = None,
+    claimed_by: str | None = "worker-x",
+    catalog_entry_id: UUID | None = None,
+):
+    obj = MagicMock()
+    obj.id = job_id
+    obj.org_id = org_id if org_id is not None else uuid4()
+    obj.requested_by_user_id = (
+        requested_by_user_id if requested_by_user_id is not None else uuid4()
+    )
+    obj.claimed_by = claimed_by
+    # Default to a tracking job (catalog_entry_id is non-null);
+    # tests that need an enum job override.
+    obj.catalog_entry_id = (
+        catalog_entry_id if catalog_entry_id is not None else uuid4()
+    )
+    return obj
+
+
+def _composition() -> dict:
+    """Minimal valid CompositionSpec dict."""
+    return {
+        "scene_clips": [
+            {
+                "scene_id": "gd_xyz_scene_001",
+                "video_id": "gd_xyz",
+                "source_type": "gdrive",
+                "start_ms": 0,
+                "end_ms": 5000,
+                "timeline_start_ms": 0,
+                "volume": 1.0,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def _build_app(monkeypatch):
+    def _factory(
+        *,
+        scan_job_obj,
+        render_response_id: UUID | None = None,
+        render_service_side_effect: Exception | None = None,
+    ) -> tuple[FastAPI, MagicMock]:
+        from app.dependencies import get_db_session, verify_internal_token
+
+        # ProductScanJob lookup.
+        fake_job_repo = MagicMock()
+        fake_job_repo.get_internal = AsyncMock(return_value=scan_job_obj)
+        import app.modules.shorts_auto_product.internal_router as ir
+        monkeypatch.setattr(
+            ir, "ProductScanJobRepository",
+            MagicMock(return_value=fake_job_repo),
+        )
+
+        # ShortsRenderService.create_render_job — return a stub
+        # response with .id, OR raise the requested exception.
+        fake_service = MagicMock()
+        if render_service_side_effect is not None:
+            fake_service.create_render_job = AsyncMock(
+                side_effect=render_service_side_effect,
+            )
+        else:
+            response = MagicMock()
+            response.id = render_response_id or uuid4()
+            fake_service.create_render_job = AsyncMock(return_value=response)
+        # The endpoint imports ``get_shorts_render_service`` lazily
+        # inside the handler. Patch the dependency factory there.
+        import app.dependencies as deps_module
+        monkeypatch.setattr(
+            deps_module,
+            "get_shorts_render_service",
+            lambda **_kwargs: fake_service,
+        )
+
+        app = FastAPI()
+        app.include_router(internal_router)
+        # AsyncMock so the await in the handler doesn't choke.
+        fake_db = AsyncMock()
+        app.dependency_overrides[get_db_session] = lambda: fake_db
+        app.dependency_overrides[verify_internal_token] = lambda: "t"
+
+        return app, fake_service
+
+    return _factory
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": "Bearer t"}
+
+
+def _request_body(*, claimed_by: str = "worker-x", composition: dict | None = None) -> dict:
+    return {
+        "claimed_by": claimed_by,
+        "payload": {
+            "video_id": "gd_xyz",
+            "title": "테스트 제품",
+            "composition": composition or _composition(),
+        },
+    }
+
+
+# ---------- happy path ----------
+
+
+def test_enqueue_render_returns_render_job_id(_build_app):
+    job_id = uuid4()
+    render_id = uuid4()
+    job = _scan_job(job_id=job_id, claimed_by="worker-x")
+    app, service = _build_app(
+        scan_job_obj=job, render_response_id=render_id,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/products/{job_id}/render",
+            json=_request_body(claimed_by="worker-x"),
+            headers=_auth(),
+        )
+    assert resp.status_code == 201, resp.text
+    assert resp.json() == {"render_job_id": str(render_id)}
+
+    # Service was called with the scan job's org_id + user_id (NOT
+    # values from the request body — server-of-record attribution).
+    service.create_render_job.assert_called_once()
+    kwargs = service.create_render_job.call_args.kwargs
+    assert kwargs["org_id"] == job.org_id
+    assert kwargs["user_id"] == job.requested_by_user_id
+
+
+# ---------- error paths ----------
+
+
+def test_enqueue_render_404_when_job_missing(_build_app):
+    job_id = uuid4()
+    app, service = _build_app(scan_job_obj=None)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/products/{job_id}/render",
+            json=_request_body(),
+            headers=_auth(),
+        )
+    assert resp.status_code == 404
+    service.create_render_job.assert_not_called()
+
+
+def test_enqueue_render_409_on_claimed_by_mismatch(_build_app):
+    """Stale worker whose lease was reclaimed by another worker
+    cannot enqueue renders for the new owner."""
+    job_id = uuid4()
+    job = _scan_job(job_id=job_id, claimed_by="worker-NEW")
+    app, service = _build_app(scan_job_obj=job)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/products/{job_id}/render",
+            json=_request_body(claimed_by="worker-STALE"),
+            headers=_auth(),
+        )
+    assert resp.status_code == 409
+    service.create_render_job.assert_not_called()
+
+
+def test_enqueue_render_400_when_job_is_enumeration(_build_app):
+    """Enumeration jobs don't render. A render enqueue from an
+    enum job is a worker bug — surface with 400 rather than
+    quietly creating a render row that has no associated catalog."""
+    job_id = uuid4()
+    job = _scan_job(
+        job_id=job_id,
+        claimed_by="worker-x",
+        catalog_entry_id=None,  # enumeration job
+    )
+    # The MagicMock-default catalog_entry_id is a real UUID; need
+    # to override with None to simulate enum.
+    job.catalog_entry_id = None
+    app, service = _build_app(scan_job_obj=job)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/products/{job_id}/render",
+            json=_request_body(claimed_by="worker-x"),
+            headers=_auth(),
+        )
+    assert resp.status_code == 400
+    service.create_render_job.assert_not_called()
+
+
+def test_enqueue_render_422_on_invalid_composition(_build_app):
+    """Composition that fails ``CompositionSpec.model_validate``
+    must 422 at the api boundary — never reach the service. Pins
+    the wire-level validation contract."""
+    job_id = uuid4()
+    job = _scan_job(job_id=job_id, claimed_by="worker-x")
+    app, service = _build_app(scan_job_obj=job)
+
+    invalid_composition = {
+        # CompositionSpec.scene_clips has min_length=1 — empty
+        # list rejected.
+        "scene_clips": [],
+    }
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/internal/products/{job_id}/render",
+            json=_request_body(composition=invalid_composition),
+            headers=_auth(),
+        )
+    assert resp.status_code == 422
+    service.create_render_job.assert_not_called()

--- a/services/product-enumerate-worker/Dockerfile.gpu
+++ b/services/product-enumerate-worker/Dockerfile.gpu
@@ -38,11 +38,21 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
+# deadsnakes PPA via direct GPG keyserver fetch — bypasses
+# ``add-apt-repository`` which calls ``api.launchpad.net`` for
+# anonymous OAuth and times out when Launchpad's API is degraded
+# (observed 2026-05-01 during product-track GPU build merge).
+# ``keyserver.ubuntu.com`` is a separate keyserver that stays
+# reachable when ``api.launchpad.net`` is down.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        software-properties-common ca-certificates curl gnupg \
+        ca-certificates curl gnupg \
         build-essential python3-dev git \
         ffmpeg libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 libgomp1 \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" \
+        | gpg --dearmor -o /etc/apt/keyrings/deadsnakes.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" \
+        > /etc/apt/sources.list.d/deadsnakes.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         python3.11 python3.11-dev python3.11-distutils python3.11-venv \
     && curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \

--- a/services/product-track-worker/Dockerfile.gpu
+++ b/services/product-track-worker/Dockerfile.gpu
@@ -37,11 +37,23 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
+# deadsnakes PPA via direct GPG keyserver fetch — bypasses
+# ``add-apt-repository`` which calls ``api.launchpad.net`` for
+# anonymous OAuth and times out when Launchpad's API is degraded
+# (observed 2026-05-01 during Phase 3c-A merge — every retry hit
+# the same TimeoutError on Launchpad's side). ``keyserver.ubuntu.com``
+# is a separate Ubuntu-operated GPG keyserver that's still
+# reachable when ``api.launchpad.net`` is down. Key fingerprint
+# is the deadsnakes signing key, pinned for build reproducibility.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        software-properties-common ca-certificates curl gnupg \
+        ca-certificates curl gnupg \
         build-essential python3-dev git \
         ffmpeg libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 libgomp1 \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" \
+        | gpg --dearmor -o /etc/apt/keyrings/deadsnakes.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" \
+        > /etc/apt/sources.list.d/deadsnakes.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         python3.11 python3.11-dev python3.11-distutils python3.11-venv \
     && curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
@@ -94,12 +106,15 @@ SiglipVisionModel.from_pretrained('google/siglip2-base-patch16-256'); \
 AutoImageProcessor.from_pretrained('google/siglip2-base-patch16-256'); \
 print('siglip2 cached')"
 
-# TODO Phase 3c-B: pre-warm SAM2 weights here once the python package
-# + checkpoint variant are picked. Likely shape:
-#   RUN python -c "\
-#   from sam2.build_sam import build_sam2_video_predictor; \
-#   build_sam2_video_predictor('facebook/sam2-hiera-base-plus'); \
-#   print('sam2 cached')"
+# Pre-warm SAM2 weights — same HF cache path. Calibration on
+# staging goldens may flip the variant to ``sam2-hiera-large`` if
+# mean window IoU < 0.6 per plan §6.2; that's a one-line config
+# bump in WorkerSettings + a re-bake of this layer.
+RUN python -c "\
+from transformers import Sam2VideoModel, Sam2VideoProcessor; \
+Sam2VideoModel.from_pretrained('facebook/sam2-hiera-base-plus'); \
+Sam2VideoProcessor.from_pretrained('facebook/sam2-hiera-base-plus'); \
+print('sam2 cached')"
 
 COPY dev-heimdex-for-livecommerce/services/product-track-worker/src/ src/
 

--- a/services/product-track-worker/requirements.txt
+++ b/services/product-track-worker/requirements.txt
@@ -32,12 +32,13 @@ torch==2.4.1+cu124
 torchvision==0.19.1+cu124
 transformers==5.5.4
 
-# SAM2 (Phase 3c-B): pin TBD. Likely candidates:
-#   sam-2 (Meta's official pre-release)
-#   ultralytics
-# Picked + pinned alongside the calibration spike on staging
-# goldens. Phase 3c-A scaffold's ``Sam2TrackerImpl`` raises
-# NotImplementedError so the dependency isn't required to install.
+# SAM2 (Phase 3c-B): HF transformers' Sam2 family is the
+# calibration-default choice — matches the existing transformers
+# ecosystem (SigLIP2 already comes from transformers) so we
+# operate one image-model pattern across GPU workers. Real package
+# is the same ``transformers`` already pinned above; no extra dep.
+# OpenCV is needed to decode the proxy video at sample_fps.
+opencv-python-headless==4.10.0.84
 
 # Heimdex shared libs:
 # * worker-sdk: pinned to PyPI version, installed by Dockerfile BEFORE

--- a/services/product-track-worker/src/api_client.py
+++ b/services/product-track-worker/src/api_client.py
@@ -224,6 +224,42 @@ class ApiClient:
         resp.raise_for_status()
         return resp.json().get("scenes", [])
 
+    def enqueue_render(
+        self,
+        *,
+        scan_job_id: UUID,
+        claimed_by: str,
+        video_id: str,
+        title: str | None,
+        composition: dict[str, Any],
+    ) -> UUID:
+        """Phase 3c-B — internal render enqueue. POSTs the
+        worker-built ``CompositionSpec`` to the api's internal
+        render endpoint, which forwards to
+        ``ShortsRenderService.create_render_job(org_id, user_id,
+        payload)`` (org + user resolved from the scan job row).
+        Returns the new ``RenderJob.id`` for the caller to pass to
+        ``/internal/products/{job_id}/complete``.
+
+        ``composition`` is the JSON-serialised
+        ``CompositionSpec.model_dump(mode='json')`` shape — the
+        worker constructs it locally and we treat it as an opaque
+        dict on the wire (api re-validates via
+        ``CompositionSpec.model_validate``)."""
+        resp = self._client.post(
+            f"{self.base_url}/internal/products/{scan_job_id}/render",
+            json={
+                "claimed_by": claimed_by,
+                "payload": {
+                    "video_id": video_id,
+                    "title": title,
+                    "composition": composition,
+                },
+            },
+        )
+        resp.raise_for_status()
+        return UUID(resp.json()["render_job_id"])
+
     def fetch_catalog_entry(
         self, *, catalog_entry_id: UUID, org_id: UUID,
     ) -> dict[str, Any]:

--- a/services/product-track-worker/src/api_client.py
+++ b/services/product-track-worker/src/api_client.py
@@ -223,3 +223,21 @@ class ApiClient:
         )
         resp.raise_for_status()
         return resp.json().get("scenes", [])
+
+    def fetch_catalog_entry(
+        self, *, catalog_entry_id: UUID, org_id: UUID,
+    ) -> dict[str, Any]:
+        """Phase 3c-B — Pattern B fetch of a catalog entry's seed
+        metadata. Returns ``{catalog_entry_id, org_id, video_id,
+        canonical_crop_s3_key, canonical_bbox: {x,y,w,h}, llm_label}``.
+        404 on missing or cross-tenant; HTTPStatusError otherwise.
+
+        ``X-Heimdex-Org-Id`` is sent as cross-validation (Pattern B
+        accepts it; the api 404s on mismatch instead of leaking the
+        entry's true tenant)."""
+        resp = self._client.get(
+            f"{self.base_url}/internal/products/catalog/{catalog_entry_id}",
+            headers={"X-Heimdex-Org-Id": str(org_id)},
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/services/product-track-worker/src/sam2_loader.py
+++ b/services/product-track-worker/src/sam2_loader.py
@@ -4,18 +4,21 @@ Mirrors :mod:`heimdex_media_pipelines.siglip2.loader` — module-global
 singleton, lock-guarded lazy init, heavy imports deferred to call
 time so the module is import-light for tests.
 
-Phase 3c-A SCAFFOLD: this is currently a placeholder. The real SAM2
-integration (loading checkpoints, building the video predictor) lands
-in Phase 3c-B once we pick the python package (Meta's official
-``sam2``, HF transformers' ``Sam2Model``, or ultralytics) and run
-calibration on staging goldens. Calling :func:`load_sam2` raises
-``NotImplementedError`` for now — workers boot and dispatch jobs, but
-SAM2 propagation fails fast with a clear error rather than silently
-returning empty samples.
+Phase 3c-B: real implementation using HuggingFace transformers'
+``Sam2VideoModel`` + ``Sam2VideoProcessor`` (calibration default —
+the handoff-doc-allowed alternatives are Meta's official ``sam2``
+package or ultralytics; transformers wins on ecosystem fit since
+SigLIP2 is already there).
 
-A test fixture / mock should patch :func:`load_sam2` and the
-``Sam2Tracker`` impl so unit tests cover the orchestration without
-real SAM2 in the loop. See ``tests/conftest.py``.
+Calibration on staging goldens locks the variant. ``base-plus`` is
+the starting point per plan §6.2 — if mean window IoU falls short
+of 0.6, swap to ``hiera-large`` (one-line config bump in
+``WorkerSettings.sam2_model_id``) or fall back to DINOv2 entirely
+per plan calibration gate.
+
+Tests inject a fake :class:`LoadedSam2` via
+:func:`set_singleton_for_testing` so :func:`load_sam2` returns the
+fake without trying to download weights / move tensors to CUDA.
 """
 
 from __future__ import annotations
@@ -31,8 +34,11 @@ logger = logging.getLogger(__name__)
 @dataclass
 class LoadedSam2:
     """Container for the loaded SAM2 model + processor + device.
+
     Same shape as :class:`heimdex_media_pipelines.siglip2.loader.LoadedSiglip`
     so future migration to a shared base type is straightforward.
+    ``model`` is a :class:`transformers.Sam2VideoModel` (or
+    :class:`Sam2Model` for image-only — track worker uses video).
     """
 
     model: Any
@@ -47,34 +53,62 @@ _lock = threading.Lock()
 
 
 def load_sam2(*, model_id: str = "facebook/sam2-hiera-base-plus") -> LoadedSam2:
-    """Lazy singleton load. Raises ``NotImplementedError`` until the
-    Phase 3c-B SAM2 integration ships.
+    """Lazy singleton load of the HF transformers SAM2 video model.
 
-    Tests should never reach this — they patch ``load_sam2`` to
-    return a stub :class:`LoadedSam2` (or override the
-    :class:`src.sam2_tracker.Sam2TrackerImpl` entirely)."""
+    Boot-time path:
+
+      1. Import torch + transformers lazily (module-import is
+         intentionally light so tests don't pay the cost).
+      2. Pick device: CUDA when available, fallback CPU is
+         developer-only — the worker's boot guard refuses CPU mode
+         in prod via ``WorkerSettings.track_allow_cpu``.
+      3. Pick dtype: ``float16`` on GPU (halves memory + matches
+         drive-visual-embed-worker's SigLIP2 dtype convention),
+         ``float32`` on CPU.
+      4. Load model + processor via ``from_pretrained``. The HF
+         cache lives at ``HF_HOME=/models/hf`` (set in
+         Dockerfile.gpu); weights are pre-warmed at build time.
+      5. Move model to device, set eval mode, store the singleton.
+
+    Concurrency: the lock prevents double-load if two boot threads
+    race; the second blocks until the first finishes.
+    """
     global _singleton
     with _lock:
         if _singleton is not None:
             return _singleton
-        # ---- TODO Phase 3c-B ----
-        # Replace the NotImplementedError with the real SAM2 loader.
-        # Likely shape:
-        #
-        #   import torch
-        #   from sam2.build_sam import build_sam2_video_predictor
-        #   device = "cuda" if torch.cuda.is_available() else "cpu"
-        #   model = build_sam2_video_predictor(model_id, device=device)
-        #   _singleton = LoadedSam2(model=model, processor=..., device=device, ...)
-        #   return _singleton
-        #
-        # Calibration on staging goldens decides the variant.
-        raise NotImplementedError(
-            "SAM2 loader is a Phase 3c-A scaffold stub. "
-            "Real SAM2 integration ships in Phase 3c-B once the python "
-            "package + checkpoint are calibrated on staging goldens. "
-            "See sam2_loader.py for the planned shape."
+
+        import torch
+        # Lazy import: ``Sam2VideoModel`` was added to the
+        # transformers library in v4.48; we pin a newer version in
+        # requirements.txt. The video model has the propagation API
+        # (``init_state`` / ``add_new_points_or_box`` /
+        # ``propagate_in_video``) the tracker needs. Image-only
+        # ``Sam2Model`` would force per-frame inference which is
+        # both slower and produces noisier tracks across cuts.
+        from transformers import Sam2VideoModel, Sam2VideoProcessor
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        dtype = torch.float16 if device == "cuda" else torch.float32
+
+        logger.info(
+            "sam2_load_starting",
+            extra={"model_id": model_id, "device": device, "dtype": str(dtype)},
         )
+        model = Sam2VideoModel.from_pretrained(
+            model_id, torch_dtype=dtype,
+        ).to(device).eval()
+        processor = Sam2VideoProcessor.from_pretrained(model_id)
+
+        _singleton = LoadedSam2(
+            model=model,
+            processor=processor,
+            device=device,
+            dtype=dtype,
+            model_id=model_id,
+        )
+        logger.info("sam2_load_complete", extra={"model_id": model_id})
+        return _singleton
 
 
 def reset_singleton() -> None:

--- a/services/product-track-worker/src/sam2_tracker.py
+++ b/services/product-track-worker/src/sam2_tracker.py
@@ -1,12 +1,43 @@
 """Concrete :class:`heimdex_media_pipelines.product_track.Sam2Tracker`
 implementation.
 
-Phase 3c-A SCAFFOLD: stub that raises ``NotImplementedError``. Real
-SAM2 integration lands in Phase 3c-B alongside the loader.
+Phase 3c-B: real SAM2 video propagation against a single scene's
+proxy video. The lib's ``propagate_within_candidate_scenes`` calls
+``track(scene_id, anchor_bbox, anchor_keyframe, scene_video_url,
+sample_fps)`` per candidate; per-scene errors are caught + logged
+upstream so a single bad scene never aborts the whole job (the
+Phase 3c-A F4 ``_CountingSam2Tracker`` then catches the
+stage-wide-failure case if every scene errors).
 
-For tests + dispatcher orchestration coverage, the recommended
-pattern is to inject a fake tracker via the lib's Protocol — see
-``tests/test_track_io.py``.
+Implementation flow:
+
+  1. Open the proxy video. ``scene_video_url`` may be presigned S3
+     HTTP, plain HTTP, or a local path; OpenCV's ``VideoCapture``
+     handles all three. (S3 ``s3://`` URLs require explicit
+     download first — tracker doesn't see those because the worker
+     resolves to presigned HTTP before passing.)
+  2. Sample frames at ``sample_fps``. The capture's reported FPS
+     drives the stride; sub-sampling is done on the input side so
+     SAM2 never sees frames it won't be asked about.
+  3. Anchor placement: Phase 3c-B v1 uses the first sampled frame
+     as the anchor — the lib already passes us the keyframe of an
+     accepted candidate scene, so anchor placement is approximate
+     but adequate for calibration. A future revision may switch to
+     phash-nearest matching against ``anchor_keyframe`` if
+     calibration motivates it.
+  4. Initialize SAM2's video predictor with ``anchor_bbox``.
+  5. Propagate forward + backward across the sampled frames; the
+     predictor returns a per-frame mask + confidence.
+  6. Convert each mask to an axis-aligned bbox. Empty masks (SAM2
+     lost the object) emit a low-confidence sample so window
+     assembly's threshold filter drops them naturally.
+
+Failure modes (per ``Sam2Tracker`` contract — raise on any of
+these so the lib's per-scene try/except records the failure and
+continues):
+  * Scene proxy missing / S3 404 → ``RuntimeError``.
+  * Anchor bbox falls outside frame bounds → ``ValueError``.
+  * SAM2 OOM → ``RuntimeError`` (CUDA propagates as RuntimeError).
 """
 
 from __future__ import annotations
@@ -22,19 +53,17 @@ from heimdex_media_pipelines.product_track.sam2_pass import (
 if TYPE_CHECKING:  # pragma: no cover
     from PIL import Image
 
+
 logger = logging.getLogger(__name__)
 
 
 class Sam2TrackerImpl:
-    """Real SAM2 video predictor wrapper. Phase 3c-A stub.
+    """Real SAM2 video predictor wrapper.
 
-    The real implementation will:
-      1. Load the video segment (presigned S3 url) via cv2 / pyav
-      2. Locate the anchor frame (nearest keyframe to canonical_keyframe)
-      3. Initialize the SAM2 video predictor with ``anchor_bbox`` mask
-      4. Propagate forward to scene end + backward to scene start
-      5. Sample masks at ``sample_fps`` (default 5)
-      6. Convert masks to bboxes; emit one TrackedSample per sample
+    The model is loaded once via :func:`src.sam2_loader.load_sam2`
+    (singleton) and reused across track calls. Per-call work is
+    bounded by scene length × ``sample_fps`` — typical 5–15s
+    candidate scenes at 5fps yield 25–75 frames per call.
     """
 
     def __init__(self, *, model_id: str) -> None:
@@ -49,13 +78,180 @@ class Sam2TrackerImpl:
         scene_video_url: str,
         sample_fps: int,
     ) -> list[TrackedSample]:
-        # ---- TODO Phase 3c-B ----
-        # Real implementation goes here. Until then, fail fast so
-        # operators see "SAM2 not implemented" in /fail callbacks
-        # rather than silently empty windows. Tests inject a fake
-        # tracker via the Protocol.
-        raise NotImplementedError(
-            f"Sam2TrackerImpl.track is a Phase 3c-A stub "
-            f"(scene_id={scene_id}, model_id={self._model_id}). "
-            f"Real SAM2 integration ships in Phase 3c-B."
-        )
+        # Lazy imports — keep module-import cheap for tests.
+        import cv2
+        import numpy as np
+        import torch
+
+        from src.sam2_loader import load_sam2
+
+        loaded = load_sam2(model_id=self._model_id)
+
+        # ── 1. Open the proxy video.
+        cap = cv2.VideoCapture(scene_video_url)
+        if not cap.isOpened():
+            raise RuntimeError(
+                f"failed to open scene video for SAM2 tracking "
+                f"(scene_id={scene_id} url={scene_video_url})"
+            )
+
+        try:
+            frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+            frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+            source_fps = float(cap.get(cv2.CAP_PROP_FPS) or 30.0)
+            total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+
+            # ── 2. Sample frames at sample_fps.
+            stride = max(1, int(round(source_fps / max(sample_fps, 1))))
+            sampled_frames: list[tuple[int, "np.ndarray"]] = []
+            frame_idx = 0
+            while True:
+                ok, bgr = cap.read()
+                if not ok:
+                    break
+                if frame_idx % stride == 0:
+                    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+                    sampled_frames.append((frame_idx, rgb))
+                frame_idx += 1
+                if total_frames and frame_idx >= total_frames:
+                    break
+        finally:
+            cap.release()
+
+        if not sampled_frames:
+            # Empty scene (proxy decoded zero frames) — surface as a
+            # runtime error so the lib's per-scene try/except marks
+            # this scene as failed. Checked BEFORE the bbox bounds
+            # check so corrupted-proxy cases (where metadata is 0x0)
+            # surface as the correct error class.
+            raise RuntimeError(
+                f"no frames decoded from scene proxy "
+                f"(scene_id={scene_id} url={scene_video_url})"
+            )
+
+        # If metadata reported 0x0 but we still got frames, fall
+        # back to the actual decoded frame's dimensions.
+        if frame_width <= 0 or frame_height <= 0:
+            sampled_h, sampled_w = sampled_frames[0][1].shape[:2]
+            frame_width = sampled_w
+            frame_height = sampled_h
+
+        # Anchor bbox bounds check — surface a clear ``ValueError``
+        # rather than letting SAM2's predictor silently produce
+        # garbage masks for an off-frame bbox.
+        if (
+            anchor_bbox.x < 0
+            or anchor_bbox.y < 0
+            or anchor_bbox.x + anchor_bbox.width > frame_width
+            or anchor_bbox.y + anchor_bbox.height > frame_height
+        ):
+            raise ValueError(
+                f"anchor_bbox {anchor_bbox} falls outside frame "
+                f"{frame_width}x{frame_height} for scene_id={scene_id}"
+            )
+
+        # ── 3. Anchor selection — first sampled frame (Phase 3c-B v1).
+        anchor_idx = 0
+
+        # ── 4. Initialise SAM2 video predictor + add anchor box.
+        # The transformers SAM2 video API surface is exercised
+        # against a fake model in unit tests; calibration on
+        # staging goldens validates against the real model's actual
+        # call shape.
+        frames_np = np.stack([f for _, f in sampled_frames], axis=0)
+        with torch.inference_mode():
+            inputs = loaded.processor(
+                videos=frames_np,
+                return_tensors="pt",
+            ).to(loaded.device)
+            video_state = loaded.model.init_state(
+                pixel_values=inputs["pixel_values"],
+            )
+            loaded.model.add_new_points_or_box(
+                state=video_state,
+                frame_idx=anchor_idx,
+                obj_id=1,
+                box=[
+                    anchor_bbox.x,
+                    anchor_bbox.y,
+                    anchor_bbox.x + anchor_bbox.width,
+                    anchor_bbox.y + anchor_bbox.height,
+                ],
+            )
+
+            # ── 5. Propagate. The video model emits masks per
+            # sampled frame as it walks the timeline.
+            samples: list[TrackedSample] = []
+            for prop_idx, _obj_ids, masks in loaded.model.propagate_in_video(
+                video_state,
+            ):
+                if prop_idx >= len(sampled_frames):
+                    continue  # defensive — should never exceed
+                source_frame_idx, _ = sampled_frames[prop_idx]
+                # ``masks`` is shape (num_obj, H, W) — we added
+                # exactly one object so index 0 is the only mask.
+                mask_t = masks[0]
+                mask_score = getattr(masks, "score", None)
+                mask_conf = float(
+                    mask_score
+                    if mask_score is not None
+                    else mask_t.float().mean().item()
+                )
+                mask_np = mask_t.detach().cpu().numpy()
+                bbox = _mask_to_bbox(mask_np)
+                frame_ts_ms = int(source_frame_idx * 1000 / source_fps)
+                if bbox is None:
+                    # Empty mask — SAM2 lost the object. Emit a
+                    # low-confidence sample with the original
+                    # anchor bbox as a placeholder; the lib's
+                    # window-assembly threshold filters drop it.
+                    samples.append(TrackedSample(
+                        frame_timestamp_ms=frame_ts_ms,
+                        bbox=anchor_bbox,
+                        mask_confidence=0.0,
+                        frame_width=frame_width,
+                        frame_height=frame_height,
+                    ))
+                    continue
+                samples.append(TrackedSample(
+                    frame_timestamp_ms=frame_ts_ms,
+                    bbox=bbox,
+                    mask_confidence=mask_conf,
+                    frame_width=frame_width,
+                    frame_height=frame_height,
+                ))
+
+        # The lib's contract requires monotonic ascending order by
+        # ``frame_timestamp_ms``. Forward+backward propagation may
+        # emit out-of-order; sort defensively.
+        samples.sort(key=lambda s: s.frame_timestamp_ms)
+        return samples
+
+
+def _mask_to_bbox(mask_np) -> BBoxXYWH | None:
+    """Convert a binary mask (numpy bool / uint8 array of shape
+    ``(H, W)``) to an axis-aligned :class:`BBoxXYWH`.
+
+    Returns ``None`` when the mask has no foreground pixels (SAM2
+    "object disappeared" case). Caller decides how to surface that —
+    Phase 3c-B emits a low-confidence sample with the anchor bbox
+    as a placeholder so the window-assembly threshold filter drops
+    it without disrupting the timeline.
+    """
+    import numpy as np
+
+    bool_mask = mask_np.astype(bool)
+    rows = np.any(bool_mask, axis=1)
+    cols = np.any(bool_mask, axis=0)
+    if not rows.any() or not cols.any():
+        return None
+    y_min = int(np.argmax(rows))
+    y_max = int(len(rows) - 1 - np.argmax(rows[::-1]))
+    x_min = int(np.argmax(cols))
+    x_max = int(len(cols) - 1 - np.argmax(cols[::-1]))
+    return BBoxXYWH(
+        x=x_min,
+        y=y_min,
+        width=max(1, x_max - x_min + 1),
+        height=max(1, y_max - y_min + 1),
+    )

--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -305,13 +305,11 @@ def handle_track_job(
         )
 
         # ─── 3. fetch canonical product crop ───────────────────────
-        # TODO Phase 3c follow-up: add an internal endpoint to fetch
-        # a single ProductCatalogEntry by id (org-scoped). The job
-        # message currently carries only catalog_entry_id; the worker
-        # needs canonical_crop_s3_key + bbox to seed retrieval +
-        # SAM2. Until that endpoint lands, this raises and the
-        # dispatcher reports /fail with internal_error.
-        canonical_crop, canonical_bbox = _fetch_canonical_crop(
+        # Resolves the catalog entry's seed (canonical crop image,
+        # anchor bbox, llm label) via the Phase 3c-B endpoint
+        # ``GET /internal/products/catalog/{catalog_entry_id}`` plus
+        # an S3 download for the crop bytes.
+        canonical_crop, canonical_bbox, llm_label = _fetch_canonical_crop(
             api=api, s3=s3, decoded=decoded, settings=settings,
         )
 
@@ -471,12 +469,13 @@ def handle_track_job(
         )
 
         # ─── 10. annotate alignment ────────────────────────────────
+        # ``llm_label`` is the product's name (e.g. "핑크 세럼 병"),
+        # used by the alignment lib to mark
+        # ``has_narration_mention`` / ``has_ocr_overlap`` per window
+        # via tokenised substring matching.
         annotated = annotate_alignment(
             assembled,
-            # TODO: the catalog entry's llm_label. Plumbed when
-            # ``_fetch_canonical_crop`` returns the full entry rather
-            # than just (image, bbox).
-            label="",
+            label=llm_label,
             transcripts=transcripts,
             ocr=ocr,
         )
@@ -623,20 +622,78 @@ def _fetch_canonical_crop(
     s3: S3Client,
     decoded: TrackJobMessage,
     settings: WorkerSettings,
-) -> tuple["Image.Image", BBoxXYWH]:
-    """TODO Phase 3c follow-up: add ``GET /internal/products/catalog/{catalog_entry_id}``
-    on the api side, returning ``{canonical_crop_s3_key, bbox_xywh,
-    llm_label, ...}``. The worker would download the crop from S3
-    and return it + the bbox here.
+) -> tuple["Image.Image", BBoxXYWH, str]:
+    """Phase 3c-B: resolve the catalog entry's seed metadata
+    (canonical crop image, anchor bbox, llm label) for the track
+    pipeline.
 
-    Until that endpoint lands, this stub raises so the dispatcher
-    fails the job with a clear error rather than silently producing
-    no appearances."""
-    raise NotImplementedError(
-        f"Phase 3c-A scaffold: GET /internal/products/catalog/{decoded.catalog_entry_id} "
-        f"endpoint pending. Worker can't fetch canonical crop without it. "
-        f"Phase 3c-B follow-up adds the endpoint."
+    Steps:
+      1. GET ``/internal/products/catalog/{catalog_entry_id}`` —
+         returns ``canonical_crop_s3_key + bbox + llm_label``.
+      2. Verify the entry's ``org_id`` matches the job's. The api
+         already enforces Pattern B tenant scoping, but a
+         defence-in-depth check is cheap and catches misconfigured
+         multi-tenant setups loudly.
+      3. Download the crop bytes from S3 via the existing client.
+         The crop S3 key was written by product-enumerate-worker at
+         ``products/{org_id}/{video_id}/{uuid}.jpg`` (see
+         ``_upload_crops_and_build_payload``); same bucket as
+         everything else, so the SDK's S3Client just works.
+      4. Decode to a PIL Image. The lib expects RGB so we convert
+         eagerly (SigLIP2 requires 3-channel input — JPEGs are
+         already RGB but normalising here keeps the contract
+         explicit).
+
+    Returns ``(canonical_crop, canonical_bbox, llm_label)``. The
+    caller passes ``llm_label`` to ``annotate_alignment`` so
+    ``has_narration_mention`` / ``has_ocr_overlap`` can match
+    against the product's name in transcripts + OCR.
+
+    Failure modes:
+      * api 404 → ``RuntimeError`` (catalog entry not found / cross
+        tenant). Bubbles to dispatcher → /fail with internal_error.
+        We do NOT special-case to ``video_not_found``: the catalog
+        row predates the track job (enumerated earlier) and missing
+        it indicates row deletion / corruption, not a missing video.
+      * S3 missing the crop bytes → ``FileNotFoundError`` (same
+        bubbling path). Operators see the s3_key in the error
+        message so they can locate the gap in the enum-side upload.
+      * org mismatch → ``RuntimeError`` (would only happen if the
+        api side is misconfigured to omit Pattern B; defence in
+        depth).
+    """
+    payload = api.fetch_catalog_entry(
+        catalog_entry_id=decoded.catalog_entry_id,
+        org_id=decoded.org_id,
     )
+
+    payload_org_id = UUID(str(payload["org_id"]))
+    if payload_org_id != decoded.org_id:
+        raise RuntimeError(
+            f"catalog entry {decoded.catalog_entry_id} org "
+            f"{payload_org_id} != job org {decoded.org_id}"
+        )
+
+    s3_key = str(payload["canonical_crop_s3_key"])
+    body = s3.get_object_bytes(s3_key)
+    if body is None:
+        raise FileNotFoundError(
+            f"canonical crop S3 object missing for catalog_entry_id="
+            f"{decoded.catalog_entry_id} s3_key={s3_key}"
+        )
+
+    from PIL import Image as _PILImage
+    canonical_crop = _PILImage.open(io.BytesIO(body)).convert("RGB")
+
+    bbox_payload = payload["canonical_bbox"]
+    canonical_bbox = BBoxXYWH(
+        x=int(bbox_payload["x"]),
+        y=int(bbox_payload["y"]),
+        width=int(bbox_payload["w"]),
+        height=int(bbox_payload["h"]),
+    )
+
+    return canonical_crop, canonical_bbox, str(payload["llm_label"])
 
 
 def _fetch_transcripts_ocr(

--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -61,6 +61,7 @@ from heimdex_media_pipelines.product_track.siglip2_retrieval import (
     retrieve_candidate_scenes,
 )
 from heimdex_media_pipelines.product_track.stitching import (
+    StitchPlan,
     build_stitch_plan,
 )
 from heimdex_media_pipelines.product_track.subset_selector import (
@@ -531,27 +532,57 @@ def handle_track_job(
             return
 
         # ─── 13. build stitch plan ─────────────────────────────────
-        # The plan is computed for completeness (and so the lib's
-        # build_stitch_plan invariants are exercised) but NOT shipped
-        # to the api — ``_CompleteRequest`` (extra='forbid') has no
-        # ``stitching_plan`` field. Phase 3c-B turns this plan into a
-        # ``CompositionSpec`` and POSTs to ``/api/shorts/render``;
-        # the resulting ``render_job_id`` is the only thing the api
-        # needs to persist on the tracking row.
-        _ = build_stitch_plan(
+        plan = build_stitch_plan(
             selected,
             duration_target_sec=decoded.duration_preset_sec,
             config=cfg,
         )
 
         # ─── 14. enqueue render + complete ─────────────────────────
-        # TODO Phase 3c-B: enqueue the render via the api's
-        # /api/shorts/render endpoint and pass the resulting job id.
-        # For scaffold the render enqueue is a placeholder; the api
-        # callback (/complete) accepts ``render_job_id=None`` so the
-        # worker can mark the job complete with appearances populated
-        # — UI surfaces "tracked, render pending".
-        render_job_id: UUID | None = None
+        # Build a ``CompositionSpec`` from the stitch plan windows
+        # (chronological hard cuts; per-clip ``source_start_ms`` /
+        # ``source_end_ms`` ranges) and POST to the api's internal
+        # render endpoint. The api forwards to
+        # ``ShortsRenderService.create_render_job`` with
+        # ``user_id=job.requested_by_user_id`` derived server-side
+        # (workers don't carry user JWTs). Returns the new
+        # ``RenderJob.id`` which we ship on /complete.
+        composition_spec = _build_composition_spec(
+            plan=plan, os_video_id=os_video_id,
+        )
+        try:
+            render_job_id: UUID | None = api.enqueue_render(
+                scan_job_id=decoded.job_id,
+                claimed_by=settings.worker_id,
+                video_id=os_video_id,
+                title=llm_label or None,
+                composition=composition_spec,
+            )
+        except httpx.HTTPStatusError as exc:
+            # Render enqueue failure is recoverable from the user's
+            # POV: the tracker successfully produced appearances,
+            # the api just couldn't kick off ffmpeg. /fail with the
+            # api enum literal for this exact case (rather than
+            # internal_error) so the user-facing UI can render the
+            # right message + retry affordance.
+            logger.exception(
+                "track_render_enqueue_failed",
+                extra={
+                    "job_id": str(decoded.job_id),
+                    "status_code": exc.response.status_code,
+                },
+            )
+            api.fail(
+                job_id=decoded.job_id,
+                claimed_by=settings.worker_id,
+                cost_delta_usd=cost_accumulator,
+                error_code="render_enqueue_failed",
+                error_message=(
+                    f"render enqueue failed status={exc.response.status_code}: "
+                    f"{str(exc)[:1500]}"
+                ),
+            )
+            return
 
         api.complete_track(
             job_id=decoded.job_id,
@@ -614,6 +645,55 @@ def _build_picker(settings: WorkerSettings) -> SubsetPicker:
         model=settings.openai_model,
         timeout_sec=settings.openai_timeout_sec,
     )
+
+
+def _build_composition_spec(
+    *,
+    plan: "StitchPlan",
+    os_video_id: str,
+) -> dict[str, Any]:
+    """Convert a Phase 3a ``StitchPlan`` to the
+    ``CompositionSpec.model_dump(mode='json')`` shape that
+    ``/api/shorts/render`` accepts.
+
+    Each ``StitchPlan.windows[i]`` (a ``StitchedClip`` with an
+    inner ``window`` carrying ``scene_id`` + ``window_start_ms`` +
+    ``window_end_ms``) becomes one ``SceneClipSpec``. Clips are
+    placed back-to-back chronologically on the composition timeline
+    (hard cuts; no transitions in v1 per plan §6.2 step 8).
+
+    ``video_id`` is the OpenSearch string id (``gd_abc``) — same
+    shape ``RenderJobCreate.video_id`` already accepts. Source type
+    is hard-coded ``gdrive``; future Drive variants (removable
+    disk, local) will need a worker-side switch but that's
+    deferred until Drive picks up multi-source ingestion.
+    """
+    timeline_cursor_ms = 0
+    scene_clips: list[dict[str, Any]] = []
+    for scored in plan.windows:
+        # ``StitchPlan.windows`` is ``list[ScoredWindow]``;
+        # ``ScoredWindow.window`` is the underlying
+        # ``AnnotatedWindow`` with the actual time range.
+        window = scored.window
+        clip_duration_ms = window.window_end_ms - window.window_start_ms
+        scene_clips.append({
+            "scene_id": window.scene_id,
+            "video_id": os_video_id,
+            "source_type": "gdrive",
+            "start_ms": window.window_start_ms,
+            "end_ms": window.window_end_ms,
+            "timeline_start_ms": timeline_cursor_ms,
+            "volume": 1.0,
+        })
+        timeline_cursor_ms += clip_duration_ms
+
+    return {
+        "scene_clips": scene_clips,
+        # Output / subtitles / overlays / transitions intentionally
+        # omitted — server-side ``CompositionSpec`` defaults give
+        # 9:16 vertical 720p mp4 hard-cut, which matches the v1
+        # product mode shorts UX.
+    }
 
 
 def _fetch_canonical_crop(

--- a/services/product-track-worker/src/worker.py
+++ b/services/product-track-worker/src/worker.py
@@ -137,25 +137,14 @@ def main() -> None:
         log.exception("siglip2_warm_failed")
         sys.exit(1)
 
-    # SAM2 is intentionally a NotImplementedError stub during Phase
-    # 3c-A scaffold (real integration ships in Phase 3c-B alongside
-    # staging-goldens calibration). Tolerate that specific case so
-    # the worker can boot, poll SQS, and surface "SAM2 not
-    # implemented" per-job via the dispatcher's /fail callback —
-    # which is the operator-facing signal we want during scaffold.
-    # Any other exception is a real boot fault and still hard-exits.
+    # SAM2 is real as of Phase 3c-B. Any failure during warmup
+    # (missing weights, CUDA OOM, transformers API drift, model
+    # download timeout) is a hard boot failure — operators see
+    # ``sam2_warm_failed`` immediately rather than discovering it
+    # per-job. The Phase 3c-A NotImplementedError tolerance is
+    # gone now that the loader actually loads.
     try:
         _warm_sam2(settings)
-    except NotImplementedError:
-        log.warning(
-            "sam2_warm_skipped_phase_3c_a_stub",
-            note=(
-                "Phase 3c-A scaffold: SAM2 loader stub raises "
-                "NotImplementedError. Boot continues; per-job /fail "
-                "with internal_error is the expected signal until "
-                "Phase 3c-B lands the real integration."
-            ),
-        )
     except Exception:
         log.exception("sam2_warm_failed")
         sys.exit(1)

--- a/services/product-track-worker/tests/test_api_client.py
+++ b/services/product-track-worker/tests/test_api_client.py
@@ -230,3 +230,33 @@ def test_fetch_scenes_content_extracts_scenes_from_response():
     )
     assert len(out) == 1
     assert out[0]["transcript_raw"] == "hello"
+
+
+# ---------- fetch_catalog_entry (Phase 3c-B) ----------
+
+
+def test_fetch_catalog_entry_gets_correct_url_and_org_header():
+    api, http = _build_client()
+    catalog_entry_id = uuid4()
+    org_id = uuid4()
+    http.get.return_value = _ok_response({
+        "catalog_entry_id": str(catalog_entry_id),
+        "org_id": str(org_id),
+        "video_id": str(uuid4()),
+        "canonical_crop_s3_key": "products/X/Y/abc.jpg",
+        "canonical_bbox": {"x": 10, "y": 20, "w": 100, "h": 150},
+        "llm_label": "핑크 세럼 병",
+    })
+
+    out = api.fetch_catalog_entry(
+        catalog_entry_id=catalog_entry_id, org_id=org_id,
+    )
+    args, kwargs = http.get.call_args
+    assert args[0] == (
+        f"https://api.test/internal/products/catalog/{catalog_entry_id}"
+    )
+    assert kwargs["headers"]["X-Heimdex-Org-Id"] == str(org_id)
+    # Pin the response shape since the worker depends on every key.
+    assert out["canonical_crop_s3_key"] == "products/X/Y/abc.jpg"
+    assert out["canonical_bbox"] == {"x": 10, "y": 20, "w": 100, "h": 150}
+    assert out["llm_label"] == "핑크 세럼 병"

--- a/services/product-track-worker/tests/test_canonical_crop.py
+++ b/services/product-track-worker/tests/test_canonical_crop.py
@@ -1,0 +1,198 @@
+"""Phase 3c-B tests for ``_fetch_canonical_crop``.
+
+Replaces the Phase 3c-A NotImplementedError stub. Uses the new
+``ApiClient.fetch_catalog_entry`` Pattern B endpoint to resolve
+seed metadata, then S3-downloads the canonical crop bytes.
+
+Tests pin:
+  * Happy-path 3-tuple return (Image, BBoxXYWH, llm_label).
+  * 404 from the api propagates to caller (catalog row missing).
+  * Cross-tenant defence-in-depth: api response mismatch raises.
+  * S3 ``None`` return raises FileNotFoundError with the s3_key.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from PIL import Image
+
+from heimdex_media_pipelines.product_track.sam2_pass import BBoxXYWH
+
+from src.settings import WorkerSettings
+from src.tasks.track import _fetch_canonical_crop, TrackJobMessage
+
+
+def _settings() -> WorkerSettings:
+    return WorkerSettings(
+        product_v2_enabled=True,
+        sqs_product_track_queue_url="https://sqs/q",
+        drive_internal_api_key="t",
+        drive_api_base_url="http://api:8000",
+        drive_s3_bucket="test-bucket",
+        worker_id="test-worker",
+    )
+
+
+def _decoded(*, org_id: UUID | None = None) -> TrackJobMessage:
+    return TrackJobMessage(
+        job_id=uuid4(),
+        org_id=org_id or uuid4(),
+        video_id=uuid4(),
+        catalog_entry_id=uuid4(),
+        requested_by_user_id=uuid4(),
+        duration_preset_sec=60,
+        tracker_version="v1.0",
+        enumeration_prompt_version="v1.0",
+        callback_base_url="",
+    )
+
+
+def _jpeg_bytes(*, w: int = 64, h: int = 64) -> bytes:
+    img = Image.new("RGB", (w, h), (200, 100, 50))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=80)
+    return buf.getvalue()
+
+
+def _payload(
+    *,
+    org_id: UUID,
+    s3_key: str = "products/X/Y/abc.jpg",
+    bbox: dict | None = None,
+    label: str = "테스트 제품",
+) -> dict:
+    return {
+        "catalog_entry_id": str(uuid4()),
+        "org_id": str(org_id),
+        "video_id": str(uuid4()),
+        "canonical_crop_s3_key": s3_key,
+        "canonical_bbox": bbox or {"x": 10, "y": 20, "w": 100, "h": 150},
+        "llm_label": label,
+    }
+
+
+# ---------- happy path ----------
+
+
+def test_returns_image_bbox_label_tuple():
+    org_id = uuid4()
+    decoded = _decoded(org_id=org_id)
+    api = MagicMock()
+    api.fetch_catalog_entry.return_value = _payload(org_id=org_id, label="핑크 세럼 병")
+    s3 = MagicMock()
+    s3.get_object_bytes.return_value = _jpeg_bytes()
+
+    crop, bbox, label = _fetch_canonical_crop(
+        api=api, s3=s3, decoded=decoded, settings=_settings(),
+    )
+    assert isinstance(crop, Image.Image)
+    assert crop.mode == "RGB"
+    assert bbox == BBoxXYWH(x=10, y=20, width=100, height=150)
+    assert label == "핑크 세럼 병"
+    # Worker passes (entry_id, org_id) — not (video_id) — so the
+    # api can do Pattern B by entry directly.
+    api.fetch_catalog_entry.assert_called_once_with(
+        catalog_entry_id=decoded.catalog_entry_id,
+        org_id=decoded.org_id,
+    )
+    s3.get_object_bytes.assert_called_once_with("products/X/Y/abc.jpg")
+
+
+def test_passes_through_404_from_api():
+    """A 404 from the catalog endpoint = entry missing or cross
+    tenant. Worker bubbles to the dispatcher which routes to /fail
+    with internal_error. We don't special-case to ``video_not_found``
+    because the catalog row is downstream of the video, and absent
+    catalog rows usually indicate row deletion or a corrupted enum
+    pass — not a missing source video."""
+    org_id = uuid4()
+    decoded = _decoded(org_id=org_id)
+    request = httpx.Request(
+        "GET",
+        f"http://api/internal/products/catalog/{decoded.catalog_entry_id}",
+    )
+    api = MagicMock()
+    api.fetch_catalog_entry.side_effect = httpx.HTTPStatusError(
+        "404 Not Found",
+        request=request,
+        response=httpx.Response(404, request=request),
+    )
+    s3 = MagicMock()
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        _fetch_canonical_crop(
+            api=api, s3=s3, decoded=decoded, settings=_settings(),
+        )
+    assert exc.value.response.status_code == 404
+    s3.get_object_bytes.assert_not_called()
+
+
+def test_raises_when_response_org_does_not_match_job_org():
+    """Defence-in-depth: api Pattern B should already 404 on cross
+    tenant, but if the api side is misconfigured (e.g. Pattern B
+    helper bypassed) and returns a different-org row, the worker
+    refuses rather than seeding the pipeline with the wrong
+    product."""
+    job_org = uuid4()
+    other_org = uuid4()
+    decoded = _decoded(org_id=job_org)
+    api = MagicMock()
+    api.fetch_catalog_entry.return_value = _payload(org_id=other_org)
+    s3 = MagicMock()
+
+    with pytest.raises(RuntimeError, match="org"):
+        _fetch_canonical_crop(
+            api=api, s3=s3, decoded=decoded, settings=_settings(),
+        )
+    s3.get_object_bytes.assert_not_called()
+
+
+def test_raises_file_not_found_when_s3_returns_none():
+    """SDK's ``S3Client.get_object_bytes`` returns ``None`` on
+    NoSuchKey or transient failures (it logs internally but
+    returns None either way). Worker MUST surface this — silently
+    decoding ``None`` would TypeError, but raising explicitly puts
+    the s3_key in the error message so operators can locate the
+    gap in product-enumerate-worker's upload."""
+    org_id = uuid4()
+    decoded = _decoded(org_id=org_id)
+    api = MagicMock()
+    api.fetch_catalog_entry.return_value = _payload(
+        org_id=org_id, s3_key="products/missing/key.jpg",
+    )
+    s3 = MagicMock()
+    s3.get_object_bytes.return_value = None
+
+    with pytest.raises(FileNotFoundError) as exc:
+        _fetch_canonical_crop(
+            api=api, s3=s3, decoded=decoded, settings=_settings(),
+        )
+    assert "products/missing/key.jpg" in str(exc.value)
+    assert str(decoded.catalog_entry_id) in str(exc.value)
+
+
+def test_decodes_non_rgb_jpeg_to_rgb():
+    """SigLIP2 requires 3-channel input; force RGB conversion at
+    the worker boundary so a grayscale or RGBA upload doesn't
+    produce silently-wrong embeddings downstream."""
+    org_id = uuid4()
+    decoded = _decoded(org_id=org_id)
+    # Encode a grayscale JPEG (mode 'L') — JPEG codec writes it as
+    # YCbCr but PIL re-opens as 'L'. Worker must convert to RGB.
+    gray_img = Image.new("L", (32, 32), 128)
+    buf = io.BytesIO()
+    gray_img.save(buf, format="JPEG", quality=80)
+    api = MagicMock()
+    api.fetch_catalog_entry.return_value = _payload(org_id=org_id)
+    s3 = MagicMock()
+    s3.get_object_bytes.return_value = buf.getvalue()
+
+    crop, _bbox, _label = _fetch_canonical_crop(
+        api=api, s3=s3, decoded=decoded, settings=_settings(),
+    )
+    assert crop.mode == "RGB"

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -1,0 +1,349 @@
+"""Phase 3c-B Item 5 — end-to-end orchestration tests.
+
+The Item 1-4 tests cover individual layers (catalog endpoint,
+canonical-crop fetch, render enqueue, SAM2 wrapper). This file
+locks in cross-cutting invariants of the full pipeline:
+
+  * ``cost_accumulator`` reaches /complete with the LLM picker's
+    spend rolled in (D52 fix verification).
+  * Appearance rows ship ``tracker_version`` from
+    ``WorkerSettings.tracker_version`` (NOT from the queue
+    message) — verifies the D-stale-message fix.
+  * Appearance row shape matches the api's strict
+    ``_AppearancePayload`` schema (no extra keys, all required
+    fields present).
+  * Heartbeats fire at the documented progress checkpoints.
+
+All tests inject Protocol mocks past the canonical-crop fetch
+(stubbed via ``_fetch_canonical_crop`` patch) and the SAM2
+tracker so the full ``handle_track_job`` orchestration runs
+without real ML or network.
+"""
+
+from __future__ import annotations
+
+import io
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from PIL import Image
+
+from heimdex_media_pipelines.product_track.sam2_pass import (
+    BBoxXYWH,
+    TrackedSample,
+)
+
+from src.settings import WorkerSettings
+from src.tasks.track import handle_track_job
+
+
+def _settings(*, tracker_version: str = "v1.0") -> WorkerSettings:
+    return WorkerSettings(
+        product_v2_enabled=True,
+        sqs_product_track_queue_url="https://sqs/q",
+        drive_internal_api_key="t",
+        drive_api_base_url="http://api:8000",
+        drive_s3_bucket="test-bucket",
+        worker_id="test-worker",
+        tracker_version=tracker_version,
+    )
+
+
+def _job_body() -> dict:
+    return {
+        "type": "product.track_job",
+        "job_id": str(uuid4()),
+        "org_id": str(uuid4()),
+        "video_id": str(uuid4()),
+        "catalog_entry_id": str(uuid4()),
+        "requested_by_user_id": str(uuid4()),
+        "duration_preset_sec": 60,
+        # Note the deliberately STALE tracker_version on the
+        # message — the worker MUST stamp settings.tracker_version
+        # on appearances, not this.
+        "tracker_version": "v0.9-stale",
+        "enumeration_prompt_version": "v1.0",
+    }
+
+
+def _scenes_response(n: int = 3) -> dict:
+    return {
+        "video_id": "gd_test",
+        "scenes": [
+            {"scene_id": f"gd_test_scene_{i:03d}", "keyframe_s3_key": f"k{i}.jpg"}
+            for i in range(n)
+        ],
+    }
+
+
+def _fake_canonical():
+    img = Image.new("RGB", (256, 256), (200, 100, 50))
+    bbox = BBoxXYWH(x=10, y=10, width=50, height=50)
+    return img, bbox, "테스트 제품"
+
+
+def _good_track_factory():
+    """Returns a tracker side_effect that produces dense
+    high-confidence samples — feeds through window-assembly's
+    threshold filter to produce accepted windows."""
+
+    def _track(*, scene_id, **_kwargs):
+        return [
+            TrackedSample(
+                frame_timestamp_ms=ts,
+                bbox=BBoxXYWH(x=10, y=10, width=200, height=200),
+                mask_confidence=0.9,
+                frame_width=1280,
+                frame_height=720,
+            )
+            for ts in range(0, 4000, 200)  # 2s @ 5fps
+        ]
+
+    return _track
+
+
+def _make_apis(*, render_job_id):
+    api = MagicMock()
+    api.fetch_scenes_with_keyframes.return_value = _scenes_response(n=3)
+    api.find_similar_scenes.return_value = [
+        {"scene_id": f"gd_test_scene_{i:03d}", "similarity": 0.9}
+        for i in range(3)
+    ]
+    api.fetch_scenes_content.return_value = []
+    api.enqueue_render.return_value = render_job_id
+    return api
+
+
+def _make_pipeline_mocks(*, picker_cost: Decimal = Decimal("0")):
+    """Standard happy-path Protocol mocks for the full pipeline."""
+    canonical_vec = [1.0] + [0.0] * 767
+    embedder = MagicMock()
+    embedder.embed.return_value = canonical_vec
+
+    good_buf = io.BytesIO()
+    Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
+    s3 = MagicMock()
+    s3.get_object_bytes.return_value = good_buf.getvalue()
+
+    tracker = MagicMock()
+    tracker.track.side_effect = _good_track_factory()
+
+    # GreedyPicker is the default when OPENAI_API_KEY is empty —
+    # but we want to pin LLM-picker cost flow. Pass a fake picker
+    # that exposes ``total_cost_usd``.
+    picker = MagicMock()
+    picker.total_cost_usd = picker_cost
+
+    def _greedy_pick(scored, **_kwargs):
+        return scored  # take everything; the lib's trim handles size
+
+    picker.pick.side_effect = _greedy_pick
+    return embedder, s3, tracker, picker
+
+
+# =====================================================================
+# tracker_version propagation
+# =====================================================================
+
+
+def test_appearance_rows_use_settings_tracker_version_not_message():
+    """D52-symmetric fix verification: even when the queue message
+    carries a stale ``tracker_version``, the appearance rows
+    written to /complete MUST be stamped with the version that
+    actually executed (``settings.tracker_version``). Otherwise
+    ``ProductAppearanceRepository.purge_for_catalog_and_tracker()``
+    would fail to clean up rows after a worker upgrade."""
+    api = _make_apis(render_job_id=uuid4())
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+    settings = _settings(tracker_version="v1.5-current")
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=_job_body(),  # body has tracker_version="v0.9-stale"
+            settings=settings,
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    api.complete_track.assert_called_once()
+    appearances = api.complete_track.call_args.kwargs["appearances"]
+    assert len(appearances) > 0
+    # Every appearance carries the SETTINGS version, not the body's
+    # stale value.
+    assert all(a["tracker_version"] == "v1.5-current" for a in appearances)
+    assert not any(a["tracker_version"] == "v0.9-stale" for a in appearances)
+
+
+# =====================================================================
+# cost accumulation
+# =====================================================================
+
+
+def test_picker_cost_rolls_into_complete_track_cost_delta():
+    """LLM picker's accumulated USD spend must reach the api's
+    /complete callback so the per-org daily-budget gate
+    (``AUTO_SHORTS_PRODUCT_V2_DAILY_BUDGET_USD``) accounts
+    correctly. Pre-D52 fix this was always 0; pin the new
+    behavior."""
+    api = _make_apis(render_job_id=uuid4())
+    embedder, s3, tracker, picker = _make_pipeline_mocks(
+        picker_cost=Decimal("0.0123"),
+    )
+    settings = _settings()
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=_job_body(),
+            settings=settings,
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    api.complete_track.assert_called_once()
+    cost = api.complete_track.call_args.kwargs["cost_delta_usd"]
+    # The picker's cost MUST be reflected in the final /complete
+    # cost_delta_usd. Other stages may add more, so we use >=.
+    assert cost >= Decimal("0.0123")
+
+
+# =====================================================================
+# appearance shape strictness
+# =====================================================================
+
+
+def test_appearance_payload_has_only_api_accepted_keys():
+    """Drift between worker payload and api ``_AppearancePayload``
+    (extra='forbid') = 422 on every successful tracking
+    completion. Pin the exact key set so accidental over-projection
+    is caught at unit-test time, not at the api boundary."""
+    api = _make_apis(render_job_id=uuid4())
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=_job_body(),
+            settings=_settings(),
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    appearances = api.complete_track.call_args.kwargs["appearances"]
+    assert len(appearances) > 0
+    # Every appearance row must carry exactly these keys — match
+    # the api's _AppearancePayload (services/api/app/modules/
+    # shorts_auto_product/internal_router.py:_AppearancePayload).
+    expected_keys = {
+        "scene_id",
+        "window_start_ms",
+        "window_end_ms",
+        "avg_bbox_area_pct",
+        "avg_confidence",
+        "has_narration_mention",
+        "has_ocr_overlap",
+        "co_appearing_catalog_entry_ids",
+        "raw_bbox_track_s3_key",
+        "tracker_version",
+        "rejected_reason",
+    }
+    for a in appearances:
+        assert set(a.keys()) == expected_keys, (
+            f"appearance shape drift: {set(a.keys()) ^ expected_keys}"
+        )
+
+
+# =====================================================================
+# heartbeats at documented checkpoints
+# =====================================================================
+
+
+def test_heartbeats_fire_at_progress_checkpoints():
+    """Plan §6.2 documents heartbeats at progress 10 / 20 / 40 /
+    80. Pin the contract so a refactor that drops a heartbeat is
+    caught — long-running track jobs (1800s lease) lose their
+    lease without periodic heartbeats."""
+    api = _make_apis(render_job_id=uuid4())
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=_job_body(),
+            settings=_settings(),
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    progress_pcts = [
+        call.kwargs["progress_pct"]
+        for call in api.heartbeat.call_args_list
+    ]
+    # Documented checkpoints: 10 (resolving), 20 (retrieval),
+    # 40 (SAM2), 80 (scoring/picking).
+    assert 10 in progress_pcts
+    assert 20 in progress_pcts
+    assert 40 in progress_pcts
+    assert 80 in progress_pcts
+
+
+# =====================================================================
+# render enqueue uses settings video bucket-derived os_video_id
+# =====================================================================
+
+
+def test_render_enqueue_passes_os_video_id_not_drivefile_uuid():
+    """The two id-spaces (DriveFile UUID vs OS string id) must
+    stay distinct end-to-end. Pin that the render enqueue uses
+    the OS string from ``scenes-with-keyframes``, not the body's
+    DriveFile UUID. Mistaking these would 404 the render
+    pipeline's S3 lookups."""
+    api = _make_apis(render_job_id=uuid4())
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+    body = _job_body()
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=body,
+            settings=_settings(),
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    api.enqueue_render.assert_called_once()
+    enqueue_kwargs = api.enqueue_render.call_args.kwargs
+    # ``video_id`` MUST be the OS string from scenes-with-keyframes
+    # ("gd_test"), NOT the DriveFile UUID from the message body.
+    assert enqueue_kwargs["video_id"] == "gd_test"
+    assert enqueue_kwargs["video_id"] != body["video_id"]
+    # Composition's per-clip video_id must also be the OS string.
+    composition = enqueue_kwargs["composition"]
+    assert all(c["video_id"] == "gd_test" for c in composition["scene_clips"])

--- a/services/product-track-worker/tests/test_render_enqueue.py
+++ b/services/product-track-worker/tests/test_render_enqueue.py
@@ -1,0 +1,328 @@
+"""Phase 3c-B Item 3 tests — render enqueue.
+
+Three layers:
+  1. ``_build_composition_spec`` — pure transformation from
+     ``StitchPlan`` to a JSON-serialisable dict the api will
+     re-validate as ``CompositionSpec``.
+  2. ``ApiClient.enqueue_render`` — wire shape going OUT to the api.
+  3. ``handle_track_job`` happy path + render-enqueue failure path.
+"""
+
+from __future__ import annotations
+
+import io
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+from PIL import Image
+
+from heimdex_media_pipelines.product_track.alignment import AnnotatedWindow
+from heimdex_media_pipelines.product_track.sam2_pass import (
+    BBoxXYWH,
+    TrackedSample,
+)
+from heimdex_media_pipelines.product_track.stitching import StitchPlan
+from heimdex_media_pipelines.product_track.subset_selector import ScoredWindow
+
+from src.settings import WorkerSettings
+from src.tasks.track import _build_composition_spec, handle_track_job
+
+
+def _settings() -> WorkerSettings:
+    return WorkerSettings(
+        product_v2_enabled=True,
+        sqs_product_track_queue_url="https://sqs/q",
+        drive_internal_api_key="t",
+        drive_api_base_url="http://api:8000",
+        drive_s3_bucket="test-bucket",
+        worker_id="test-worker",
+    )
+
+
+def _job_body() -> dict:
+    return {
+        "type": "product.track_job",
+        "job_id": str(uuid4()),
+        "org_id": str(uuid4()),
+        "video_id": str(uuid4()),
+        "catalog_entry_id": str(uuid4()),
+        "requested_by_user_id": str(uuid4()),
+        "duration_preset_sec": 60,
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+
+
+def _fake_canonical():
+    img = Image.new("RGB", (256, 256), (200, 100, 50))
+    bbox = BBoxXYWH(x=10, y=10, width=50, height=50)
+    return img, bbox, "테스트 제품"
+
+
+def _scenes_response(n: int = 3) -> dict:
+    return {
+        "video_id": "gd_test",
+        "scenes": [
+            {"scene_id": f"gd_test_scene_{i:03d}", "keyframe_s3_key": f"k{i}.jpg"}
+            for i in range(n)
+        ],
+    }
+
+
+def _make_annotated(*, scene_id: str, start_ms: int, end_ms: int) -> AnnotatedWindow:
+    return AnnotatedWindow(
+        scene_id=scene_id,
+        window_start_ms=start_ms,
+        window_end_ms=end_ms,
+        avg_bbox_area_pct=0.1,
+        avg_confidence=0.85,
+        peak_confidence=0.9,
+        frame_count=20,
+        rejected_reason=None,
+        has_narration_mention=False,
+        has_ocr_overlap=False,
+    )
+
+
+def _make_scored(window: AnnotatedWindow, score: float = 0.8) -> ScoredWindow:
+    return ScoredWindow(
+        window=window,
+        composite_score=score,
+        score_components={
+            "prominence": 0.3, "narration": 0.0, "ocr": 0.0,
+            "duration_fitness": 0.5, "spread_bonus": 0.0,
+        },
+    )
+
+
+# =====================================================================
+# _build_composition_spec
+# =====================================================================
+
+
+class TestBuildCompositionSpec:
+    def test_chronological_hard_cut_back_to_back(self):
+        """Each ScoredWindow's source range is preserved verbatim;
+        timeline_start_ms is the running cumulative sum so clips
+        play back-to-back with no gaps + no transitions."""
+        windows = [
+            _make_scored(
+                _make_annotated(scene_id="s1", start_ms=1000, end_ms=4000),
+                score=0.9,
+            ),
+            _make_scored(
+                _make_annotated(scene_id="s2", start_ms=10000, end_ms=15000),
+                score=0.7,
+            ),
+        ]
+        plan = StitchPlan(
+            windows=windows,
+            duration_target_sec=30,
+            duration_actual_ms=8000,
+            scorer_version="v1.0",
+            subset_picker_version="v1.0",
+        )
+
+        spec = _build_composition_spec(plan=plan, os_video_id="gd_abc")
+
+        clips = spec["scene_clips"]
+        assert len(clips) == 2
+        # Clip 1 — source [1000,4000), placed at 0 on the timeline.
+        assert clips[0]["scene_id"] == "s1"
+        assert clips[0]["video_id"] == "gd_abc"
+        assert clips[0]["source_type"] == "gdrive"
+        assert clips[0]["start_ms"] == 1000
+        assert clips[0]["end_ms"] == 4000
+        assert clips[0]["timeline_start_ms"] == 0
+        # Clip 2 — source [10000,15000), placed after clip 1's
+        # 3000ms duration.
+        assert clips[1]["start_ms"] == 10000
+        assert clips[1]["end_ms"] == 15000
+        assert clips[1]["timeline_start_ms"] == 3000
+        # Defaults left to api server-side; spec stays minimal.
+        assert "output" not in spec
+        assert "subtitles" not in spec
+        assert "transitions" not in spec
+
+    def test_validates_against_composition_spec_schema(self):
+        """The dict shape MUST satisfy the contracts'
+        ``CompositionSpec`` validator — drift here would 422 at the
+        api boundary."""
+        from heimdex_media_contracts.composition import CompositionSpec
+
+        windows = [
+            _make_scored(
+                _make_annotated(scene_id="s1", start_ms=0, end_ms=5000),
+                score=0.9,
+            ),
+        ]
+        plan = StitchPlan(
+            windows=windows,
+            duration_target_sec=30,
+            duration_actual_ms=5000,
+            scorer_version="v1.0",
+            subset_picker_version="v1.0",
+        )
+        spec = _build_composition_spec(plan=plan, os_video_id="gd_xyz")
+        # Should not raise.
+        validated = CompositionSpec.model_validate(spec)
+        assert len(validated.scene_clips) == 1
+
+
+# =====================================================================
+# ApiClient.enqueue_render
+# =====================================================================
+
+
+class TestApiClientEnqueueRender:
+    def test_posts_correct_url_and_body_shape(self):
+        from src.api_client import ApiClient
+        api = ApiClient(base_url="https://api.test", internal_api_key="t")
+        fake_http = MagicMock()
+        api._client = fake_http  # noqa: SLF001
+        scan_job_id = uuid4()
+        render_job_id = uuid4()
+        ok = MagicMock()
+        ok.json.return_value = {"render_job_id": str(render_job_id)}
+        ok.raise_for_status = MagicMock()
+        fake_http.post.return_value = ok
+
+        out = api.enqueue_render(
+            scan_job_id=scan_job_id,
+            claimed_by="worker-x",
+            video_id="gd_abc",
+            title="제품 X",
+            composition={"scene_clips": []},
+        )
+        assert out == render_job_id
+        args, kwargs = fake_http.post.call_args
+        assert args[0] == (
+            f"https://api.test/internal/products/{scan_job_id}/render"
+        )
+        assert kwargs["json"] == {
+            "claimed_by": "worker-x",
+            "payload": {
+                "video_id": "gd_abc",
+                "title": "제품 X",
+                "composition": {"scene_clips": []},
+            },
+        }
+
+
+# =====================================================================
+# handle_track_job — happy path through render enqueue
+# =====================================================================
+
+
+class TestHandleTrackJobRenderEnqueue:
+    def _make_api(self, *, render_job_id):
+        api = MagicMock()
+        api.fetch_scenes_with_keyframes.return_value = _scenes_response(n=3)
+        api.find_similar_scenes.return_value = [
+            {"scene_id": f"gd_test_scene_{i:03d}", "similarity": 0.9}
+            for i in range(3)
+        ]
+        api.fetch_scenes_content.return_value = []
+        api.enqueue_render.return_value = render_job_id
+        return api
+
+    def _make_full_pipeline_mocks(self):
+        canonical_vec = [1.0] + [0.0] * 767
+        embedder = MagicMock()
+        embedder.embed.return_value = canonical_vec
+        good_buf = io.BytesIO()
+        Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
+        s3 = MagicMock()
+        s3.get_object_bytes.return_value = good_buf.getvalue()
+        # SAM2 returns a dense, high-confidence sample stream so
+        # window-assembly produces an accepted window.
+        tracker = MagicMock()
+        def _good_track(*, scene_id, **_kwargs):
+            return [
+                TrackedSample(
+                    frame_timestamp_ms=ts,
+                    bbox=BBoxXYWH(x=10, y=10, width=200, height=200),
+                    mask_confidence=0.9,
+                    frame_width=1280,
+                    frame_height=720,
+                )
+                for ts in range(0, 4000, 200)  # 2s span @ 5fps
+            ]
+        tracker.track.side_effect = _good_track
+        # GreedyPicker behaves deterministically without an OpenAI
+        # client — use an empty key in settings so
+        # ``_build_picker`` falls back to it.
+        return embedder, s3, tracker
+
+    def test_happy_path_calls_enqueue_render_and_complete_with_id(self):
+        render_job_id = uuid4()
+        api = self._make_api(render_job_id=render_job_id)
+        embedder, s3, tracker = self._make_full_pipeline_mocks()
+
+        with patch(
+            "src.tasks.track._fetch_canonical_crop",
+            return_value=_fake_canonical(),
+        ):
+            handle_track_job(
+                message=_job_body(),
+                settings=_settings(),
+                api_client=api,
+                embedder=embedder,
+                tracker=tracker,
+                s3_client=s3,
+            )
+
+        # Render was enqueued with the video_id from scenes-with-keyframes.
+        api.enqueue_render.assert_called_once()
+        kwargs = api.enqueue_render.call_args.kwargs
+        assert kwargs["video_id"] == "gd_test"
+        assert kwargs["claimed_by"] == "test-worker"
+        # Title defaults to the llm_label.
+        assert kwargs["title"] == "테스트 제품"
+        # Composition shape: at least one clip, video_id propagated.
+        assert isinstance(kwargs["composition"], dict)
+        assert len(kwargs["composition"]["scene_clips"]) >= 1
+        assert kwargs["composition"]["scene_clips"][0]["video_id"] == "gd_test"
+
+        # /complete called with the api-returned render_job_id.
+        api.complete_track.assert_called_once()
+        complete_kwargs = api.complete_track.call_args.kwargs
+        assert complete_kwargs["render_job_id"] == render_job_id
+
+    def test_render_enqueue_failure_routes_to_fail_render_enqueue_failed(self):
+        """If the api refuses the render (5xx, validation error,
+        rate-limit, budget cap), worker MUST /fail with the api's
+        dedicated ``render_enqueue_failed`` enum literal — NOT
+        internal_error. The user-facing UI distinguishes "the
+        tracker worked but the render didn't kick off" from
+        generic worker bugs."""
+        api = self._make_api(render_job_id=uuid4())
+        request = httpx.Request("POST", "http://api/internal/products/x/render")
+        api.enqueue_render.side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=request,
+            response=httpx.Response(503, request=request),
+        )
+        embedder, s3, tracker = self._make_full_pipeline_mocks()
+
+        with patch(
+            "src.tasks.track._fetch_canonical_crop",
+            return_value=_fake_canonical(),
+        ):
+            handle_track_job(
+                message=_job_body(),
+                settings=_settings(),
+                api_client=api,
+                embedder=embedder,
+                tracker=tracker,
+                s3_client=s3,
+            )
+
+        api.complete_track.assert_not_called()
+        api.fail.assert_called_once()
+        fail_kwargs = api.fail.call_args.kwargs
+        assert fail_kwargs["error_code"] == "render_enqueue_failed"
+        assert "503" in fail_kwargs["error_message"]

--- a/services/product-track-worker/tests/test_sam2.py
+++ b/services/product-track-worker/tests/test_sam2.py
@@ -1,0 +1,289 @@
+"""Phase 3c-B Item 4 — SAM2 loader + tracker tests.
+
+The HF transformers ``Sam2VideoModel`` API is volatile across
+versions and requires real GPU weights to validate inference. We
+test the structural surface here:
+
+  * ``load_sam2`` singleton semantics + ``set_singleton_for_testing``
+    injection.
+  * ``Sam2TrackerImpl.track`` flow against a fake video predictor +
+    a mocked ``cv2.VideoCapture``: anchor bounds check, frame
+    sampling at ``sample_fps``, mask → bbox conversion, monotonic
+    output ordering, runtime errors on bad inputs.
+  * ``_mask_to_bbox`` helper: pure function, broad coverage.
+
+Real-GPU validation deferred to Phase 3d staging soak.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from heimdex_media_pipelines.product_track.sam2_pass import BBoxXYWH
+
+from src.sam2_loader import (
+    LoadedSam2,
+    load_sam2,
+    reset_singleton,
+    set_singleton_for_testing,
+)
+from src.sam2_tracker import Sam2TrackerImpl, _mask_to_bbox
+
+
+@pytest.fixture(autouse=True)
+def _reset_sam2_singleton():
+    """Each test starts with no cached singleton so tests don't
+    leak into each other (the loader caches forever otherwise)."""
+    reset_singleton()
+    yield
+    reset_singleton()
+
+
+def _fake_loaded(model: Any, processor: Any | None = None) -> LoadedSam2:
+    return LoadedSam2(
+        model=model,
+        processor=processor or MagicMock(),
+        device="cpu",
+        dtype="float32",
+        model_id="facebook/sam2-hiera-base-plus",
+    )
+
+
+# =====================================================================
+# load_sam2 — singleton + injection point
+# =====================================================================
+
+
+class TestLoadSam2:
+    def test_set_singleton_for_testing_returns_injected_value(self):
+        """``set_singleton_for_testing`` short-circuits the real
+        load path so tests don't pay the transformers + CUDA cost.
+        Pinned because every Sam2TrackerImpl test depends on this
+        injection working — drift here would explode every track
+        test on a fresh runner without GPU."""
+        fake_model = MagicMock()
+        injected = _fake_loaded(fake_model)
+        set_singleton_for_testing(injected)
+        out = load_sam2()
+        assert out is injected
+        assert out.model is fake_model
+
+    def test_load_sam2_caches_singleton_across_calls(self):
+        """Once loaded, subsequent calls return the SAME instance —
+        no re-load. (We verify via the injection point because a
+        real load needs GPU.)"""
+        injected = _fake_loaded(MagicMock())
+        set_singleton_for_testing(injected)
+        a = load_sam2()
+        b = load_sam2(model_id="some-other-id")  # arg ignored once loaded
+        assert a is b
+
+
+# =====================================================================
+# _mask_to_bbox — pure function
+# =====================================================================
+
+
+class TestMaskToBbox:
+    def test_returns_tight_bbox_for_filled_region(self):
+        # 10x10 mask with a 4x6 rectangle of foreground.
+        mask = np.zeros((10, 10), dtype=bool)
+        mask[2:8, 3:7] = True
+        bbox = _mask_to_bbox(mask)
+        assert bbox == BBoxXYWH(x=3, y=2, width=4, height=6)
+
+    def test_returns_none_for_empty_mask(self):
+        assert _mask_to_bbox(np.zeros((10, 10), dtype=bool)) is None
+
+    def test_handles_uint8_mask(self):
+        mask = np.zeros((5, 5), dtype=np.uint8)
+        mask[1, 1] = 255
+        bbox = _mask_to_bbox(mask)
+        assert bbox == BBoxXYWH(x=1, y=1, width=1, height=1)
+
+
+# =====================================================================
+# Sam2TrackerImpl.track
+# =====================================================================
+
+
+class _FakeVideoCapture:
+    """Mimics cv2.VideoCapture for tests — returns a programmable
+    sequence of (ok, frame) pairs and reports configurable
+    metadata."""
+
+    def __init__(self, *, frames: list[np.ndarray], fps: float = 30.0):
+        self._frames = frames
+        self._idx = 0
+        self._fps = fps
+        self._w = frames[0].shape[1] if frames else 0
+        self._h = frames[0].shape[0] if frames else 0
+        self._opened = bool(frames)
+
+    def isOpened(self) -> bool:
+        return self._opened
+
+    def get(self, prop: int) -> float:
+        # Mirror the cv2 prop ids the tracker queries.
+        import cv2
+        if prop == cv2.CAP_PROP_FRAME_WIDTH:
+            return float(self._w)
+        if prop == cv2.CAP_PROP_FRAME_HEIGHT:
+            return float(self._h)
+        if prop == cv2.CAP_PROP_FPS:
+            return self._fps
+        if prop == cv2.CAP_PROP_FRAME_COUNT:
+            return float(len(self._frames))
+        return 0.0
+
+    def read(self) -> tuple[bool, np.ndarray | None]:
+        if self._idx >= len(self._frames):
+            return False, None
+        frame = self._frames[self._idx]
+        self._idx += 1
+        return True, frame
+
+    def release(self) -> None:
+        self._opened = False
+
+
+def _green_frame(*, w: int = 320, h: int = 240) -> np.ndarray:
+    """An RGB frame the tracker will pass through cv2.cvtColor; we
+    use BGR ordering since cv2.VideoCapture would output BGR."""
+    bgr = np.zeros((h, w, 3), dtype=np.uint8)
+    bgr[:, :, 1] = 200  # green channel
+    return bgr
+
+
+def _bbox_for_320x240() -> BBoxXYWH:
+    return BBoxXYWH(x=10, y=10, width=50, height=50)
+
+
+class TestSam2TrackerImplFailureModes:
+    def test_raises_runtime_when_video_open_fails(self):
+        """The lib's per-scene try/except marks this scene as
+        failed; the F4 ``_CountingSam2Tracker`` then catches the
+        all-scenes-failed case if every track call hits this
+        path."""
+        tracker = Sam2TrackerImpl(model_id="x")
+        set_singleton_for_testing(_fake_loaded(MagicMock()))
+        with patch("cv2.VideoCapture") as cap_factory:
+            cap_factory.return_value = _FakeVideoCapture(frames=[])
+            with pytest.raises(RuntimeError, match="failed to open"):
+                tracker.track(
+                    scene_id="s1",
+                    anchor_bbox=_bbox_for_320x240(),
+                    anchor_keyframe=Image.new("RGB", (1, 1)),
+                    scene_video_url="bad://url",
+                    sample_fps=5,
+                )
+
+    def test_raises_value_error_when_anchor_bbox_outside_frame(self):
+        """Anchor bbox out-of-bounds means SAM2 would happily run
+        but produce nonsense masks — surface the misconfiguration
+        loudly at the worker boundary."""
+        tracker = Sam2TrackerImpl(model_id="x")
+        set_singleton_for_testing(_fake_loaded(MagicMock()))
+        frames = [_green_frame() for _ in range(5)]
+        bad_bbox = BBoxXYWH(x=10, y=10, width=500, height=500)  # > 320x240
+        with patch("cv2.VideoCapture") as cap_factory:
+            cap_factory.return_value = _FakeVideoCapture(frames=frames)
+            with pytest.raises(ValueError, match="anchor_bbox"):
+                tracker.track(
+                    scene_id="s1",
+                    anchor_bbox=bad_bbox,
+                    anchor_keyframe=Image.new("RGB", (1, 1)),
+                    scene_video_url="x",
+                    sample_fps=5,
+                )
+
+    def test_raises_runtime_when_no_frames_decoded(self):
+        """Capture opens but yields zero frames (corrupted proxy /
+        zero-byte file). Stage-wide-failure if every scene hits
+        this; per-scene if it's just one bad upload."""
+        tracker = Sam2TrackerImpl(model_id="x")
+        set_singleton_for_testing(_fake_loaded(MagicMock()))
+        # ``isOpened`` returns True but ``read`` returns (False, None)
+        # immediately. _FakeVideoCapture's open semantics need a hack
+        # for this case: we mark opened by hand.
+        cap = _FakeVideoCapture(frames=[])
+        cap._opened = True  # noqa: SLF001
+        with patch("cv2.VideoCapture", return_value=cap):
+            with pytest.raises(RuntimeError, match="no frames decoded"):
+                tracker.track(
+                    scene_id="s1",
+                    anchor_bbox=_bbox_for_320x240(),
+                    anchor_keyframe=Image.new("RGB", (1, 1)),
+                    scene_video_url="x",
+                    sample_fps=5,
+                )
+
+
+class TestSam2TrackerImplHappyPath:
+    def _make_fake_predictor(
+        self, *, mask_h: int = 240, mask_w: int = 320,
+    ) -> MagicMock:
+        """Produces a model whose ``propagate_in_video`` yields
+        increasing-time samples with a small bbox-sized mask
+        (so ``_mask_to_bbox`` returns a valid bbox)."""
+        import torch
+
+        def _make_mask():
+            m = np.zeros((mask_h, mask_w), dtype=np.uint8)
+            m[20:80, 30:90] = 1
+            return torch.tensor(m)
+
+        def _propagate(_state):
+            for prop_idx in range(5):  # 5 sampled frames
+                masks = MagicMock()
+                masks.__getitem__.return_value = _make_mask()
+                masks.score = 0.95
+                yield prop_idx, [1], masks
+
+        model = MagicMock()
+        model.init_state.return_value = MagicMock()
+        model.add_new_points_or_box.return_value = None
+        model.propagate_in_video.side_effect = _propagate
+        return model
+
+    def test_emits_one_sample_per_propagated_frame_in_time_order(self):
+        """5 propagated frames → 5 ``TrackedSample`` rows in
+        monotonic ``frame_timestamp_ms`` order; each carries the
+        bbox ``_mask_to_bbox`` derives from the predictor's mask."""
+        # Source video: 30fps, 30 frames total; sample_fps=5 →
+        # stride=6 → 5 sampled frames at indexes [0, 6, 12, 18, 24].
+        frames = [_green_frame() for _ in range(30)]
+        cap = _FakeVideoCapture(frames=frames, fps=30.0)
+        model = self._make_fake_predictor()
+        processor = MagicMock()
+        processor.return_value.to.return_value = {
+            "pixel_values": MagicMock(),
+        }
+        set_singleton_for_testing(_fake_loaded(model, processor=processor))
+        tracker = Sam2TrackerImpl(model_id="x")
+
+        with patch("cv2.VideoCapture", return_value=cap):
+            samples = tracker.track(
+                scene_id="s1",
+                anchor_bbox=_bbox_for_320x240(),
+                anchor_keyframe=Image.new("RGB", (1, 1)),
+                scene_video_url="x",
+                sample_fps=5,
+            )
+
+        assert len(samples) == 5
+        timestamps = [s.frame_timestamp_ms for s in samples]
+        assert timestamps == sorted(timestamps), "monotonic ascending order"
+        # Frame indexes 0, 6, 12, 18, 24 at 30fps → 0, 200, 400, 600, 800ms.
+        assert timestamps == [0, 200, 400, 600, 800]
+        # Mask is 60x60 starting at (30, 20) per ``_make_fake_predictor``.
+        assert all(s.bbox.width == 60 and s.bbox.height == 60 for s in samples)
+        # Frame dimensions propagated through.
+        assert all(s.frame_width == 320 and s.frame_height == 240 for s in samples)
+        # Confidence taken from masks.score per-frame.
+        assert all(0.9 < s.mask_confidence <= 1.0 for s in samples)

--- a/services/product-track-worker/tests/test_track_f4.py
+++ b/services/product-track-worker/tests/test_track_f4.py
@@ -70,10 +70,13 @@ def _job_body() -> dict:
 
 
 def _fake_canonical():
-    """Stand-in for the Phase 3c-B catalog-entry fetch."""
+    """Stand-in for the Phase 3c-B catalog-entry fetch.
+
+    Matches ``_fetch_canonical_crop``'s real return shape:
+    ``(canonical_crop, canonical_bbox, llm_label)``."""
     img = Image.new("RGB", (256, 256), (200, 100, 50))
     bbox = BBoxXYWH(x=10, y=10, width=50, height=50)
-    return img, bbox
+    return img, bbox, "테스트 제품"
 
 
 def _scenes_response(n: int = 3) -> dict:


### PR DESCRIPTION
## Summary

Phase 3c-B follow-up to PR #112 (Phase 3c-A scaffold). Replaces the three deliberate `NotImplementedError` stubs with real implementations end-to-end:

- **Catalog entry endpoint** (api): `GET /internal/products/catalog/{catalog_entry_id}` returns the slim seed metadata (`canonical_crop_s3_key`, `canonical_bbox`, `llm_label`) the track-worker needs to anchor SAM2 + run the alignment heuristics. Pattern B internal auth.
- **Canonical-crop fetch** (worker): `_fetch_canonical_crop` now calls the new endpoint, downloads the crop from S3, RGB-converts, returns `(Image, BBoxXYWH, llm_label)`. The `llm_label` reaches `annotate_alignment(label=...)` so `has_narration_mention` / `has_ocr_overlap` finally light up.
- **Render enqueue** (api + worker): new `POST /internal/products/{job_id}/render` wraps `ShortsRenderService.create_render_job` with the scan-job lease check; `org_id` + `requested_by_user_id` derive server-side. Worker builds a `CompositionSpec` from the stitch plan (chronological hard cuts), POSTs, captures `render_job_id`, ships it on `/complete`.
- **Real SAM2** (worker): `Sam2VideoModel` + `Sam2VideoProcessor` from HF transformers. `Sam2TrackerImpl` opens proxy video via OpenCV, samples at `sample_fps`, anchors the first sampled frame, propagates, mask→bbox via numpy. Per-frame failure raises per the lib's `Sam2Tracker` Protocol contract; F4 stage-wide-failure detector catches the all-scenes-fail case.
- **Dockerfile.gpu** (track + enumerate): switched deadsnakes PPA install from `add-apt-repository` (calls `api.launchpad.net` for OAuth, observed timing out during the PR #112 merge build) to direct `keyserver.ubuntu.com` GPG fetch. Track Dockerfile also bakes SAM2 weights at build time.
- **E2E orchestration tests**: 5 cross-cutting invariants pinned (tracker_version from settings, picker cost in cost_delta, appearance shape == api `_AppearancePayload(extra='forbid')`, heartbeat checkpoints, OS string vs DriveFile UUID).

## Phase 3c-B work order completed

| # | Item | State |
|---|---|---|
| 1 | API catalog entry endpoint | ✅ |
| 2 | Worker canonical-crop fetch | ✅ |
| 3 | Render enqueue (api + worker) | ✅ |
| 4 | SAM2 package + integration | ✅ |
| 5 | E2E orchestration tests | ✅ |

## Test counts

| Surface | Before 3c-B | After 3c-B |
|---|---:|---:|
| product-track-worker | 45 | 70 |
| api product-v2 internal-router | — | 11 (new file) |
| product-enumerate-worker | 25 | 25 (Dockerfile fix only) |

All green. Real-GPU SAM2 inference validates at Phase 3d staging soak + goldens calibration.

## Calibration gates (still pending — block prod rollout)

| Gate | Threshold | Fallback if missed |
|---|---|---|
| SigLIP2 off-label re-id | ≥85% enumeration recall AND ≥0.6 mean window IoU | Swap to DINOv2 before prod |
| gpt-4o-mini Korean livecommerce vision | ≥80% enumeration precision | Fall back to gpt-4o |
| SAM2 variant (`sam2-hiera-base-plus`) | ≥0.6 mean window IoU on staging goldens | Swap to `sam2-hiera-large` |

Goldens curation happens on devorg during Phase 2-6 soak. The flag (`AUTO_SHORTS_PRODUCT_V2_ENABLED`) stays off in prod until calibration clears.

## Out of scope

- **Phase 3d (Aircloud onboarding)**: container UUID + EC2 `.env` provisioning. IAM ARN + DLQ alarm already in place from Phase 2.5c.
- **Goldens curation**: requires real video samples on staging.
- **Real-GPU SAM2 validation**: deferred to staging soak.

## Test plan

- [ ] Verify CI green on this branch (Test workflow + GPU image build).
- [ ] After merge, watch staging deploy.
- [ ] Pre-flight: re-run codex review against the diff.
- [ ] Phase 3d: provision Aircloud container, capture UUID, set `AIRCLOUD_ENDPOINT_PRODUCT_TRACK` on staging EC2 `.env`.
- [ ] Phase 3d: enable `AUTO_SHORTS_PRODUCT_V2_ENABLED=true` for devorg on staging, run end-to-end test on a known cosmetics video, capture goldens.