### PR TITLE
Phase 4 PR #2: scan-order service + wizard endpoints

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -410,6 +410,35 @@ class Settings(BaseSettings):
     auto_shorts_product_v2_enumerate_lease_seconds: int = 600
     auto_shorts_product_v2_track_lease_seconds: int = 1800
 
+    # --- Phase 4 wizard / child runner ---
+    #
+    # Bounded concurrency for the in-API-process child render runner
+    # (services/api/app/modules/shorts_auto_product/children/runner.py).
+    # Children are CPU-light (subset_pick + stitch_plan + 1 HTTP call to
+    # /render) but should not starve request handlers under load. If
+    # render-enqueue latency rises, drop to 2.
+    auto_shorts_product_v2_child_runner_max_concurrency: int = 4
+    # Poll interval for the runner loop. 5s is fast enough for the
+    # wizard's 3s polling cadence to feel near-instant; lower values
+    # burn CPU on idle replicas.
+    auto_shorts_product_v2_child_runner_poll_seconds: float = 5.0
+    # Lease length for child claims. Children are fast (subset_pick is
+    # bounded by parent's appearances; stitch_plan is O(N); render
+    # enqueue is one HTTP call), so a short lease catches a wedged
+    # replica quickly without spuriously stealing work from a healthy
+    # one.
+    auto_shorts_product_v2_child_lease_seconds: int = 300
+    # Master switch for the child runner loop. Default ON in prod;
+    # disable to suspend wizard fan-out without redeploying (e.g. while
+    # debugging a render-side incident).
+    auto_shorts_product_v2_child_runner_enabled: bool = True
+
+    # Wizard idempotency window. Same shape as the legacy
+    # ``auto_shorts_product_v2_scan_idempotency_seconds`` but keyed on
+    # the canonical-JSON ``settings_hash`` so two different sets of
+    # wizard inputs don't collide.
+    auto_shorts_product_v2_scan_order_idempotency_seconds: int = 60
+
     # --- CORS ---
     cors_allow_origin_regex: str = (
         r"^https?://"

--- a/services/api/app/modules/shorts_auto_product/repositories/job.py
+++ b/services/api/app/modules/shorts_auto_product/repositories/job.py
@@ -25,6 +25,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.shorts_auto_product.models import (
     ACTIVE_SCAN_STAGES,
+    SCAN_MODE_ENUMERATE,
+    SCAN_MODE_RENDER_CHILD,
+    SCAN_MODE_SCAN_ORDER,
     SCAN_STAGE_ASSEMBLING,
     SCAN_STAGE_CANCELLED,
     SCAN_STAGE_DONE,
@@ -34,6 +37,7 @@ from app.modules.shorts_auto_product.models import (
     SCAN_STAGE_QUEUED,
     SCAN_STAGE_RENDERING,
     SCAN_STAGE_TRACKING,
+    TERMINAL_SCAN_STAGES,
     ProductScanJob,
 )
 
@@ -194,7 +198,11 @@ class ProductScanJobRepository:
         claimed / completed (idempotent — the worker can safely retry
         and another worker will not steal the lease).
         """
-        if next_stage not in {SCAN_STAGE_ENUMERATING, SCAN_STAGE_TRACKING}:
+        if next_stage not in {
+            SCAN_STAGE_ENUMERATING,
+            SCAN_STAGE_TRACKING,
+            SCAN_STAGE_ASSEMBLING,  # Phase 4: child runner claims queued → assembling
+        }:
             raise ValueError(f"invalid claim next_stage: {next_stage!r}")
         now = datetime.now(timezone.utc)
         lease_expires = now + timedelta(seconds=lease_seconds)
@@ -400,3 +408,234 @@ class ProductScanJobRepository:
             .returning(ProductScanJob)
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # Phase 4 wizard — scan-order parent + render-child helpers
+    # ------------------------------------------------------------------
+
+    async def create_scan_order_parent(
+        self,
+        *,
+        org_id: UUID,
+        video_id: UUID,
+        user_id: UUID,
+        length_seconds: int,
+        requested_count: int,
+        time_range_start_ms: int | None,
+        time_range_end_ms: int | None,
+        product_distribution: str,
+        language: str,
+        intent: str,
+        settings_hash: str,
+    ) -> ProductScanJob:
+        """Insert a wizard parent row.
+
+        ``mode='scan_order'`` + every wizard input from the body. The
+        DB-level CHECKs (``ck_psj_parent_required_fields``,
+        ``ck_psj_aggregate_output``, etc.) catch any service-side
+        validation gap. ``catalog_entry_id`` is NULL — parents process
+        the whole catalog.
+        """
+        job = ProductScanJob(
+            org_id=org_id,
+            video_id=video_id,
+            requested_by_user_id=user_id,
+            catalog_entry_id=None,
+            duration_preset_sec=length_seconds,  # legacy column carries the same number
+            mode=SCAN_MODE_SCAN_ORDER,
+            length_seconds=length_seconds,
+            requested_count=requested_count,
+            time_range_start_ms=time_range_start_ms,
+            time_range_end_ms=time_range_end_ms,
+            product_distribution=product_distribution,
+            language=language,
+            intent=intent,
+            settings_hash=settings_hash,
+        )
+        self.session.add(job)
+        await self.session.flush()
+        return job
+
+    async def create_render_children(
+        self,
+        *,
+        parent: ProductScanJob,
+        count: int,
+    ) -> list[ProductScanJob]:
+        """Bulk insert N child rows for a scan_order parent.
+
+        Children inherit ``org_id``, ``video_id``,
+        ``requested_by_user_id``, and ``length_seconds`` from the
+        parent. Each carries its own ``shorts_index`` (1..count) which
+        the picker uses to spread products across shorts.
+        """
+        if parent.mode != SCAN_MODE_SCAN_ORDER:
+            raise ValueError(
+                f"cannot fan out children from non-scan_order parent "
+                f"(parent.mode={parent.mode!r})"
+            )
+        if count < 1:
+            raise ValueError(f"count must be >= 1, got {count!r}")
+        children = [
+            ProductScanJob(
+                org_id=parent.org_id,
+                video_id=parent.video_id,
+                requested_by_user_id=parent.requested_by_user_id,
+                catalog_entry_id=None,
+                duration_preset_sec=parent.length_seconds,
+                mode=SCAN_MODE_RENDER_CHILD,
+                parent_job_id=parent.id,
+                shorts_index=i,
+                length_seconds=parent.length_seconds,
+            )
+            for i in range(1, count + 1)
+        ]
+        self.session.add_all(children)
+        await self.session.flush()
+        return children
+
+    async def find_recent_scan_order_duplicate(
+        self,
+        *,
+        org_id: UUID,
+        user_id: UUID,
+        settings_hash: str,
+        within_seconds: int,
+    ) -> ProductScanJob | None:
+        """Wizard idempotency lookup — returns the existing parent
+        row if (org, user, settings_hash) matches within window.
+
+        Settings hash is canonical-JSON of every wizard input
+        (computed in the service layer). ``intent`` is part of the
+        hash, so preview and commit cannot dedupe each other.
+        ``org_id`` is mandatory (mirrors the defensive fix on
+        ``find_recent_duplicate``).
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=within_seconds)
+        stmt = (
+            select(ProductScanJob)
+            .where(
+                ProductScanJob.org_id == org_id,
+                ProductScanJob.requested_by_user_id == user_id,
+                ProductScanJob.mode == SCAN_MODE_SCAN_ORDER,
+                ProductScanJob.settings_hash == settings_hash,
+                ProductScanJob.created_at >= cutoff,
+            )
+            .order_by(ProductScanJob.created_at.desc())
+            .limit(1)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def find_children_for_parent(
+        self,
+        *,
+        org_id: UUID,
+        parent_job_id: UUID,
+    ) -> list[ProductScanJob]:
+        """List a parent's children ordered by ``shorts_index``.
+        Org-scoped — defense in depth (``parent_job_id`` is unique
+        but the join keeps this query consistent with the rest of
+        the module's tenant-scoping convention).
+        """
+        stmt = (
+            select(ProductScanJob)
+            .where(
+                ProductScanJob.parent_job_id == parent_job_id,
+                ProductScanJob.org_id == org_id,
+                ProductScanJob.mode == SCAN_MODE_RENDER_CHILD,
+            )
+            .order_by(ProductScanJob.shorts_index.asc())
+        )
+        return list((await self.session.execute(stmt)).scalars().all())
+
+    async def find_queued_render_children(
+        self,
+        *,
+        limit: int,
+    ) -> list[UUID]:
+        """Runner poll query — returns at most ``limit`` queued
+        ``mode='render_child'`` job ids ordered FIFO by created_at.
+
+        Returns id-only to keep the row footprint small; the runner
+        re-fetches via ``get_internal`` after a successful claim.
+        Multi-replica safe: claim is the actual race resolver, not
+        this poll.
+        """
+        stmt = (
+            select(ProductScanJob.id)
+            .where(
+                ProductScanJob.mode == SCAN_MODE_RENDER_CHILD,
+                ProductScanJob.stage == SCAN_STAGE_QUEUED,
+            )
+            .order_by(ProductScanJob.created_at.asc())
+            .limit(limit)
+        )
+        return list((await self.session.execute(stmt)).scalars().all())
+
+    async def cancel_scan_order(
+        self,
+        *,
+        org_id: UUID,
+        parent_job_id: UUID,
+    ) -> int:
+        """Cascade-cancel a wizard order: parent + all non-terminal
+        children. Returns the count of rows transitioned (parent
+        included if it was active).
+
+        Idempotent — already-terminal rows are skipped silently.
+        """
+        now = datetime.now(timezone.utc)
+        # Parent: active stages only (so already-cancelled parents
+        # don't re-trigger the timestamps).
+        parent_stmt = (
+            update(ProductScanJob)
+            .where(
+                ProductScanJob.id == parent_job_id,
+                ProductScanJob.org_id == org_id,
+                ProductScanJob.mode == SCAN_MODE_SCAN_ORDER,
+                ProductScanJob.stage.in_(list(ACTIVE_SCAN_STAGES)),
+            )
+            .values(
+                stage=SCAN_STAGE_CANCELLED,
+                cancelled_at=now,
+                last_heartbeat_at=now,
+            )
+        )
+        parent_result = await self.session.execute(parent_stmt)
+        # Children: cancel any non-terminal child of this parent.
+        children_stmt = (
+            update(ProductScanJob)
+            .where(
+                ProductScanJob.parent_job_id == parent_job_id,
+                ProductScanJob.org_id == org_id,
+                ProductScanJob.mode == SCAN_MODE_RENDER_CHILD,
+                ProductScanJob.stage.notin_(list(TERMINAL_SCAN_STAGES)),
+            )
+            .values(
+                stage=SCAN_STAGE_CANCELLED,
+                cancelled_at=now,
+                last_heartbeat_at=now,
+            )
+        )
+        children_result = await self.session.execute(children_stmt)
+        return (parent_result.rowcount or 0) + (children_result.rowcount or 0)
+
+    async def get_scan_order_with_children(
+        self,
+        *,
+        org_id: UUID,
+        parent_job_id: UUID,
+    ) -> tuple[ProductScanJob, list[ProductScanJob]] | None:
+        """Aggregate read for ``GET /scan-orders/{parent_job_id}``.
+
+        Two queries (parent + children) — pgsql window functions
+        could pack this into one but the row count is bounded by
+        ``requested_count`` (≤50) so the simpler shape wins.
+        """
+        parent = await self.get(org_id=org_id, job_id=parent_job_id)
+        if parent is None or parent.mode != SCAN_MODE_SCAN_ORDER:
+            return None
+        children = await self.find_children_for_parent(
+            org_id=org_id, parent_job_id=parent_job_id,
+        )
+        return parent, children

--- a/services/api/app/modules/shorts_auto_product/router.py
+++ b/services/api/app/modules/shorts_auto_product/router.py
@@ -29,6 +29,10 @@ from app.modules.shorts_auto_product.schemas import (
     ProductCatalogResponse,
     ProductV2AvailabilityFragment,
     RescanResponse,
+    ScanOrderCommitRequest,
+    ScanOrderCreateRequest,
+    ScanOrderResponse,
+    ScanOrderStatusResponse,
     ScanRequest,
     ScanResponse,
 )
@@ -280,3 +284,120 @@ async def get_product_v2_availability(
     """
     service = _build_service(db, settings)
     return await service.availability_fragment(org_id=org_ctx.org_id)
+
+
+# ----------------------------------------------------------------------
+# Phase 4 wizard — scan-order endpoints
+# ----------------------------------------------------------------------
+
+
+@router.post(
+    "/scan-orders/videos/{video_id}",
+    response_model=ScanOrderResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_scan_order(
+    video_id: UUID,
+    body: ScanOrderCreateRequest,
+    org_ctx: Annotated[OrgContext, Depends(get_current_org)],
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ScanOrderResponse:
+    """Submit the 4-step wizard.
+
+    Body captures every wizard input. Idempotent within
+    ``auto_shorts_product_v2_scan_order_idempotency_seconds``
+    (default 60s) keyed on canonical-JSON ``settings_hash``.
+
+    Validation chain (422 with descriptive messages):
+    * ``length_seconds``: 10..120 (Pydantic Field bounds)
+    * ``requested_count``: 1..50
+    * ``requested_count * length_seconds <= 1800`` (aggregate cap)
+    * If time-range provided: end > start AND
+      ``(end - start) / count >= length_seconds * 1000``
+
+    Mounted under ``/videos/{video_id}`` so the path naturally scopes
+    to the video the user picked in step 1 of the wizard. The
+    counterpart ``GET /scan-orders/{parent_job_id}`` does NOT carry
+    ``video_id`` in the path — once a parent exists, the wizard
+    polls by parent id directly.
+    """
+    service = _build_service(db, settings)
+    return await service.enqueue_scan_order(
+        org_id=org_ctx.org_id,
+        video_id=video_id,
+        user_id=user.id,
+        body=body,
+    )
+
+
+@router.get(
+    "/scan-orders/{parent_job_id}",
+    response_model=ScanOrderStatusResponse,
+)
+async def get_scan_order_status(
+    parent_job_id: UUID,
+    org_ctx: Annotated[OrgContext, Depends(get_current_org)],
+    _user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ScanOrderStatusResponse:
+    """Aggregate status for a wizard order — parent + all children +
+    rollup counts. The wizard polls THIS endpoint, not the legacy
+    ``/jobs/{job_id}`` flat shape.
+    """
+    service = _build_service(db, settings)
+    return await service.get_scan_order_status(
+        org_id=org_ctx.org_id, parent_job_id=parent_job_id,
+    )
+
+
+@router.post(
+    "/scan-orders/{parent_job_id}/cancel",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def cancel_scan_order(
+    parent_job_id: UUID,
+    org_ctx: Annotated[OrgContext, Depends(get_current_org)],
+    _user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> None:
+    """Cascade-cancel a scan order: parent + non-terminal children.
+
+    Best-effort for in-flight children — the lease + claimed_by
+    discipline means a running render won't be ripped out from
+    under itself; the next heartbeat sees ``stage=cancelled`` and
+    exits cleanly.
+    """
+    service = _build_service(db, settings)
+    await service.cancel_scan_order(
+        org_id=org_ctx.org_id, parent_job_id=parent_job_id,
+    )
+
+
+@router.post(
+    "/scan-orders/{parent_job_id}/commit",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def commit_scan_order(
+    parent_job_id: UUID,
+    body: ScanOrderCommitRequest,
+    org_ctx: Annotated[OrgContext, Depends(get_current_org)],
+    _user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> None:
+    """Phase 6 endpoint — preview → commit transition.
+
+    Currently returns 501. The body shape is locked now so the
+    frontend wizard can be built against a stable contract; Phase 6
+    will wire the SAM2 + render-enqueue commit path.
+    """
+    service = _build_service(db, settings)
+    await service.commit_scan_order(
+        org_id=org_ctx.org_id,
+        parent_job_id=parent_job_id,
+        selected_window_ids=body.selected_window_ids,
+    )

--- a/services/api/app/modules/shorts_auto_product/schemas.py
+++ b/services/api/app/modules/shorts_auto_product/schemas.py
@@ -220,3 +220,83 @@ class ProductV2AvailabilityFragment(BaseModel):
     product_v2_in_rollout: bool
     product_v2_daily_budget_remaining_pct: int = Field(..., ge=0, le=100)
     product_v2_duration_presets_sec: list[int] = Field(default_factory=list)
+
+
+# ----------------------------------------------------------------------
+# Phase 4 wizard — scan-order endpoints
+# ----------------------------------------------------------------------
+
+ProductDistribution = Literal["single", "multi"]
+Language = Literal["ko", "en"]
+ScanIntent = Literal["preview", "commit"]
+
+
+class ScanOrderCreateRequest(BaseModel):
+    """Body for ``POST /api/shorts/auto/scan-orders``.
+
+    Captures every wizard input the parent job needs. Validation:
+      * ``length_seconds``: 10..120 (per-shorts duration; see Q5 codex
+        correction in the plan).
+      * ``requested_count * length_seconds <= 1800`` (aggregate output
+        cap; the daily cost ledger does NOT track render cost so this
+        is the operative guard against runaway output).
+      * ``time_range_*_ms``: optional; if both set, end > start AND
+        ``(end - start) / count >= length_seconds * 1000`` (each short
+        has at least its length in source range).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    length_seconds: int = Field(..., ge=10, le=120)
+    requested_count: int = Field(..., ge=1, le=50)
+    time_range_start_ms: int | None = Field(default=None, ge=0)
+    time_range_end_ms: int | None = Field(default=None, gt=0)
+    product_distribution: ProductDistribution
+    language: Language
+    intent: ScanIntent = "commit"
+
+
+class ScanOrderResponse(BaseModel):
+    """Response for ``POST /api/shorts/auto/scan-orders``.
+
+    Returns the parent job id; the wizard then subscribes to
+    ``GET /scan-orders/{parent_job_id}`` for aggregate status.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    parent_job_id: UUID
+    deduped: bool = False
+
+
+class ScanOrderStatusResponse(BaseModel):
+    """Response for ``GET /api/shorts/auto/scan-orders/{parent_job_id}``.
+
+    The wizard's primary subscription. One round-trip yields the
+    full picture (parent + all children + their progress) — frontend
+    does not poll N+1 endpoints.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    parent: JobStatusResponse
+    children: list[JobStatusResponse] = Field(default_factory=list)
+    # Wizard-level rollup so the UI doesn't have to compute it. None
+    # while the parent is still in non-fanned-out states.
+    children_complete: int = Field(..., ge=0)
+    children_failed: int = Field(..., ge=0)
+    children_total: int = Field(..., ge=0)
+
+
+class ScanOrderCommitRequest(BaseModel):
+    """Body for ``POST /api/shorts/auto/scan-orders/{parent_job_id}/commit``.
+
+    Phase 6 endpoint — currently returns 501. Body shape locked now
+    so the frontend wizard can be built against a stable contract.
+    Optional ``selected_window_ids`` lets the user drop preview
+    windows before SAM2 + render-enqueue runs in commit mode.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    selected_window_ids: list[UUID] | None = None

--- a/services/api/app/modules/shorts_auto_product/service.py
+++ b/services/api/app/modules/shorts_auto_product/service.py
@@ -21,8 +21,10 @@ repositories.
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Any
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -60,6 +62,9 @@ from app.modules.shorts_auto_product.schemas import (
     ProductCatalogResponse,
     ProductV2AvailabilityFragment,
     RescanResponse,
+    ScanOrderCreateRequest,
+    ScanOrderResponse,
+    ScanOrderStatusResponse,
     ScanResponse,
     ScanStage,
     ScanStatus,
@@ -563,8 +568,311 @@ class ProductScanService:
             product_v2_duration_presets_sec=presets,
         )
 
+    # ------------------------------------------------------------------
+    # Phase 4 wizard — scan-order endpoints
+    # ------------------------------------------------------------------
+
+    async def enqueue_scan_order(
+        self,
+        *,
+        org_id: UUID,
+        video_id: UUID,
+        user_id: UUID,
+        body: ScanOrderCreateRequest,
+    ) -> ScanOrderResponse:
+        """Create a wizard parent job from the 4-step wizard inputs.
+
+        Pre-flight order matches the rest of this service (flag,
+        budget, idempotency, concurrency). Aggregate-output cap is
+        enforced both as a 422 here and as a DB CHECK
+        (``ck_psj_aggregate_output``) — service-layer 422 gives a
+        meaningful error message before the row hits Postgres.
+
+        SQS publish for ``mode='scan_order'`` parents is wired in PR #3
+        alongside the worker refactor. Until then, parent rows persist
+        in stage='queued' but no worker consumes them — so the wizard
+        flow end-to-end requires PR #3 to land before the parent
+        actually progresses past 'queued'. This is intentional: it
+        keeps PR #2 testable in isolation without DLQ noise from the
+        existing track-worker rejecting the new mode.
+        """
+        self._require_enabled_for_org(org_id)
+        await self._require_budget(org_id)
+
+        # Service-layer validation that complements the DB CHECKs with
+        # better error messages for the frontend.
+        _validate_scan_order_inputs(body=body)
+
+        # Active catalog set drives idempotency invalidation: a rescan
+        # that produces new entries naturally invalidates the dedupe
+        # key without needing an explicit catalog version column.
+        active_entries = await self.catalog_repo.list_active_by_video(
+            org_id=org_id, video_id=video_id,
+        )
+        active_entry_ids = sorted(str(e.id) for e in active_entries)
+
+        settings_hash = compute_settings_hash(
+            video_id=video_id,
+            user_id=user_id,
+            length_seconds=body.length_seconds,
+            requested_count=body.requested_count,
+            time_range_start_ms=body.time_range_start_ms,
+            time_range_end_ms=body.time_range_end_ms,
+            product_distribution=body.product_distribution,
+            language=body.language,
+            intent=body.intent,
+            active_catalog_entry_ids=active_entry_ids,
+            tracker_version=self.settings.auto_shorts_product_v2_tracker_version,
+            enumeration_prompt_version=(
+                self.settings.auto_shorts_product_v2_enumeration_prompt_version
+            ),
+        )
+
+        existing = await self.job_repo.find_recent_scan_order_duplicate(
+            org_id=org_id,
+            user_id=user_id,
+            settings_hash=settings_hash,
+            within_seconds=(
+                self.settings.auto_shorts_product_v2_scan_order_idempotency_seconds
+            ),
+        )
+        if existing is not None:
+            return ScanOrderResponse(
+                parent_job_id=existing.id, deduped=True,
+            )
+
+        await self._require_concurrency_slot(org_id)
+
+        parent = await self.job_repo.create_scan_order_parent(
+            org_id=org_id,
+            video_id=video_id,
+            user_id=user_id,
+            length_seconds=body.length_seconds,
+            requested_count=body.requested_count,
+            time_range_start_ms=body.time_range_start_ms,
+            time_range_end_ms=body.time_range_end_ms,
+            product_distribution=body.product_distribution,
+            language=body.language,
+            intent=body.intent,
+            settings_hash=settings_hash,
+        )
+        await self.session.flush()
+
+        # TODO(PR#3): publish_product_scan_order_job — wired with the
+        # worker refactor that teaches product-track-worker to handle
+        # mode='scan_order'. Until then, parent rows sit in 'queued'.
+        logger.info(
+            "product_v2_scan_order_created",
+            parent_job_id=str(parent.id),
+            org_id=str(org_id),
+            video_id=str(video_id),
+            user_id=str(user_id),
+            length_seconds=body.length_seconds,
+            requested_count=body.requested_count,
+            distribution=body.product_distribution,
+            language=body.language,
+            intent=body.intent,
+            settings_hash=settings_hash,
+            note="SQS publish deferred to PR #3",
+        )
+        return ScanOrderResponse(parent_job_id=parent.id, deduped=False)
+
+    async def get_scan_order_status(
+        self,
+        *,
+        org_id: UUID,
+        parent_job_id: UUID,
+    ) -> ScanOrderStatusResponse:
+        """Aggregate read for the wizard's polling subscription."""
+        self._require_enabled_for_org(org_id)
+        result = await self.job_repo.get_scan_order_with_children(
+            org_id=org_id, parent_job_id=parent_job_id,
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="scan order not found",
+            )
+        parent, children = result
+        children_responses = [_job_to_status_response(c) for c in children]
+        complete_count = sum(
+            1 for c in children_responses if c.completed_at is not None
+        )
+        failed_count = sum(
+            1 for c in children_responses
+            if c.failed_at is not None or c.cancelled_at is not None
+        )
+        return ScanOrderStatusResponse(
+            parent=_job_to_status_response(parent),
+            children=children_responses,
+            children_complete=complete_count,
+            children_failed=failed_count,
+            children_total=len(children_responses),
+        )
+
+    async def cancel_scan_order(
+        self,
+        *,
+        org_id: UUID,
+        parent_job_id: UUID,
+    ) -> None:
+        """Cascade-cancel a parent + its non-terminal children.
+
+        404 if parent is missing OR not a scan_order OR no rows were
+        transitioned (already-terminal cases hit the latter — same
+        no-info-leak shape as the legacy ``cancel_job``).
+        """
+        self._require_enabled_for_org(org_id)
+        # Verify the parent exists and is a scan_order before
+        # attempting the cascade — keeps 404 semantics tight.
+        parent = await self.job_repo.get(
+            org_id=org_id, job_id=parent_job_id,
+        )
+        if parent is None or parent.mode != "scan_order":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="scan order not found",
+            )
+        rows_changed = await self.job_repo.cancel_scan_order(
+            org_id=org_id, parent_job_id=parent_job_id,
+        )
+        if rows_changed == 0:
+            # Parent + all children already terminal — idempotent
+            # 404 same as the legacy cancel.
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="scan order not found or already terminal",
+            )
+
+    async def commit_scan_order(
+        self,
+        *,
+        org_id: UUID,
+        parent_job_id: UUID,
+        selected_window_ids: list[UUID] | None,
+    ) -> None:
+        """Phase 6 endpoint — preview → commit transition. Stubbed
+        until the preview flow lands. Body shape locked now so the
+        frontend wizard can be built against a stable contract.
+        """
+        self._require_enabled_for_org(org_id)
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="scan order commit is a Phase 6 deliverable",
+        )
+
 
 # ---------- helpers ----------
+
+
+def compute_settings_hash(
+    *,
+    video_id: UUID,
+    user_id: UUID,
+    length_seconds: int,
+    requested_count: int,
+    time_range_start_ms: int | None,
+    time_range_end_ms: int | None,
+    product_distribution: str,
+    language: str,
+    intent: str,
+    active_catalog_entry_ids: list[str],
+    tracker_version: str,
+    enumeration_prompt_version: str,
+) -> str:
+    """Canonical-JSON SHA256 of every wizard input that should
+    discriminate "same intent" from "different intent" for the 60s
+    idempotency window.
+
+    Why these fields, codex-reviewed (plan §19 Q3):
+
+    * ``video_id`` + ``user_id``: tenant-scoping happens at the SQL
+      level via the ``find_recent_scan_order_duplicate`` filter, but
+      including them in the hash makes the hash cross-tenant unique
+      so cache poisoning via ID collision is impossible.
+    * ``intent``: separates preview-flow dedupe from commit-flow
+      dedupe — same wizard inputs in preview mode must not dedupe a
+      subsequent commit.
+    * ``active_catalog_entry_ids``: rescan that produces new entries
+      naturally changes the hash → new parent. No catalog-version
+      column needed.
+    * ``tracker_version`` + ``enumeration_prompt_version``: model
+      bumps invalidate dedupe correctly, so the user re-running with
+      the same wizard inputs after a model deploy gets fresh output
+      (otherwise the cached parent would be stuck on the old model).
+
+    Canonical-JSON via ``sort_keys=True`` + tightest separators so
+    the hash is stable across Python versions / dict ordering /
+    unicode differences. NEVER change the hash composition without
+    bumping this function's name; otherwise rolling deploys would
+    miss caches across replicas mid-deploy.
+    """
+    payload: dict[str, Any] = {
+        "video_id": str(video_id),
+        "user_id": str(user_id),
+        "intent": intent,
+        "length_seconds": length_seconds,
+        "requested_count": requested_count,
+        "time_range_start_ms": time_range_start_ms or 0,
+        "time_range_end_ms": time_range_end_ms or 0,
+        "product_distribution": product_distribution,
+        "language": language,
+        "catalog_entry_ids": list(active_catalog_entry_ids),
+        "tracker_version": tracker_version,
+        "enumeration_prompt_version": enumeration_prompt_version,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_scan_order_inputs(*, body: ScanOrderCreateRequest) -> None:
+    """Service-layer validation that the DB CHECKs back-stop.
+
+    Pydantic already enforces 10..120 length and 1..50 count via Field
+    bounds. The DB enforces ``count * length <= 1800`` and
+    time-range monotonicity. This function adds the 422s the
+    frontend can render as inline errors:
+
+      * aggregate output cap (count * length <= 1800)
+      * time-range sanity: each short has at least its length in
+        source range
+    """
+    aggregate_output_seconds = body.requested_count * body.length_seconds
+    if aggregate_output_seconds > 1800:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"requested_count ({body.requested_count}) * length_seconds "
+                f"({body.length_seconds}) = {aggregate_output_seconds}s exceeds "
+                f"the 1800s (30 min) aggregate cap per scan order"
+            ),
+        )
+    if (body.time_range_start_ms is None) != (body.time_range_end_ms is None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "time_range_start_ms and time_range_end_ms must both be "
+                "set or both be null"
+            ),
+        )
+    if body.time_range_start_ms is not None and body.time_range_end_ms is not None:
+        if body.time_range_end_ms <= body.time_range_start_ms:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="time_range_end_ms must be greater than time_range_start_ms",
+            )
+        span_ms = body.time_range_end_ms - body.time_range_start_ms
+        per_short_budget_ms = span_ms / body.requested_count
+        required_per_short_ms = body.length_seconds * 1000
+        if per_short_budget_ms < required_per_short_ms:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"time range ({span_ms}ms) split across {body.requested_count} "
+                    f"shorts gives only {int(per_short_budget_ms)}ms per short — "
+                    f"each short needs at least {required_per_short_ms}ms of source"
+                ),
+            )
 
 def _job_to_status_response(job: ProductScanJob) -> JobStatusResponse:
     """Mode-aware projection of a ``ProductScanJob`` to the public

--- a/services/api/tests/test_shorts_auto_product_scan_order.py
+++ b/services/api/tests/test_shorts_auto_product_scan_order.py
@@ -1,0 +1,543 @@
+"""Phase 4 PR #2 — scan-order service tests.
+
+Covers the wizard's parent-job orchestration plumbing:
+
+* ``compute_settings_hash`` — canonical-JSON SHA256 (codex Q3).
+* ``_validate_scan_order_inputs`` — aggregate-output cap + time-range
+  sanity (codex Q5).
+* ``ProductScanService.enqueue_scan_order`` — pre-flight gates,
+  idempotency via settings_hash, parent-row creation.
+* ``ProductScanService.get_scan_order_status`` — aggregate shape
+  with rollup counters.
+* ``ProductScanService.cancel_scan_order`` — cascading cancel.
+* ``ProductScanService.commit_scan_order`` — Phase 6 stub.
+
+NOT in CI allowlist (consistent with the rest of the
+test_shorts_auto_product_*.py suite).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.modules.shorts_auto_product.models import (
+    SCAN_MODE_RENDER_CHILD,
+    SCAN_MODE_SCAN_ORDER,
+    SCAN_STAGE_DONE,
+    SCAN_STAGE_FAILED,
+    SCAN_STAGE_QUEUED,
+)
+from app.modules.shorts_auto_product.schemas import ScanOrderCreateRequest
+from app.modules.shorts_auto_product.service import (
+    ProductScanService,
+    _validate_scan_order_inputs,
+    compute_settings_hash,
+)
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+def _settings_stub(**overrides):
+    """Minimal Settings stub for service construction."""
+    s = MagicMock()
+    s.auto_shorts_product_v2_enabled = True
+    s.auto_shorts_product_v2_rollout_pct = 100
+    s.auto_shorts_product_v2_daily_budget_usd = 50.0
+    s.auto_shorts_product_v2_max_concurrent_per_org = 3
+    s.auto_shorts_product_v2_scan_order_idempotency_seconds = 60
+    s.auto_shorts_product_v2_tracker_version = "v1.0"
+    s.auto_shorts_product_v2_enumeration_prompt_version = "v1.0"
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def _build_service(*, settings=None):
+    """Construct a ProductScanService with all repos mocked."""
+    svc = ProductScanService(
+        session=MagicMock(),
+        settings=settings or _settings_stub(),
+    )
+    svc.session.flush = AsyncMock()
+    svc.catalog_repo = MagicMock()
+    svc.catalog_repo.list_active_by_video = AsyncMock(return_value=[])
+    svc.appearance_repo = MagicMock()
+    svc.job_repo = MagicMock()
+    svc.cost_repo = MagicMock()
+    svc.cost_repo.get_today_cost = AsyncMock(return_value=Decimal("0"))
+    svc.job_repo.count_active_for_org = AsyncMock(return_value=0)
+    svc.job_repo.find_recent_scan_order_duplicate = AsyncMock(return_value=None)
+    return svc
+
+
+def _scan_order_body(**overrides):
+    defaults = {
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+    }
+    defaults.update(overrides)
+    return ScanOrderCreateRequest(**defaults)
+
+
+# ======================================================================
+# compute_settings_hash — canonical-JSON SHA256
+# ======================================================================
+
+
+def test_settings_hash_is_deterministic():
+    """Same inputs → same hash. Output is a 64-char hex digest."""
+    args = {
+        "video_id": UUID("11111111-1111-1111-1111-111111111111"),
+        "user_id": UUID("22222222-2222-2222-2222-222222222222"),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+        "active_catalog_entry_ids": ["aaa", "bbb", "ccc"],
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+    h1 = compute_settings_hash(**args)
+    h2 = compute_settings_hash(**args)
+    assert h1 == h2
+    assert len(h1) == 64
+    assert all(c in "0123456789abcdef" for c in h1)
+
+
+def test_settings_hash_intent_separates_preview_from_commit():
+    """Codex Q3: preview and commit MUST produce different hashes
+    even with otherwise-identical inputs.
+    """
+    args = {
+        "video_id": uuid4(),
+        "user_id": uuid4(),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "active_catalog_entry_ids": [],
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+    preview_hash = compute_settings_hash(intent="preview", **args)
+    commit_hash = compute_settings_hash(intent="commit", **args)
+    assert preview_hash != commit_hash
+
+
+def test_settings_hash_catalog_set_changes_hash():
+    """Rescan that produces new catalog entries must change the hash
+    (the catalog set is the version signal — codex confirmed this
+    avoids needing a separate catalog_version column).
+    """
+    base = {
+        "video_id": uuid4(),
+        "user_id": uuid4(),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+    h_a = compute_settings_hash(active_catalog_entry_ids=["e1", "e2"], **base)
+    h_b = compute_settings_hash(active_catalog_entry_ids=["e1", "e2", "e3"], **base)
+    assert h_a != h_b
+
+
+def test_settings_hash_tracker_version_changes_hash():
+    """Codex Q3: model bumps invalidate dedupe so re-running after
+    a deploy gets fresh output instead of stale cached results.
+    """
+    base = {
+        "video_id": uuid4(),
+        "user_id": uuid4(),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+        "active_catalog_entry_ids": [],
+        "enumeration_prompt_version": "v1.0",
+    }
+    h_old = compute_settings_hash(tracker_version="v1.0", **base)
+    h_new = compute_settings_hash(tracker_version="v2.0", **base)
+    assert h_old != h_new
+
+
+def test_settings_hash_canonical_json_is_key_order_insensitive():
+    """Canonical JSON sorts keys, so dict ordering at the call site
+    must not affect the hash. Verified by inspecting that the
+    function is deterministic across multiple invocations with the
+    same kwargs (Python dict order is insertion-sensitive in 3.7+).
+    """
+    args_1 = {
+        "video_id": uuid4(),
+        "user_id": uuid4(),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+        "active_catalog_entry_ids": [],
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+    h1 = compute_settings_hash(**args_1)
+    # Reconstruct with reversed kwarg order
+    args_2 = dict(reversed(list(args_1.items())))
+    h2 = compute_settings_hash(**args_2)
+    assert h1 == h2
+
+
+# ======================================================================
+# _validate_scan_order_inputs — codex Q5 aggregate cap + time range
+# ======================================================================
+
+
+def test_validate_aggregate_cap_under_limit_passes():
+    """count=15 × length=120 = 1800 — exactly at the cap, accepted."""
+    body = _scan_order_body(requested_count=15, length_seconds=120)
+    _validate_scan_order_inputs(body=body)
+
+
+def test_validate_aggregate_cap_over_limit_422():
+    """count=20 × length=120 = 2400 → 422 with clear message."""
+    body = _scan_order_body(requested_count=20, length_seconds=120)
+    with pytest.raises(HTTPException) as exc:
+        _validate_scan_order_inputs(body=body)
+    assert exc.value.status_code == 422
+    assert "1800" in str(exc.value.detail)
+
+
+def test_validate_time_range_partial_422():
+    """Setting only start (not end) — 422."""
+    body = _scan_order_body(time_range_start_ms=1000)
+    with pytest.raises(HTTPException) as exc:
+        _validate_scan_order_inputs(body=body)
+    assert exc.value.status_code == 422
+
+
+def test_validate_time_range_inverted_422():
+    """end <= start — 422."""
+    body = _scan_order_body(
+        time_range_start_ms=5000,
+        time_range_end_ms=2000,
+        requested_count=2,  # so the per-short check doesn't fire first
+    )
+    with pytest.raises(HTTPException) as exc:
+        _validate_scan_order_inputs(body=body)
+    assert exc.value.status_code == 422
+
+
+def test_validate_time_range_too_short_per_short_422():
+    """count=10 shorts × 60s each = 600s required source.
+    Range = 300s → 30s/short → 422.
+    """
+    body = _scan_order_body(
+        length_seconds=60,
+        requested_count=10,
+        time_range_start_ms=0,
+        time_range_end_ms=300_000,
+    )
+    with pytest.raises(HTTPException) as exc:
+        _validate_scan_order_inputs(body=body)
+    assert exc.value.status_code == 422
+    assert "source" in str(exc.value.detail)
+
+
+def test_validate_time_range_sufficient_passes():
+    """count=5 × 60s each = 300s required.
+    Range = 600s → 120s/short → passes.
+    """
+    body = _scan_order_body(
+        length_seconds=60,
+        requested_count=5,
+        time_range_start_ms=0,
+        time_range_end_ms=600_000,
+    )
+    _validate_scan_order_inputs(body=body)
+
+
+# ======================================================================
+# ProductScanService.enqueue_scan_order
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_happy_path_creates_parent():
+    """End-to-end: validation passes → settings_hash computed →
+    no dedupe match → parent row created → response returned."""
+    svc = _build_service()
+    org_id = uuid4()
+    video_id = uuid4()
+    user_id = uuid4()
+
+    parent = MagicMock()
+    parent.id = uuid4()
+    svc.job_repo.create_scan_order_parent = AsyncMock(return_value=parent)
+
+    body = _scan_order_body(
+        length_seconds=60, requested_count=5,
+        product_distribution="single", language="ko", intent="commit",
+    )
+    resp = await svc.enqueue_scan_order(
+        org_id=org_id, video_id=video_id, user_id=user_id, body=body,
+    )
+    assert resp.parent_job_id == parent.id
+    assert resp.deduped is False
+    # Verify settings_hash was passed and is a 64-char hex string.
+    call_kwargs = svc.job_repo.create_scan_order_parent.await_args.kwargs
+    assert len(call_kwargs["settings_hash"]) == 64
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_dedupes_within_window():
+    """Existing parent with matching settings_hash → return existing
+    job_id with deduped=True; no new row created.
+    """
+    svc = _build_service()
+    org_id = uuid4()
+    user_id = uuid4()
+    existing_parent = MagicMock()
+    existing_parent.id = uuid4()
+    svc.job_repo.find_recent_scan_order_duplicate = AsyncMock(
+        return_value=existing_parent,
+    )
+    svc.job_repo.create_scan_order_parent = AsyncMock()
+
+    resp = await svc.enqueue_scan_order(
+        org_id=org_id, video_id=uuid4(), user_id=user_id, body=_scan_order_body(),
+    )
+    assert resp.deduped is True
+    assert resp.parent_job_id == existing_parent.id
+    svc.job_repo.create_scan_order_parent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_aggregate_cap_422():
+    svc = _build_service()
+    body = _scan_order_body(requested_count=20, length_seconds=120)
+    with pytest.raises(HTTPException) as exc:
+        await svc.enqueue_scan_order(
+            org_id=uuid4(), video_id=uuid4(), user_id=uuid4(), body=body,
+        )
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_budget_402():
+    settings = _settings_stub(auto_shorts_product_v2_daily_budget_usd=10.0)
+    svc = _build_service(settings=settings)
+    svc.cost_repo.get_today_cost = AsyncMock(return_value=Decimal("10.5"))
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.enqueue_scan_order(
+            org_id=uuid4(), video_id=uuid4(), user_id=uuid4(), body=_scan_order_body(),
+        )
+    assert exc.value.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_concurrency_429():
+    svc = _build_service()
+    svc.job_repo.count_active_for_org = AsyncMock(return_value=3)
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.enqueue_scan_order(
+            org_id=uuid4(), video_id=uuid4(), user_id=uuid4(), body=_scan_order_body(),
+        )
+    assert exc.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_disabled_404():
+    settings = _settings_stub(auto_shorts_product_v2_enabled=False)
+    svc = _build_service(settings=settings)
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.enqueue_scan_order(
+            org_id=uuid4(), video_id=uuid4(), user_id=uuid4(), body=_scan_order_body(),
+        )
+    assert exc.value.status_code == 404
+
+
+# ======================================================================
+# ProductScanService.get_scan_order_status
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_scan_order_status_aggregates_children():
+    """Parent + 3 children (1 done, 1 failed, 1 in-flight) → response
+    carries rollup counters for the wizard's progress UI.
+    """
+    svc = _build_service()
+    parent_id = uuid4()
+    org_id = uuid4()
+
+    parent = MagicMock()
+    parent.id = parent_id
+    parent.mode = SCAN_MODE_SCAN_ORDER
+    parent.catalog_entry_id = None
+    parent.parent_job_id = None
+    parent.shorts_index = None
+    parent.render_job_id = None
+    parent.stage = "fanned_out"
+    parent.progress_pct = 100
+    parent.progress_label = None
+    parent.completed_at = None
+    parent.failed_at = None
+    parent.cancelled_at = None
+    parent.error_code = None
+    parent.error_message = None
+    parent.cost_usd_estimate = Decimal("0.5")
+
+    def _child(idx, *, stage, completed_at=None, failed_at=None):
+        c = MagicMock()
+        c.id = uuid4()
+        c.mode = SCAN_MODE_RENDER_CHILD
+        c.catalog_entry_id = None
+        c.parent_job_id = parent_id
+        c.shorts_index = idx
+        c.render_job_id = uuid4() if completed_at else None
+        c.stage = stage
+        c.progress_pct = 100 if completed_at else (50 if not failed_at else 0)
+        c.progress_label = None
+        c.completed_at = completed_at
+        c.failed_at = failed_at
+        c.cancelled_at = None
+        c.error_code = None
+        c.error_message = None
+        c.cost_usd_estimate = Decimal("0")
+        return c
+
+    from datetime import datetime, timezone
+    children = [
+        _child(1, stage=SCAN_STAGE_DONE, completed_at=datetime.now(timezone.utc)),
+        _child(2, stage=SCAN_STAGE_FAILED, failed_at=datetime.now(timezone.utc)),
+        _child(3, stage="rendering"),
+    ]
+    svc.job_repo.get_scan_order_with_children = AsyncMock(
+        return_value=(parent, children),
+    )
+
+    resp = await svc.get_scan_order_status(
+        org_id=org_id, parent_job_id=parent_id,
+    )
+    assert resp.parent.kind == "scan_order"
+    assert resp.parent.render_job_id is None  # Q4 invariant
+    assert len(resp.children) == 3
+    assert resp.children_total == 3
+    assert resp.children_complete == 1
+    assert resp.children_failed == 1
+
+
+@pytest.mark.asyncio
+async def test_get_scan_order_status_404_when_missing():
+    svc = _build_service()
+    svc.job_repo.get_scan_order_with_children = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.get_scan_order_status(
+            org_id=uuid4(), parent_job_id=uuid4(),
+        )
+    assert exc.value.status_code == 404
+
+
+# ======================================================================
+# ProductScanService.cancel_scan_order
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_cancel_scan_order_cascades():
+    svc = _build_service()
+    parent = MagicMock()
+    parent.mode = SCAN_MODE_SCAN_ORDER
+    svc.job_repo.get = AsyncMock(return_value=parent)
+    # 1 parent + 3 children all transitioned
+    svc.job_repo.cancel_scan_order = AsyncMock(return_value=4)
+
+    await svc.cancel_scan_order(org_id=uuid4(), parent_job_id=uuid4())
+    svc.job_repo.cancel_scan_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_scan_order_404_when_missing():
+    svc = _build_service()
+    svc.job_repo.get = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.cancel_scan_order(org_id=uuid4(), parent_job_id=uuid4())
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_scan_order_404_when_already_terminal():
+    svc = _build_service()
+    parent = MagicMock()
+    parent.mode = SCAN_MODE_SCAN_ORDER
+    svc.job_repo.get = AsyncMock(return_value=parent)
+    svc.job_repo.cancel_scan_order = AsyncMock(return_value=0)  # nothing to cancel
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.cancel_scan_order(org_id=uuid4(), parent_job_id=uuid4())
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_scan_order_404_when_wrong_mode():
+    """Targeting a non-scan_order job for cancel via this endpoint
+    must 404 (legacy enumerate / clip jobs use the existing
+    /jobs/{id}/cancel endpoint)."""
+    svc = _build_service()
+    parent = MagicMock()
+    parent.mode = "enumerate"  # not scan_order
+    svc.job_repo.get = AsyncMock(return_value=parent)
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.cancel_scan_order(org_id=uuid4(), parent_job_id=uuid4())
+    assert exc.value.status_code == 404
+
+
+# ======================================================================
+# ProductScanService.commit_scan_order — Phase 6 stub
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_commit_scan_order_returns_501():
+    svc = _build_service()
+    with pytest.raises(HTTPException) as exc:
+        await svc.commit_scan_order(
+            org_id=uuid4(),
+            parent_job_id=uuid4(),
+            selected_window_ids=None,
+        )
+    assert exc.value.status_code == 501
+    assert "Phase 6" in exc.value.detail


### PR DESCRIPTION
## Summary

The wizard's parent-job orchestration plumbing — service-layer code that creates parent `ProductScanJob` rows from the 4-step wizard inputs, plus the public REST endpoints the frontend wizard will subscribe to. Builds on PR #114 (foundation: schema + mode dispatch).

Plan: `.claude/plans/shorts-auto-product-v2-phase-4-7.md` §4 + §6.2.

### What ships

* **`compute_settings_hash`** — canonical-JSON SHA256 (codex-corrected from the original pipe-joined sketch). Hash payload includes `intent`, the active catalog set, `tracker_version`, and `enumeration_prompt_version` so model bumps invalidate dedupe and preview/commit can't collide.
* **`ProductScanService.enqueue_scan_order`** — pre-flight gate chain (flag → budget → idempotency → concurrency) + parent row creation. Aggregate cap (`count*length<=1800`) enforced both as a service-layer 422 (descriptive frontend error) and as a DB CHECK (`ck_psj_aggregate_output` from PR #114).
* **`ProductScanService.get_scan_order_status`** — aggregate read for the wizard's polling subscription. Parent + all children + rollup counters in one round-trip. Codex Q2 contract correction — wizard polls THIS, not N+1 `/jobs/{id}` endpoints.
* **`ProductScanService.cancel_scan_order`** — cascading cancel (parent + non-terminal children).
* **`ProductScanService.commit_scan_order`** — Phase 6 stub returning 501. Body shape locked now so the frontend wizard can be built against a stable contract.
* **Repo extensions on `ProductScanJobRepository`**: `create_scan_order_parent`, `create_render_children`, `find_recent_scan_order_duplicate`, `find_children_for_parent`, `find_queued_render_children` (PR #3 runner's poll), `cancel_scan_order`, `get_scan_order_with_children`. `claim()` accepts `SCAN_STAGE_ASSEMBLING` so the runner can claim queued → assembling cleanly.
* **New routes**: `POST /api/shorts/auto/scan-orders/videos/{video_id}`, `GET /api/shorts/auto/scan-orders/{parent_job_id}`, `POST /api/shorts/auto/scan-orders/{parent_job_id}/cancel`, `POST /api/shorts/auto/scan-orders/{parent_job_id}/commit` (501).
* **Config**: `PRODUCT_V2_CHILD_RUNNER_*` env vars (consumed in PR #3), `PRODUCT_V2_SCAN_ORDER_IDEMPOTENCY_SECONDS`, child runner enable switch.

### Out of scope (deferred to subsequent PRs)

* **PR #3**: SQS publish for `mode='scan_order'` parents + child runner asyncio loop in `app.main:lifespan` + worker refactor in `services/product-track-worker/` to handle the new mode + contracts v0.14.0 publish. Without these, parent rows persist in stage='queued' but no worker consumes them — intentional, keeps PR #2 testable in isolation without DLQ noise from the existing worker rejecting the new mode.
* **PR #4**: Frontend wizard `features/shorts-auto-product-wizard/`.

## Test plan

- [x] **24 new unit tests** in `tests/test_shorts_auto_product_scan_order.py`:
  - `compute_settings_hash` determinism, intent separation (preview vs commit), catalog-set sensitivity, tracker_version sensitivity, key-order insensitivity (canonical-JSON regression).
  - `_validate_scan_order_inputs` aggregate cap, time-range partial / inverted / per-short-budget cases.
  - `enqueue_scan_order` happy path, dedupe, validation 422s, budget 402, concurrency 429, disabled 404.
  - `get_scan_order_status` aggregate shape with rollup counters + Q4 invariant (parent's `render_job_id` always None in response).
  - `cancel_scan_order` cascade, missing 404, already-terminal 404, wrong-mode 404.
  - `commit_scan_order` Phase 6 stub returns 501.
- [x] **84 tests pass across the full `shorts_auto_product` module** (60 from PR #114 + 24 new).
- [x] **339 CI allowlist tests green** locally.

## Risk

- **Scope-risk: narrow**. Additive — every new endpoint is a fresh path. Legacy enumerate / clip flows are untouched.
- **Constraint**: the SQS publish is intentionally NOT wired in this PR. PR #3 wires it alongside the worker refactor — landing it now would fill the existing track-worker's DLQ with messages it can't parse.
- **Constraint**: child runner asyncio loop also deferred to PR #3. Children rows are dormant until the runner ships, but the cancel-cascade path in this PR works without it.

## Stack

- ✅ PR #114 — Phase 4 foundation: schema + mode dispatch (merged as `ba2833c`)
- 🟡 **This PR** — Phase 4 PR #2: scan-order service + wizard endpoints
- ⏳ PR #3 — Phase 4 PR #3: child runner + SQS publish + worker refactor + contracts v0.14.0
- ⏳ PR #4 — Phase 4 PR #4: frontend wizard