### PR TITLE
Phase 4 foundation: wizard schema + mode dispatch (codex-reviewed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,8 @@ artifacts/
 data/
 .insightface/
 .gstack/
+# Codex CLI session state (transient — session ids are not stable across runs)
+.context/
 
 # E2E Playwright test artifacts (local only)
 e2e/node_modules/

--- a/services/api/app/db/migrations/versions/052_extend_scan_jobs_for_wizard.py
+++ b/services/api/app/db/migrations/versions/052_extend_scan_jobs_for_wizard.py
@@ -1,0 +1,322 @@
+"""Extend product_scan_jobs for the 4-step wizard (Phase 4 foundation)
+
+Adds the parent-child orchestration columns + the new ``mode`` discriminator
+that supersedes the ``catalog_entry_id IS NULL`` heuristic. Adds three new
+stage ENUM values (``preview_ready``, ``fanned_out``, ``committed``) for the
+scan-order lifecycle. Adds CHECK constraints and partial indexes that drive
+idempotency lookups, the per-replica child-runner poll, and parent-only
+concurrency counting.
+
+No new tables. The parent-child relationship lives entirely in
+``product_scan_jobs`` rows linked by ``parent_job_id``.
+
+Existing rows are backfilled to ``mode='enumerate'`` — both the enumeration
+flow and the legacy single-product flow (``enqueue_clip``) map to
+``mode='enumerate'``; the dispatch path additionally branches on
+``catalog_entry_id IS NULL`` for the enumerate-vs-legacy-tracking distinction
+during the +4wk ``enqueue_clip`` deprecation window.
+
+Plan: ``.claude/plans/shorts-auto-product-v2-phase-4-7.md`` §3.
+
+Revision ID: 052_extend_scan_jobs_for_wizard
+Revises: 051_create_product_catalog
+Create Date: 2026-05-02
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "052_extend_scan_jobs_for_wizard"
+down_revision: str | None = "051_create_product_catalog"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Extend the product_scan_stage ENUM with three new values.
+    #
+    # PostgreSQL 12+ allows ``ALTER TYPE ADD VALUE`` inside a transaction
+    # but the new value cannot be used in the same transaction. We don't
+    # INSERT any rows with these new values here; downstream service-layer
+    # code does that.
+    #
+    # ``IF NOT EXISTS`` makes the migration idempotent on re-runs.
+    # ------------------------------------------------------------------
+    op.execute(
+        "ALTER TYPE product_scan_stage ADD VALUE IF NOT EXISTS 'preview_ready'"
+    )
+    op.execute(
+        "ALTER TYPE product_scan_stage ADD VALUE IF NOT EXISTS 'fanned_out'"
+    )
+    op.execute(
+        "ALTER TYPE product_scan_stage ADD VALUE IF NOT EXISTS 'committed'"
+    )
+
+    # ------------------------------------------------------------------
+    # 2. Add the new columns to product_scan_jobs.
+    #
+    # ``mode`` defaults to 'enumerate' so existing rows are atomically
+    # backfilled. The dispatch path uses (mode, catalog_entry_id) jointly
+    # during the legacy-tracking deprecation window:
+    #
+    #   mode='enumerate' AND catalog_entry_id IS NULL  → enumeration job
+    #   mode='enumerate' AND catalog_entry_id NOT NULL → legacy single-
+    #                                                    product tracking
+    #                                                    (deprecated)
+    #   mode='scan_order'                              → wizard parent
+    #   mode='render_child'                            → wizard child
+    # ------------------------------------------------------------------
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD COLUMN parent_job_id UUID NULL
+                REFERENCES product_scan_jobs(id) ON DELETE SET NULL,
+            ADD COLUMN mode TEXT NOT NULL DEFAULT 'enumerate',
+            ADD COLUMN requested_count INTEGER NULL,
+            ADD COLUMN length_seconds INTEGER NULL,
+            ADD COLUMN time_range_start_ms INTEGER NULL,
+            ADD COLUMN time_range_end_ms INTEGER NULL,
+            ADD COLUMN product_distribution TEXT NULL,
+            ADD COLUMN language TEXT NULL,
+            ADD COLUMN shorts_index INTEGER NULL,
+            ADD COLUMN intent TEXT NULL,
+            ADD COLUMN settings_hash TEXT NULL
+    """)
+
+    # ------------------------------------------------------------------
+    # 3. CHECK constraints — every constraint mirrors the SQLAlchemy
+    # ``CheckConstraint`` in ``models.py`` so ``alembic --autogenerate``
+    # does not propose redundant DROP/CREATE pairs on a future revision.
+    # ------------------------------------------------------------------
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_mode
+            CHECK (mode IN ('enumerate', 'scan_order', 'render_child'))
+    """)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_distribution
+            CHECK (
+                product_distribution IS NULL
+                OR product_distribution IN ('single', 'multi')
+            )
+    """)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_language
+            CHECK (language IS NULL OR language IN ('ko', 'en'))
+    """)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_intent
+            CHECK (intent IS NULL OR intent IN ('preview', 'commit'))
+    """)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_parent_child
+            CHECK (
+                (mode = 'render_child' AND parent_job_id IS NOT NULL
+                                       AND shorts_index IS NOT NULL)
+                OR (mode <> 'render_child' AND parent_job_id IS NULL
+                                            AND shorts_index IS NULL)
+            )
+    """)
+    # Q4 (codex pushback): scan_order parents must NEVER carry render_job_id;
+    # children own renders. Docstring alone wasn't sufficient — DB enforces it.
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_parent_no_render
+            CHECK (mode <> 'scan_order' OR render_job_id IS NULL)
+    """)
+    # scan_order parents MUST carry settings_hash + intent; everyone else MUST NOT.
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_parent_required_fields
+            CHECK (
+                (mode = 'scan_order'
+                    AND settings_hash IS NOT NULL
+                    AND intent IS NOT NULL)
+                OR (mode <> 'scan_order'
+                    AND settings_hash IS NULL
+                    AND intent IS NULL)
+            )
+    """)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_time_range
+            CHECK (
+                (time_range_start_ms IS NULL AND time_range_end_ms IS NULL)
+                OR (time_range_end_ms > time_range_start_ms)
+            )
+    """)
+    # Q5 (codex-revised): tightened from 5..600 to 10..120 seconds. Multi-
+    # product picker calibration past 120s is unproven; deferred to Phase 7.
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_length
+            CHECK (
+                length_seconds IS NULL
+                OR (length_seconds >= 10 AND length_seconds <= 120)
+            )
+    """)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_count
+            CHECK (
+                requested_count IS NULL
+                OR (requested_count >= 1 AND requested_count <= 50)
+            )
+    """)
+    # Q5 aggregate cap: count * length <= 1800s (30 min total per scan order).
+    # Codex caught: my original budget rationale was wrong — the daily cost
+    # ledger tracks SCAN cost (heartbeat/complete/fail), not FFmpeg render
+    # cost. This aggregate cap is the right guard against runaway output.
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            ADD CONSTRAINT ck_psj_aggregate_output
+            CHECK (
+                requested_count IS NULL
+                OR length_seconds IS NULL
+                OR (requested_count * length_seconds <= 1800)
+            )
+    """)
+
+    # ------------------------------------------------------------------
+    # 4. Indexes — replace the existing active-only index so it counts
+    # parents only, then add three new partial indexes for the wizard's
+    # hot-path queries.
+    # ------------------------------------------------------------------
+
+    # The existing ix_product_scan_jobs_active was scoped to the original
+    # active stages and ignored ``mode``. Replace it with one that:
+    #   - includes the new active stages (preview_ready, fanned_out)
+    #   - excludes mode='render_child' so concurrency cap counts parents
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_active")
+    op.execute("""
+        CREATE INDEX ix_product_scan_jobs_active
+            ON product_scan_jobs(org_id, stage)
+            WHERE stage IN (
+                'queued','enumerating','tracking','assembling','rendering',
+                'preview_ready','fanned_out'
+            ) AND mode <> 'render_child'
+    """)
+
+    # Parent → children lookup. Used by GET /scan-orders/{parent_id} and
+    # by cancel-cascade.
+    op.execute("""
+        CREATE INDEX ix_product_scan_jobs_parent
+            ON product_scan_jobs(parent_job_id)
+            WHERE parent_job_id IS NOT NULL
+    """)
+
+    # Q3 (codex-revised): idempotency lookup on (org_id, user_id,
+    # settings_hash, created_at). The defensive org_id fix in
+    # ``ProductScanJobRepository.find_recent_duplicate`` requires this index
+    # to keep the dedupe lookup O(log n) under load.
+    op.execute("""
+        CREATE INDEX ix_product_scan_jobs_settings_hash
+            ON product_scan_jobs(
+                org_id, requested_by_user_id, settings_hash, created_at
+            )
+            WHERE mode = 'scan_order' AND settings_hash IS NOT NULL
+    """)
+
+    # Q1 (codex-revised): the child-runner asyncio loop polls for queued
+    # render_child rows. This partial index keeps the poll O(1) at table
+    # scale while the typical row count of queued children stays small.
+    op.execute("""
+        CREATE INDEX ix_product_scan_jobs_child_queue
+            ON product_scan_jobs(created_at)
+            WHERE mode = 'render_child' AND stage = 'queued'
+    """)
+
+
+def downgrade() -> None:
+    # Indexes
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_child_queue")
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_settings_hash")
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_parent")
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_active")
+    # Restore the original active-only index shape from migration 051.
+    op.execute("""
+        CREATE INDEX ix_product_scan_jobs_active
+            ON product_scan_jobs(org_id, stage)
+            WHERE stage IN (
+                'queued','enumerating','tracking','assembling','rendering'
+            )
+    """)
+
+    # Constraints (drop in reverse-add order; IF EXISTS for idempotency)
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_aggregate_output"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_count"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_length"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_time_range"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_parent_required_fields"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_parent_no_render"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_parent_child"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_intent"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_language"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_distribution"
+    )
+    op.execute(
+        "ALTER TABLE product_scan_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_psj_mode"
+    )
+
+    # Columns (drop in reverse-add order)
+    op.execute("""
+        ALTER TABLE product_scan_jobs
+            DROP COLUMN IF EXISTS settings_hash,
+            DROP COLUMN IF EXISTS intent,
+            DROP COLUMN IF EXISTS shorts_index,
+            DROP COLUMN IF EXISTS language,
+            DROP COLUMN IF EXISTS product_distribution,
+            DROP COLUMN IF EXISTS time_range_end_ms,
+            DROP COLUMN IF EXISTS time_range_start_ms,
+            DROP COLUMN IF EXISTS length_seconds,
+            DROP COLUMN IF EXISTS requested_count,
+            DROP COLUMN IF EXISTS mode,
+            DROP COLUMN IF EXISTS parent_job_id
+    """)
+
+    # Note: PostgreSQL ENUM values cannot be dropped (no
+    # ``ALTER TYPE … DROP VALUE``). The new ``preview_ready`` /
+    # ``fanned_out`` / ``committed`` literals stay in the type definition
+    # post-downgrade. This is acceptable because:
+    #   1. Downgrades on production schemas are rare and operator-driven.
+    #   2. The orphaned values are harmless — no app code references them
+    #      once the columns + dispatch are reverted.
+    # If a true clean rollback is needed, follow PG's documented dance of
+    # creating a new type + casting affected columns.

--- a/services/api/app/modules/shorts_auto_product/internal_router.py
+++ b/services/api/app/modules/shorts_auto_product/internal_router.py
@@ -215,7 +215,22 @@ class _CatalogEntryPayload(BaseModel):
 
 
 class _AppearancePayload(BaseModel):
+    """Per-appearance shape for the ``/complete`` callback.
+
+    For legacy single-product tracking jobs (``mode='enumerate'`` AND
+    ``catalog_entry_id IS NOT NULL``), ``catalog_entry_id`` is derived
+    server-side from the job row and MUST be omitted (or null) here —
+    the worker doesn't carry it on the wire.
+
+    For wizard scan_order parents (``mode='scan_order'``), the parent
+    processed the whole catalog so each appearance row carries its own
+    ``catalog_entry_id``. Required in this case; the dispatch path
+    below 422s if missing.
+    """
+
     model_config = ConfigDict(extra="forbid")
+    # Optional on the wire; required-by-mode in the /complete dispatch.
+    catalog_entry_id: UUID | None = None
     scene_id: str = Field(..., min_length=1)
     window_start_ms: int = Field(..., ge=0)
     window_end_ms: int = Field(..., gt=0)
@@ -272,22 +287,67 @@ async def complete(
             detail="lease lost or job missing",
         )
 
-    is_enum = job.catalog_entry_id is None
-    if is_enum and not body.catalog_entries:
+    # Phase 4 task #1 (codex-flagged): dispatch on ``job.mode``, NOT on
+    # ``catalog_entry_id IS NULL``. The pre-Phase-4 heuristic would
+    # misclassify ``mode='scan_order'`` parents (which also carry
+    # ``catalog_entry_id=NULL``) as enumeration jobs and 400 every
+    # parent /complete.
+    from app.modules.shorts_auto_product.models import (
+        SCAN_MODE_ENUMERATE,
+        SCAN_MODE_SCAN_ORDER,
+    )
+
+    if job.mode == SCAN_MODE_ENUMERATE and job.catalog_entry_id is None:
+        kind = "enumeration"
+    elif job.mode == SCAN_MODE_ENUMERATE and job.catalog_entry_id is not None:
+        kind = "legacy_tracking"  # deprecated enqueue_clip flow
+    elif job.mode == SCAN_MODE_SCAN_ORDER:
+        kind = "scan_order"
+    else:
+        # ``mode='render_child'`` callers should hit /render then
+        # /complete via a different flow entirely; rejecting here lets
+        # us catch contract drift early.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"/complete does not accept mode={job.mode!r} via this path",
+        )
+
+    # Body-shape validation by kind.
+    if kind == "enumeration" and not body.catalog_entries:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="enumeration complete must include catalog_entries",
         )
-    if not is_enum and not body.appearances:
+    if kind == "legacy_tracking" and not body.appearances:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="tracking complete must include appearances",
         )
+    if kind == "scan_order" and not body.appearances:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="scan_order complete must include appearances",
+        )
+    if kind == "scan_order":
+        # Each appearance must carry its own catalog_entry_id (the
+        # parent processed the whole catalog).
+        missing = [
+            i for i, app in enumerate(body.appearances)
+            if app.catalog_entry_id is None
+        ]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"scan_order appearances must each carry catalog_entry_id "
+                    f"(missing on indices {missing[:5]}{'...' if len(missing) > 5 else ''})"
+                ),
+            )
 
     persisted_catalog = 0
     persisted_appearances = 0
 
-    if is_enum:
+    if kind == "enumeration":
         catalog_dicts: list[dict[str, object]] = []
         for entry in body.catalog_entries:
             catalog_dicts.append({
@@ -315,11 +375,20 @@ async def complete(
             cost_delta_usd=body.cost_delta_usd,
         )
     else:
-        catalog_entry_id = job.catalog_entry_id  # type: ignore[assignment]
+        # ``legacy_tracking`` derives catalog_entry_id from the job row;
+        # ``scan_order`` reads it from each appearance's payload.
+        legacy_catalog_entry_id = (
+            job.catalog_entry_id if kind == "legacy_tracking" else None
+        )
         appearance_dicts: list[dict[str, object]] = []
         for app in body.appearances:
+            row_catalog_entry_id = (
+                legacy_catalog_entry_id
+                if kind == "legacy_tracking"
+                else app.catalog_entry_id
+            )
             appearance_dicts.append({
-                "catalog_entry_id": catalog_entry_id,
+                "catalog_entry_id": row_catalog_entry_id,
                 "org_id": job.org_id,
                 "scene_id": app.scene_id,
                 "window_start_ms": app.window_start_ms,
@@ -335,11 +404,17 @@ async def complete(
             })
         rows = await appearance_repo.bulk_insert(appearances=appearance_dicts)
         persisted_appearances = len(rows)
+        # Q4 codex pushback: scan_order parents NEVER carry render_job_id;
+        # the ck_psj_parent_no_render CHECK enforces this at the DB level
+        # but force NULL here too — defense in depth.
+        effective_render_job_id = (
+            None if kind == "scan_order" else body.render_job_id
+        )
         await job_repo.complete_tracking(
             job_id=job_id,
             claimed_by=body.claimed_by,
             cost_delta_usd=body.cost_delta_usd,
-            render_job_id=body.render_job_id,
+            render_job_id=effective_render_job_id,
         )
 
     if body.cost_delta_usd > Decimal("0"):
@@ -351,7 +426,7 @@ async def complete(
     logger.info(
         "product_v2_job_completed",
         job_id=str(job_id),
-        kind="enumeration" if is_enum else "tracking",
+        kind=kind,
         persisted_catalog=persisted_catalog,
         persisted_appearances=persisted_appearances,
         cost_delta_usd=str(body.cost_delta_usd),

--- a/services/api/app/modules/shorts_auto_product/models.py
+++ b/services/api/app/modules/shorts_auto_product/models.py
@@ -57,6 +57,10 @@ SCAN_STAGE_ENUMERATION_DONE = "enumeration_done"
 SCAN_STAGE_TRACKING = "tracking"
 SCAN_STAGE_ASSEMBLING = "assembling"
 SCAN_STAGE_RENDERING = "rendering"
+# Phase 4 wizard stages — added in migration 052 via ALTER TYPE ADD VALUE.
+SCAN_STAGE_PREVIEW_READY = "preview_ready"   # parent waiting on user commit (Phase 6)
+SCAN_STAGE_FANNED_OUT = "fanned_out"         # parent waiting on N children to terminate
+SCAN_STAGE_COMMITTED = "committed"           # parent terminal once all children terminate
 SCAN_STAGE_DONE = "done"
 SCAN_STAGE_FAILED = "failed"
 SCAN_STAGE_CANCELLED = "cancelled"
@@ -68,26 +72,79 @@ ALL_SCAN_STAGES: tuple[str, ...] = (
     SCAN_STAGE_TRACKING,
     SCAN_STAGE_ASSEMBLING,
     SCAN_STAGE_RENDERING,
+    SCAN_STAGE_PREVIEW_READY,
+    SCAN_STAGE_FANNED_OUT,
+    SCAN_STAGE_COMMITTED,
     SCAN_STAGE_DONE,
     SCAN_STAGE_FAILED,
     SCAN_STAGE_CANCELLED,
 )
 
 # Stages where the job is still in-flight — drives the per-org
-# concurrency cap query (``ix_product_scan_jobs_active``).
+# concurrency cap query (``ix_product_scan_jobs_active``). Parents in
+# ``preview_ready`` and ``fanned_out`` still hold an active slot; children
+# (``mode='render_child'``) are excluded from the count via the index's
+# WHERE clause.
 ACTIVE_SCAN_STAGES: frozenset[str] = frozenset({
     SCAN_STAGE_QUEUED,
     SCAN_STAGE_ENUMERATING,
     SCAN_STAGE_TRACKING,
     SCAN_STAGE_ASSEMBLING,
     SCAN_STAGE_RENDERING,
+    SCAN_STAGE_PREVIEW_READY,
+    SCAN_STAGE_FANNED_OUT,
 })
 
 TERMINAL_SCAN_STAGES: frozenset[str] = frozenset({
     SCAN_STAGE_DONE,
+    SCAN_STAGE_COMMITTED,
     SCAN_STAGE_FAILED,
     SCAN_STAGE_CANCELLED,
 })
+
+
+# ---------- product_scan_jobs.mode discriminator (Phase 4) ----------
+#
+# Replaces the ``catalog_entry_id IS NULL`` heuristic that pre-dated the
+# 4-step wizard. The dispatch path branches:
+#
+#   mode='enumerate' AND catalog_entry_id IS NULL  → enumeration job
+#   mode='enumerate' AND catalog_entry_id NOT NULL → legacy single-product
+#                                                    tracking (deprecated;
+#                                                    +4wk sunset window)
+#   mode='scan_order'                              → wizard parent
+#   mode='render_child'                            → wizard child
+SCAN_MODE_ENUMERATE = "enumerate"
+SCAN_MODE_SCAN_ORDER = "scan_order"
+SCAN_MODE_RENDER_CHILD = "render_child"
+
+ALL_SCAN_MODES: tuple[str, ...] = (
+    SCAN_MODE_ENUMERATE,
+    SCAN_MODE_SCAN_ORDER,
+    SCAN_MODE_RENDER_CHILD,
+)
+
+# Wizard intent (parent only) — separates preview-flow dedupe from
+# commit-flow dedupe in the ``settings_hash`` keyspace.
+SCAN_INTENT_PREVIEW = "preview"
+SCAN_INTENT_COMMIT = "commit"
+
+ALL_SCAN_INTENTS: tuple[str, ...] = (SCAN_INTENT_PREVIEW, SCAN_INTENT_COMMIT)
+
+# Product distribution mode (parent only) — drives picker selection.
+PRODUCT_DISTRIBUTION_SINGLE = "single"
+PRODUCT_DISTRIBUTION_MULTI = "multi"
+
+ALL_PRODUCT_DISTRIBUTIONS: tuple[str, ...] = (
+    PRODUCT_DISTRIBUTION_SINGLE,
+    PRODUCT_DISTRIBUTION_MULTI,
+)
+
+# Wizard language (parent only).
+LANGUAGE_KO = "ko"
+LANGUAGE_EN = "en"
+
+ALL_LANGUAGES: tuple[str, ...] = (LANGUAGE_KO, LANGUAGE_EN)
 
 # SQLAlchemy enum type bound to the existing Postgres ENUM. All ORM
 # reads / writes go through this so type-safety is preserved.
@@ -261,11 +318,27 @@ class ProductAppearance(Base, UUIDMixin):
 
 @final
 class ProductScanJob(Base, UUIDMixin):
-    """Async job state machine for the cold-start UX.
+    """Async job state machine for shorts-auto product mode v2.
 
-    ``catalog_entry_id IS NULL`` ⇒ enumeration job (output:
-    ``catalog_entries``). ``catalog_entry_id`` non-null ⇒ tracking +
-    assembly job (output: ``render_job_id``).
+    Job kind is discriminated by ``mode`` (Phase 4) — NOT by
+    ``catalog_entry_id`` (the pre-Phase-4 heuristic). The dispatch path
+    must branch on ``mode``:
+
+    * ``mode='enumerate'`` AND ``catalog_entry_id IS NULL`` →
+      enumeration job (output: ``catalog_entries`` populated).
+    * ``mode='enumerate'`` AND ``catalog_entry_id IS NOT NULL`` →
+      legacy single-product tracking (deprecated; ``enqueue_clip``
+      sunsets after the +4wk window post-Phase-4 ship).
+    * ``mode='scan_order'`` (parent) → wizard submission. Holds wizard
+      criteria (``length_seconds``, ``time_range_*``, ``requested_count``,
+      ``product_distribution``, ``language``, ``intent``,
+      ``settings_hash``). GPU pipeline runs ONCE for the whole catalog;
+      ``render_job_id`` is **always NULL** (DB-enforced via
+      ``ck_psj_parent_no_render``) — children own renders.
+    * ``mode='render_child'`` → one of N child jobs of a parent. Holds
+      ``parent_job_id`` and ``shorts_index``. CPU-only — runs in the
+      API process via the child runner loop in ``app.main:lifespan``.
+      Each child enqueues exactly one ``ShortsRenderJob``.
 
     Worker lease pattern matches blur. Stale workers can never
     overwrite a re-claimed job because the ``/internal/products/*``
@@ -335,7 +408,15 @@ class ProductScanJob(Base, UUIDMixin):
         DateTime(timezone=True), nullable=True,
     )
 
-    # Output of tracking jobs.
+    # Render job FK — semantics are mode-aware:
+    #   mode='enumerate' AND catalog_entry_id NOT NULL (legacy tracking)
+    #     → set to the produced render_job_id
+    #   mode='scan_order' (parent)
+    #     → ALWAYS NULL (DB-enforced via ck_psj_parent_no_render); children
+    #       own their own render jobs. Querying parents → render via this
+    #       FK is incorrect post-Phase-4.
+    #   mode='render_child'
+    #     → set to the child's produced render_job_id
     render_job_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),
         ForeignKey("shorts_render_jobs.id", ondelete="SET NULL"),
@@ -347,6 +428,36 @@ class ProductScanJob(Base, UUIDMixin):
     cost_usd_estimate: Mapped[Decimal] = mapped_column(
         Numeric(10, 4), nullable=False, server_default="0",
     )
+
+    # ---------- Phase 4 wizard fields (migration 052) ----------
+    #
+    # Parent → children relationship lives entirely in this table. The
+    # ck_psj_parent_child constraint enforces:
+    #   mode='render_child' → parent_job_id NOT NULL AND shorts_index NOT NULL
+    #   mode != 'render_child' → parent_job_id NULL AND shorts_index NULL
+    parent_job_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("product_scan_jobs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=SCAN_MODE_ENUMERATE,
+    )
+    requested_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    length_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    time_range_start_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    time_range_end_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    product_distribution: Mapped[str | None] = mapped_column(Text, nullable=True)
+    language: Mapped[str | None] = mapped_column(Text, nullable=True)
+    shorts_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # 'preview' | 'commit' — separates wizard intent in settings_hash keyspace.
+    # Required when mode='scan_order' (ck_psj_parent_required_fields), NULL
+    # everywhere else.
+    intent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # SHA256 of canonical-JSON wizard inputs (see service.compute_settings_hash).
+    # Drives idempotency lookups via ix_product_scan_jobs_settings_hash.
+    # Required when mode='scan_order', NULL everywhere else.
+    settings_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -361,16 +472,119 @@ class ProductScanJob(Base, UUIDMixin):
             "requested_by_user_id", "created_at",
         ),
         # Active-only — drives the per-org concurrency cap. Mirrors the
-        # ENUM list in ACTIVE_SCAN_STAGES; keep both in sync.
+        # ENUM list in ACTIVE_SCAN_STAGES; keep both in sync. Excludes
+        # ``mode='render_child'`` so children don't take a slot — only
+        # parents (and pre-Phase-4 enumerate / legacy tracking jobs)
+        # count toward the cap.
         Index(
             "ix_product_scan_jobs_active",
             "org_id", "stage",
-            postgresql_where=(stage.in_(list(ACTIVE_SCAN_STAGES))),
+            postgresql_where=(
+                stage.in_(list(ACTIVE_SCAN_STAGES))
+                & (mode != SCAN_MODE_RENDER_CHILD)
+            ),
         ),
-        # Idempotency lookup for the 60s scan-debounce window.
+        # Legacy idempotency lookup for the pre-Phase-4 60s scan-debounce
+        # window (kept for ``find_recent_duplicate``'s legacy callers).
         Index(
             "ix_product_scan_jobs_idempotency",
             "video_id", "requested_by_user_id", "catalog_entry_id", "created_at",
+        ),
+        # Parent → children lookup. Used by GET /scan-orders/{parent_id}
+        # and by cancel-cascade.
+        Index(
+            "ix_product_scan_jobs_parent",
+            "parent_job_id",
+            postgresql_where=(parent_job_id.is_not(None)),
+        ),
+        # Q3 (codex-revised): wizard idempotency lookup keyed on
+        # (org_id, user_id, settings_hash, created_at). The matching
+        # repository query (find_recent_scan_order_duplicate) MUST filter
+        # on org_id — codex caught the original find_recent_duplicate
+        # bug where org_id was missing.
+        Index(
+            "ix_product_scan_jobs_settings_hash",
+            "org_id", "requested_by_user_id", "settings_hash", "created_at",
+            postgresql_where=(
+                (mode == SCAN_MODE_SCAN_ORDER) & settings_hash.is_not(None)
+            ),
+        ),
+        # Q1 (codex-revised): the child-runner asyncio loop polls for
+        # queued render_child rows. This partial index keeps the poll
+        # O(1) at table scale while the typical row count of queued
+        # children stays small.
+        Index(
+            "ix_product_scan_jobs_child_queue",
+            "created_at",
+            postgresql_where=(
+                (mode == SCAN_MODE_RENDER_CHILD) & (stage == SCAN_STAGE_QUEUED)
+            ),
+        ),
+        # Mirrors of CHECK constraints in migration 052. Keep these in
+        # sync so ``alembic --autogenerate`` doesn't propose redundant
+        # DROP/CREATE pairs on a future revision.
+        CheckConstraint(
+            "mode IN ('enumerate','scan_order','render_child')",
+            name="ck_psj_mode",
+        ),
+        CheckConstraint(
+            "product_distribution IS NULL OR product_distribution IN ('single','multi')",
+            name="ck_psj_distribution",
+        ),
+        CheckConstraint(
+            "language IS NULL OR language IN ('ko','en')",
+            name="ck_psj_language",
+        ),
+        CheckConstraint(
+            "intent IS NULL OR intent IN ('preview','commit')",
+            name="ck_psj_intent",
+        ),
+        CheckConstraint(
+            "(mode = 'render_child' AND parent_job_id IS NOT NULL "
+            "AND shorts_index IS NOT NULL) "
+            "OR (mode <> 'render_child' AND parent_job_id IS NULL "
+            "AND shorts_index IS NULL)",
+            name="ck_psj_parent_child",
+        ),
+        # Q4 (codex pushback): scan_order parents must NEVER carry
+        # render_job_id; children own renders.
+        CheckConstraint(
+            "mode <> 'scan_order' OR render_job_id IS NULL",
+            name="ck_psj_parent_no_render",
+        ),
+        CheckConstraint(
+            "(mode = 'scan_order' AND settings_hash IS NOT NULL "
+            "AND intent IS NOT NULL) "
+            "OR (mode <> 'scan_order' AND settings_hash IS NULL "
+            "AND intent IS NULL)",
+            name="ck_psj_parent_required_fields",
+        ),
+        CheckConstraint(
+            "(time_range_start_ms IS NULL AND time_range_end_ms IS NULL) "
+            "OR (time_range_end_ms > time_range_start_ms)",
+            name="ck_psj_time_range",
+        ),
+        # Q5 (codex-revised): tightened from 5..600 to 10..120 seconds.
+        CheckConstraint(
+            "length_seconds IS NULL "
+            "OR (length_seconds >= 10 AND length_seconds <= 120)",
+            name="ck_psj_length",
+        ),
+        CheckConstraint(
+            "requested_count IS NULL "
+            "OR (requested_count >= 1 AND requested_count <= 50)",
+            name="ck_psj_count",
+        ),
+        # Q5 aggregate cap: count * length <= 1800s (30 min total
+        # output per scan order). Codex caught: my original budget
+        # rationale was wrong — the daily cost ledger tracks SCAN cost
+        # (heartbeat/complete/fail), not FFmpeg render cost. This
+        # aggregate cap is the right guard.
+        CheckConstraint(
+            "requested_count IS NULL "
+            "OR length_seconds IS NULL "
+            "OR (requested_count * length_seconds <= 1800)",
+            name="ck_psj_aggregate_output",
         ),
     )
 
@@ -408,18 +622,34 @@ class ProductScanDailyCost(Base):
 
 __all__ = [
     "ACTIVE_SCAN_STAGES",
+    "ALL_LANGUAGES",
+    "ALL_PRODUCT_DISTRIBUTIONS",
+    "ALL_SCAN_INTENTS",
+    "ALL_SCAN_MODES",
     "ALL_SCAN_STAGES",
+    "LANGUAGE_EN",
+    "LANGUAGE_KO",
+    "PRODUCT_DISTRIBUTION_MULTI",
+    "PRODUCT_DISTRIBUTION_SINGLE",
     "PRODUCT_SCAN_STAGE_ENUM",
     "ProductAppearance",
     "ProductCatalogEntry",
     "ProductScanDailyCost",
     "ProductScanJob",
+    "SCAN_INTENT_COMMIT",
+    "SCAN_INTENT_PREVIEW",
+    "SCAN_MODE_ENUMERATE",
+    "SCAN_MODE_RENDER_CHILD",
+    "SCAN_MODE_SCAN_ORDER",
     "SCAN_STAGE_ASSEMBLING",
     "SCAN_STAGE_CANCELLED",
+    "SCAN_STAGE_COMMITTED",
     "SCAN_STAGE_DONE",
     "SCAN_STAGE_ENUMERATING",
     "SCAN_STAGE_ENUMERATION_DONE",
     "SCAN_STAGE_FAILED",
+    "SCAN_STAGE_FANNED_OUT",
+    "SCAN_STAGE_PREVIEW_READY",
     "SCAN_STAGE_QUEUED",
     "SCAN_STAGE_RENDERING",
     "SCAN_STAGE_TRACKING",

--- a/services/api/app/modules/shorts_auto_product/repositories/job.py
+++ b/services/api/app/modules/shorts_auto_product/repositories/job.py
@@ -106,20 +106,29 @@ class ProductScanJobRepository:
     async def find_recent_duplicate(
         self,
         *,
+        org_id: UUID,
         video_id: UUID,
         user_id: UUID,
         catalog_entry_id: UUID | None,
         within_seconds: int,
     ) -> ProductScanJob | None:
-        """Idempotency lookup for the scan + clip endpoints.
+        """Idempotency lookup for the legacy scan + clip endpoints.
 
-        Two requests with the same (video_id, user_id, catalog_entry_id)
-        within ``within_seconds`` return the existing job. Includes
-        terminal states — re-clicking a finished scan opens the cached
-        result rather than starting a new one.
+        Two requests with the same (org_id, video_id, user_id,
+        catalog_entry_id) within ``within_seconds`` return the existing
+        job. Includes terminal states — re-clicking a finished scan
+        opens the cached result rather than starting a new one.
+
+        ``org_id`` filter is mandatory (codex defensive fix). Without
+        it, two orgs that happen to reference the same ``video_id``
+        could collide on dedupe. Postgres FK on ``video_id`` already
+        scopes uniqueness per ``drive_files`` row, but this query is
+        defense in depth — and matches every other tenant-scoped
+        repository read in this module.
         """
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=within_seconds)
         conditions: list[Any] = [
+            ProductScanJob.org_id == org_id,
             ProductScanJob.video_id == video_id,
             ProductScanJob.requested_by_user_id == user_id,
             ProductScanJob.created_at >= cutoff,

--- a/services/api/app/modules/shorts_auto_product/schemas.py
+++ b/services/api/app/modules/shorts_auto_product/schemas.py
@@ -39,12 +39,24 @@ ScanStage = Literal[
     "tracking",
     "assembling",
     "rendering",
+    # Phase 4 wizard stages.
+    "preview_ready",   # parent waiting on user commit (Phase 6)
+    "fanned_out",      # parent waiting on N children to terminate
+    "committed",       # parent terminal once all children terminate
     "done",
     "failed",
     "cancelled",
 ]
 
-JobKind = Literal["enumeration", "tracking"]
+# Job kind discriminator (Phase 4). Mirrors the ``mode`` column on
+# ``ProductScanJob`` plus the legacy "tracking" value for the deprecated
+# single-product (``enqueue_clip``) flow.
+#   ``enumeration``    → mode='enumerate' AND catalog_entry_id IS NULL
+#   ``tracking``       → mode='enumerate' AND catalog_entry_id IS NOT NULL
+#                        (legacy single-product, sunset +4wk after Phase 4 ship)
+#   ``scan_order``     → mode='scan_order' (wizard parent)
+#   ``render_child``   → mode='render_child' (wizard child)
+JobKind = Literal["enumeration", "tracking", "scan_order", "render_child"]
 
 ScanErrorCode = Literal[
     "llm_timeout",
@@ -145,8 +157,12 @@ class ClipResponse(BaseModel):
 class JobStatusResponse(BaseModel):
     """Response for ``GET /api/shorts/auto/jobs/{job_id}``.
 
-    Single shape for both enumeration and tracking jobs — the UI
-    branches on ``kind`` to render the right progress UI.
+    Single shape for all four job kinds — the UI branches on ``kind``
+    to render the right progress UI. Phase 4 added ``parent_job_id`` +
+    ``shorts_index`` so children carry lineage in this flat shape too;
+    the wizard's primary subscription is to the parent's aggregate
+    endpoint (``GET /scan-orders/{parent_id}``) but legacy callers can
+    still hit ``/jobs/{id}`` and group by parent.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -164,8 +180,16 @@ class JobStatusResponse(BaseModel):
     error_code: ScanErrorCode | None = None
     error_message: str | None = None
 
-    # Set on tracking jobs once the render is enqueued.
+    # Set on legacy single-product tracking jobs and on render_child
+    # jobs once the render is enqueued. **Always None for scan_order
+    # parents** — children own renders (Q4 codex pushback).
     render_job_id: UUID | None = None
+
+    # Wizard lineage — set only on ``kind='render_child'``. Lets the
+    # UI group children under their parent in the flat /jobs/{id}
+    # response without an extra round-trip.
+    parent_job_id: UUID | None = None
+    shorts_index: int | None = None
 
     # Per-job running cost (running total — re-reads update across
     # heartbeats). Frontend doesn't display this in v1; it's surfaced

--- a/services/api/app/modules/shorts_auto_product/service.py
+++ b/services/api/app/modules/shorts_auto_product/service.py
@@ -255,8 +255,10 @@ class ProductScanService:
         self._require_enabled_for_org(org_id)
         await self._require_budget(org_id)
 
-        # Idempotency: same (video, user) within window → return existing.
+        # Idempotency: same (org, video, user) within window → return existing.
+        # ``org_id`` is mandatory (codex defensive fix; see repositories/job.py).
         existing = await self.job_repo.find_recent_duplicate(
+            org_id=org_id,
             video_id=video_id,
             user_id=user_id,
             catalog_entry_id=None,
@@ -339,6 +341,7 @@ class ProductScanService:
             )
 
         existing = await self.job_repo.find_recent_duplicate(
+            org_id=org_id,
             video_id=video_id,
             user_id=user_id,
             catalog_entry_id=catalog_entry_id,
@@ -564,7 +567,47 @@ class ProductScanService:
 # ---------- helpers ----------
 
 def _job_to_status_response(job: ProductScanJob) -> JobStatusResponse:
-    kind: JobKind = "tracking" if job.catalog_entry_id is not None else "enumeration"
+    """Mode-aware projection of a ``ProductScanJob`` to the public
+    ``JobStatusResponse`` shape.
+
+    Discriminator switch (Phase 4 task #1, codex-flagged): branches on
+    ``job.mode`` rather than the pre-Phase-4 ``catalog_entry_id IS NULL``
+    heuristic, which would misclassify ``mode='scan_order'`` parents
+    (also NULL) as enumeration jobs.
+
+    Q4 codex pushback: ``render_job_id`` is forced to ``None`` for
+    ``mode='scan_order'`` parents in the response payload, even if the
+    row somehow carries one (the ``ck_psj_parent_no_render`` CHECK
+    should make that impossible at the DB level). Defense in depth:
+    every layer agrees parents do not carry render FKs.
+    """
+    from app.modules.shorts_auto_product.models import (
+        SCAN_MODE_ENUMERATE,
+        SCAN_MODE_RENDER_CHILD,
+        SCAN_MODE_SCAN_ORDER,
+    )
+
+    if job.mode == SCAN_MODE_SCAN_ORDER:
+        kind: JobKind = "scan_order"
+        # Defensive: parents must not echo a render_job_id even if the
+        # row carries one. CHECK constraint prevents writes; this is
+        # belt-and-suspenders for the read path.
+        render_job_id_response: UUID | None = None
+    elif job.mode == SCAN_MODE_RENDER_CHILD:
+        kind = "render_child"
+        render_job_id_response = job.render_job_id
+    elif job.mode == SCAN_MODE_ENUMERATE:
+        # Backward compat: the dispatch from ``mode='enumerate'`` to
+        # the user-facing kind still depends on ``catalog_entry_id``
+        # during the +4wk legacy ``enqueue_clip`` deprecation window.
+        if job.catalog_entry_id is not None:
+            kind = "tracking"  # legacy single-product flow
+        else:
+            kind = "enumeration"
+        render_job_id_response = job.render_job_id
+    else:  # pragma: no cover — CHECK constraint forbids other values
+        raise ValueError(f"unknown ProductScanJob.mode: {job.mode!r}")
+
     stage: ScanStage = job.stage  # type: ignore[assignment]
     error_code = job.error_code  # type: ignore[assignment]
     return JobStatusResponse(
@@ -578,6 +621,8 @@ def _job_to_status_response(job: ProductScanJob) -> JobStatusResponse:
         cancelled_at=job.cancelled_at,
         error_code=error_code,
         error_message=job.error_message,
-        render_job_id=job.render_job_id,
+        render_job_id=render_job_id_response,
+        parent_job_id=job.parent_job_id,
+        shorts_index=job.shorts_index,
         cost_usd_estimate=job.cost_usd_estimate,
     )

--- a/services/api/tests/test_shorts_auto_product_phase4_foundation.py
+++ b/services/api/tests/test_shorts_auto_product_phase4_foundation.py
@@ -1,0 +1,507 @@
+"""Phase 4 foundation regression tests.
+
+Codex-flagged work items from the Phase 4-7 plan §3.3:
+
+* The dual-discriminator switch — ``_job_to_status_response`` and
+  ``/complete`` MUST branch on ``mode``, not on
+  ``catalog_entry_id IS NULL`` (which would misclassify
+  ``mode='scan_order'`` parents).
+* The ``find_recent_duplicate`` org_id defensive bug fix — the lookup
+  was tenant-blind.
+* The Q4 invariant that ``mode='scan_order'`` parents NEVER carry
+  ``render_job_id`` in API responses (DB CHECK is the canonical
+  enforcement; this test covers the response layer's defense in depth).
+
+These tests are deliberately unit-scope (no Postgres) — DB CHECK
+constraints are exercised by the alembic migration test in
+``tests/test_alembic_migration_052_check_constraints.py`` (added in a
+follow-up PR with integration markers).
+
+NOT in the CI allowlist (yet) — same gating as the rest of the
+``test_shorts_auto_product_*.py`` suite. Run locally:
+
+    cd services/api && source .venv/bin/activate && pytest \\
+        tests/test_shorts_auto_product_phase4_foundation.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.modules.shorts_auto_product.models import (
+    SCAN_MODE_ENUMERATE,
+    SCAN_MODE_RENDER_CHILD,
+    SCAN_MODE_SCAN_ORDER,
+    SCAN_STAGE_DONE,
+    SCAN_STAGE_QUEUED,
+)
+from app.modules.shorts_auto_product.service import _job_to_status_response
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+def _job_row(
+    *,
+    job_id: UUID | None = None,
+    mode: str = SCAN_MODE_ENUMERATE,
+    catalog_entry_id: UUID | None = None,
+    parent_job_id: UUID | None = None,
+    shorts_index: int | None = None,
+    render_job_id: UUID | None = None,
+    stage: str = SCAN_STAGE_QUEUED,
+):
+    """Mocked ``ProductScanJob`` row.
+
+    ``MagicMock`` mirrors SQLAlchemy ORM attribute access without
+    needing a session or table. Only attributes ``_job_to_status_response``
+    actually reads need to be present; the rest are auto-magicked.
+    """
+    job = MagicMock()
+    job.id = job_id if job_id is not None else uuid4()
+    job.mode = mode
+    job.catalog_entry_id = catalog_entry_id
+    job.parent_job_id = parent_job_id
+    job.shorts_index = shorts_index
+    job.render_job_id = render_job_id
+    job.stage = stage
+    job.progress_pct = 0
+    job.progress_label = None
+    job.completed_at = None
+    job.failed_at = None
+    job.cancelled_at = None
+    job.error_code = None
+    job.error_message = None
+    job.cost_usd_estimate = Decimal("0")
+    return job
+
+
+# ======================================================================
+# Q1.1 dual-discriminator switch — _job_to_status_response branches on
+# mode, NOT on catalog_entry_id IS NULL
+# ======================================================================
+
+
+def test_status_response_enumerate_mode_no_catalog_entry_id():
+    """``mode='enumerate'`` with ``catalog_entry_id=NULL`` → kind='enumeration'.
+
+    This is the unchanged enumeration job path. Backward-compat baseline.
+    """
+    job = _job_row(mode=SCAN_MODE_ENUMERATE, catalog_entry_id=None)
+    resp = _job_to_status_response(job)
+    assert resp.kind == "enumeration"
+    assert resp.parent_job_id is None
+    assert resp.shorts_index is None
+
+
+def test_status_response_enumerate_mode_with_catalog_entry_id():
+    """``mode='enumerate'`` with ``catalog_entry_id`` set → kind='tracking'
+    (legacy single-product flow during +4wk deprecation window)."""
+    job = _job_row(
+        mode=SCAN_MODE_ENUMERATE,
+        catalog_entry_id=uuid4(),
+        render_job_id=uuid4(),
+    )
+    resp = _job_to_status_response(job)
+    assert resp.kind == "tracking"
+    assert resp.render_job_id == job.render_job_id
+
+
+def test_status_response_scan_order_mode_kind_and_render_job_id_masked():
+    """**The codex-flagged Q4 regression**: ``mode='scan_order'`` parents
+    must report ``kind='scan_order'`` AND **MUST NOT echo render_job_id**
+    in the response, even if the row carries one (the
+    ``ck_psj_parent_no_render`` CHECK should make that impossible at the
+    DB level, but the response layer enforces it as defense in depth).
+    """
+    parent_id = uuid4()
+    bogus_render_id = uuid4()
+    job = _job_row(
+        job_id=parent_id,
+        mode=SCAN_MODE_SCAN_ORDER,
+        catalog_entry_id=None,         # parents always NULL on this column
+        # Force a non-NULL render_job_id on the row to verify the
+        # response layer scrubs it. In production the DB CHECK would
+        # prevent this from existing — we simulate the buggy state.
+        render_job_id=bogus_render_id,
+    )
+    resp = _job_to_status_response(job)
+    assert resp.kind == "scan_order"
+    assert resp.render_job_id is None, (
+        "scan_order parents must NEVER echo render_job_id in the "
+        "response payload (Q4 codex pushback — defense in depth)"
+    )
+
+
+def test_status_response_render_child_mode_lineage_populated():
+    """``mode='render_child'`` → kind='render_child' AND
+    ``parent_job_id`` + ``shorts_index`` populated."""
+    parent_id = uuid4()
+    job = _job_row(
+        mode=SCAN_MODE_RENDER_CHILD,
+        catalog_entry_id=None,
+        parent_job_id=parent_id,
+        shorts_index=3,
+        render_job_id=uuid4(),
+    )
+    resp = _job_to_status_response(job)
+    assert resp.kind == "render_child"
+    assert resp.parent_job_id == parent_id
+    assert resp.shorts_index == 3
+    assert resp.render_job_id == job.render_job_id
+
+
+def test_status_response_unknown_mode_raises():
+    """Defensive: an unknown mode (CHECK constraint should prevent this
+    in production) should raise ValueError rather than silently
+    misclassify."""
+    job = _job_row(mode="banana")
+    with pytest.raises(ValueError, match="unknown ProductScanJob.mode"):
+        _job_to_status_response(job)
+
+
+# ======================================================================
+# Q3 — find_recent_duplicate org_id filter (codex defensive fix)
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_find_recent_duplicate_filters_on_org_id():
+    """Codex caught: pre-fix ``find_recent_duplicate`` did NOT filter
+    on ``org_id``. Even though Postgres FK on video_id provides natural
+    tenancy scoping, this is defense in depth — every other read in
+    the module is org-scoped.
+
+    Verifies the SQL statement built by the repository contains an
+    ``org_id`` predicate.
+    """
+    from app.modules.shorts_auto_product.repositories.job import (
+        ProductScanJobRepository,
+    )
+
+    captured_stmt = []
+
+    class _StubResult:
+        def scalar_one_or_none(self):
+            return None
+
+    async def _stub_execute(stmt):
+        captured_stmt.append(stmt)
+        return _StubResult()
+
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(side_effect=_stub_execute)
+
+    repo = ProductScanJobRepository(fake_session)
+    await repo.find_recent_duplicate(
+        org_id=uuid4(),
+        video_id=uuid4(),
+        user_id=uuid4(),
+        catalog_entry_id=None,
+        within_seconds=60,
+    )
+
+    assert len(captured_stmt) == 1
+    rendered = str(
+        captured_stmt[0].compile(compile_kwargs={"literal_binds": False})
+    )
+    assert "org_id" in rendered, (
+        "find_recent_duplicate must filter on org_id (codex defensive "
+        f"bug fix). Rendered SQL: {rendered}"
+    )
+
+
+# ======================================================================
+# Q1.1 dual-discriminator switch — /complete branches on mode
+# ======================================================================
+
+
+def _build_complete_app(monkeypatch, *, job, persisted_appearance_count=0,
+                       persisted_catalog_count=0):
+    """Build a minimal FastAPI app with the internal router mounted +
+    repos mocked. Pattern B test patching: stub both the package
+    re-export AND the internal_router-bound name.
+    """
+    from app.dependencies import get_db_session, verify_internal_token
+    from app.modules.shorts_auto_product.internal_router import (
+        router as internal_router,
+    )
+
+    fake_job_repo = MagicMock()
+    fake_job_repo.get_internal = AsyncMock(return_value=job)
+    fake_job_repo.complete_enumeration = AsyncMock(return_value=job)
+    fake_job_repo.complete_tracking = AsyncMock(return_value=job)
+
+    fake_catalog_repo = MagicMock()
+    catalog_rows = [MagicMock() for _ in range(persisted_catalog_count)]
+    fake_catalog_repo.bulk_insert = AsyncMock(return_value=catalog_rows)
+
+    fake_appearance_repo = MagicMock()
+    appearance_rows = [MagicMock() for _ in range(persisted_appearance_count)]
+    fake_appearance_repo.bulk_insert = AsyncMock(return_value=appearance_rows)
+
+    fake_cost_repo = MagicMock()
+    fake_cost_repo.add_cost = AsyncMock()
+
+    # Pattern B test patching (D53): patch BOTH the package re-export
+    # AND the internal_router module's bound name. The router imports
+    # repos at module-load time via `from ... import ...`, so the
+    # package patch alone doesn't reach the call site.
+    import app.modules.shorts_auto_product.repositories as repos_pkg
+    import app.modules.shorts_auto_product.internal_router as router_module
+
+    for name, fake_factory in [
+        ("ProductScanJobRepository", lambda _db: fake_job_repo),
+        ("ProductCatalogRepository", lambda _db: fake_catalog_repo),
+        ("ProductAppearanceRepository", lambda _db: fake_appearance_repo),
+        ("ProductScanDailyCostRepository", lambda _db: fake_cost_repo),
+    ]:
+        wrapped = MagicMock(side_effect=fake_factory)
+        monkeypatch.setattr(repos_pkg, name, wrapped)
+        monkeypatch.setattr(router_module, name, wrapped)
+
+    app = FastAPI()
+    app.include_router(internal_router)
+    fake_db = MagicMock()
+    fake_db.commit = AsyncMock()
+    app.dependency_overrides[get_db_session] = lambda: fake_db
+    app.dependency_overrides[verify_internal_token] = lambda: "test-token"
+    return app
+
+
+def test_complete_scan_order_accepts_appearances_with_catalog_entry_ids(
+    monkeypatch,
+):
+    """**The dual-discriminator regression**: a parent (``mode='scan_order'``,
+    ``catalog_entry_id=NULL``) calling ``/complete`` with appearances must
+    succeed.
+
+    Pre-fix code branched on ``catalog_entry_id IS NULL`` and would 400
+    every parent /complete because it'd demand ``catalog_entries``
+    instead.
+    """
+    parent_id = uuid4()
+    catalog_entry_id_a = uuid4()
+    catalog_entry_id_b = uuid4()
+    job = _job_row(
+        job_id=parent_id,
+        mode=SCAN_MODE_SCAN_ORDER,
+        catalog_entry_id=None,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+
+    app = _build_complete_app(
+        monkeypatch, job=job, persisted_appearance_count=2,
+    )
+    client = TestClient(app)
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "appearances": [
+            {
+                "catalog_entry_id": str(catalog_entry_id_a),
+                "scene_id": "scene_001",
+                "window_start_ms": 1000,
+                "window_end_ms": 5000,
+                "avg_bbox_area_pct": 0.2,
+                "avg_confidence": 0.9,
+                "tracker_version": "v1",
+            },
+            {
+                "catalog_entry_id": str(catalog_entry_id_b),
+                "scene_id": "scene_002",
+                "window_start_ms": 6000,
+                "window_end_ms": 10000,
+                "avg_bbox_area_pct": 0.3,
+                "avg_confidence": 0.85,
+                "tracker_version": "v1",
+            },
+        ],
+    }
+    resp = client.post(
+        f"/internal/products/{parent_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["persisted_appearances"] == 2
+
+
+def test_complete_scan_order_rejects_appearance_missing_catalog_entry_id(
+    monkeypatch,
+):
+    """scan_order parents process the whole catalog so each appearance
+    MUST carry its own ``catalog_entry_id``. Missing → 400."""
+    parent_id = uuid4()
+    job = _job_row(
+        job_id=parent_id,
+        mode=SCAN_MODE_SCAN_ORDER,
+        catalog_entry_id=None,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+
+    app = _build_complete_app(monkeypatch, job=job)
+    client = TestClient(app)
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "appearances": [
+            {
+                # NO catalog_entry_id — should 400
+                "scene_id": "scene_001",
+                "window_start_ms": 1000,
+                "window_end_ms": 5000,
+                "avg_bbox_area_pct": 0.2,
+                "avg_confidence": 0.9,
+                "tracker_version": "v1",
+            },
+        ],
+    }
+    resp = client.post(
+        f"/internal/products/{parent_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 400
+    assert "catalog_entry_id" in resp.text
+
+
+def test_complete_scan_order_forces_render_job_id_to_none(monkeypatch):
+    """**Q4 codex defense in depth**: even if a buggy worker passes
+    ``render_job_id`` in the body for a scan_order parent, the
+    persistence layer must force it to NULL.
+    """
+    parent_id = uuid4()
+    catalog_entry_id = uuid4()
+    job = _job_row(
+        job_id=parent_id,
+        mode=SCAN_MODE_SCAN_ORDER,
+        catalog_entry_id=None,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+
+    app = _build_complete_app(
+        monkeypatch, job=job, persisted_appearance_count=1,
+    )
+    # Capture the call args to complete_tracking so we can assert
+    # render_job_id was forced to None.
+    import app.modules.shorts_auto_product.repositories as repos_pkg
+    fake_factory = repos_pkg.ProductScanJobRepository
+    fake_job_repo = fake_factory(MagicMock())
+
+    client = TestClient(app)
+    bogus_render_id = uuid4()
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "render_job_id": str(bogus_render_id),  # buggy worker; should be ignored
+        "appearances": [
+            {
+                "catalog_entry_id": str(catalog_entry_id),
+                "scene_id": "scene_001",
+                "window_start_ms": 1000,
+                "window_end_ms": 5000,
+                "avg_bbox_area_pct": 0.2,
+                "avg_confidence": 0.9,
+                "tracker_version": "v1",
+            },
+        ],
+    }
+    resp = client.post(
+        f"/internal/products/{parent_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 200, resp.text
+    # complete_tracking must be called with render_job_id=None
+    assert fake_job_repo.complete_tracking.await_args.kwargs[
+        "render_job_id"
+    ] is None
+
+
+def test_complete_legacy_tracking_path_unchanged(monkeypatch):
+    """Backward compat: the deprecated ``enqueue_clip`` flow
+    (``mode='enumerate'`` AND ``catalog_entry_id IS NOT NULL``) must
+    continue to accept appearances without ``catalog_entry_id`` on the
+    payload — the API derives it from the job row. +4wk sunset.
+    """
+    legacy_job_id = uuid4()
+    legacy_catalog_entry_id = uuid4()
+    job = _job_row(
+        job_id=legacy_job_id,
+        mode=SCAN_MODE_ENUMERATE,
+        catalog_entry_id=legacy_catalog_entry_id,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+
+    app = _build_complete_app(
+        monkeypatch, job=job, persisted_appearance_count=1,
+    )
+    client = TestClient(app)
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "render_job_id": str(uuid4()),
+        "appearances": [
+            {
+                # NO catalog_entry_id on payload — derived server-side
+                "scene_id": "scene_001",
+                "window_start_ms": 1000,
+                "window_end_ms": 5000,
+                "avg_bbox_area_pct": 0.2,
+                "avg_confidence": 0.9,
+                "tracker_version": "v1",
+            },
+        ],
+    }
+    resp = client.post(
+        f"/internal/products/{legacy_job_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_complete_render_child_rejected_via_complete_path(monkeypatch):
+    """``mode='render_child'`` callers must NOT call /complete via
+    this path. Rejecting here lets us catch contract drift early.
+    """
+    child_id = uuid4()
+    parent_id = uuid4()
+    job = _job_row(
+        job_id=child_id,
+        mode=SCAN_MODE_RENDER_CHILD,
+        catalog_entry_id=None,
+        parent_job_id=parent_id,
+        shorts_index=1,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+
+    app = _build_complete_app(monkeypatch, job=job)
+    client = TestClient(app)
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "render_job_id": str(uuid4()),
+    }
+    resp = client.post(
+        f"/internal/products/{child_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 400
+    assert "render_child" in resp.text


### PR DESCRIPTION
## Summary

The substrate for the 4-step wizard (length / time-range / count / single-vs-multi product / KR-EN). Adds the schema columns, state-machine extensions, and mode-based dispatch the wizard's parent-children orchestration depends on. **No service-layer wizard endpoints, no frontend, no worker refactor** — those land in subsequent Phase 4 PRs. This is the smallest end-to-end-testable foundation.

Plan: `.claude/plans/shorts-auto-product-v2-phase-4-7.md` (codex-reviewed 2026-05-02; session id `019de89d-54c8-7760-885c-9338cd068c07` for follow-up consults).

### What ships

* **Migration 052**: `parent_job_id`, `mode`, `requested_count`, `length_seconds`, `time_range_*_ms`, `product_distribution`, `language`, `shorts_index`, `intent`, `settings_hash`. Three new `product_scan_stage` ENUM values (`preview_ready`, `fanned_out`, `committed`). Eleven CHECK constraints — including `ck_psj_parent_no_render` (Q4 codex pushback) and `ck_psj_aggregate_output` enforcing `count*length<=1800` (Q5 codex correction). Four partial indexes for the wizard's hot paths.
* **Mode-based dispatch in `_job_to_status_response`**: branches on `job.mode` rather than `catalog_entry_id IS NULL`. The pre-Phase-4 heuristic would misclassify `mode='scan_order'` parents (which also carry `catalog_entry_id=NULL`) as enumeration jobs and 400 every parent `/complete`. Forces `render_job_id=None` on the response payload for parents — defense in depth on top of the DB CHECK.
* **Mode-based dispatch in `/complete`**: legacy single-product flow stays intact for the +4wk `enqueue_clip` deprecation window; `scan_order` parents accept appearances tagged with per-row `catalog_entry_id`; `render_child` callers via this path are 400'd to catch contract drift.
* **Defensive fix on `find_recent_duplicate`**: now scopes lookups to `org_id`. Codex caught the latent cross-tenant collision risk — every other read in this module is org-scoped already.

### Codex review trail

The Phase 4-7 plan went through a `/codex consult` adversarial pass. Five GO-WITH-CHANGES verdicts plus one outright NO-GO on the original Q1 (asyncio.create_task fan-out) — redesigned to the DB-claim child runner loop landing in Phase 4 PR #2. The dual-discriminator collision (this PR's reason for being) was the highest-severity catch.

### Out of scope (subsequent PRs)

* `ScanOrderService` / `POST /scan-orders` / `GET /scan-orders/{id}` (Phase 4 PR #2)
* Child runner asyncio loop in `app.main:lifespan` (Phase 4 PR #2)
* Worker parent-flow refactor in `services/product-track-worker/` (Phase 4 PR #3)
* Frontend wizard `features/shorts-auto-product-wizard/` (Phase 4 PR #4)
* Contracts v0.14.0 publish (gates Phase 4 PR #3 worker changes)

## Test plan

- [x] **All 60 tests in the `shorts_auto_product` module green locally** (49 pre-existing + 11 new regression tests).
- [x] **CI allowlist (339 tests) green locally** — verifies no cross-cutting regressions in search / shorts_render / blur / image_caption.
- [x] **New regression tests** cover the codex-flagged work items:
  - Q1.1 dual-discriminator switch in `_job_to_status_response` (4 modes + unknown-raise)
  - Q4 `render_job_id` masking for parents in API responses
  - `/complete` mode-based dispatch (5 cases including legacy compat + render_child rejection)
  - Q3 defensive `org_id` predicate in `find_recent_duplicate`
- [ ] **Migration applied on staging via the Deploy workflow** — confirm `make seed` round-trip and that downgrade is mostly clean (PostgreSQL ENUM values cannot be removed; documented in `downgrade()`).
- [ ] **`alembic --autogenerate`** — verify it does not propose redundant DROP/CREATE pairs against the new constraints (mirrored in `models.py::__table_args__`).
- [ ] **Backward compat smoke** — flip `AUTO_SHORTS_PRODUCT_V2_ENABLED=true` on devorg staging, fire one legacy `enqueue_clip` flow, verify `/complete` still works for `mode='enumerate' AND catalog_entry_id IS NOT NULL`.

## Risk

- **Scope-risk: moderate**. Touches the dispatch path of every existing `/complete` callback. Backward-compat regression test in the new file covers the legacy single-product path. The full module's test suite (60 tests) is green.
- **Constraint:** PostgreSQL ENUM values cannot be removed. Downgrade leaves the three new stage values orphaned in the type definition — harmless because no app code references them post-revert, but documented inline.