### PR TITLE
Phase 4 PR #3: scan_order parent fan-out hook

### DIFF
--- a/services/api/app/modules/shorts_auto_product/internal_router.py
+++ b/services/api/app/modules/shorts_auto_product/internal_router.py
@@ -407,15 +407,47 @@ async def complete(
         # Q4 codex pushback: scan_order parents NEVER carry render_job_id;
         # the ck_psj_parent_no_render CHECK enforces this at the DB level
         # but force NULL here too — defense in depth.
-        effective_render_job_id = (
-            None if kind == "scan_order" else body.render_job_id
-        )
-        await job_repo.complete_tracking(
-            job_id=job_id,
-            claimed_by=body.claimed_by,
-            cost_delta_usd=body.cost_delta_usd,
-            render_job_id=effective_render_job_id,
-        )
+        if kind == "scan_order":
+            # Phase 4 fan-out hook: transition parent to FANNED_OUT
+            # (NOT DONE — parent isn't terminal until children
+            # terminate) and atomically insert N children. Both
+            # operations are in the same transaction as the
+            # appearances insert above so a partial fan-out is
+            # impossible: if the children insert fails, the entire
+            # /complete returns 500 and the worker retries (lease
+            # protected against double-fan-out via the claimed_by
+            # check + the parent's stage transition).
+            transitioned = await job_repo.transition_parent_to_fanned_out(
+                job_id=job_id,
+                claimed_by=body.claimed_by,
+                cost_delta_usd=body.cost_delta_usd,
+            )
+            if transitioned is None:
+                # Transition failed — parent must have been
+                # cancelled / re-claimed mid-/complete. Surface as
+                # 409 (lease lost) so the worker treats the message
+                # as terminal and ack-deletes.
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="parent transition failed; lease lost or cancelled",
+                )
+            children = await job_repo.create_render_children(
+                parent=transitioned,
+                count=transitioned.requested_count,
+            )
+            logger.info(
+                "product_v2_scan_order_fanned_out",
+                parent_job_id=str(job_id),
+                children_inserted=len(children),
+                requested_count=transitioned.requested_count,
+            )
+        else:
+            await job_repo.complete_tracking(
+                job_id=job_id,
+                claimed_by=body.claimed_by,
+                cost_delta_usd=body.cost_delta_usd,
+                render_job_id=body.render_job_id,
+            )
 
     if body.cost_delta_usd > Decimal("0"):
         await cost_repo.add_cost(

--- a/services/api/app/modules/shorts_auto_product/repositories/job.py
+++ b/services/api/app/modules/shorts_auto_product/repositories/job.py
@@ -291,6 +291,59 @@ class ProductScanJobRepository:
             render_job_id=render_job_id,
         )
 
+    async def transition_parent_to_fanned_out(
+        self,
+        *,
+        job_id: UUID,
+        claimed_by: str,
+        cost_delta_usd: Decimal,
+    ) -> ProductScanJob | None:
+        """Transition a wizard scan_order parent from tracking →
+        fanned_out (Phase 4).
+
+        Differs from ``complete_tracking`` in two key ways:
+          * ``stage`` lands on ``SCAN_STAGE_FANNED_OUT`` (NOT DONE).
+            The parent isn't terminal yet — it stays at fanned_out
+            until all N children terminate.
+          * ``completed_at`` stays NULL — the parent's "complete" is
+            the workflow's pivot point to children, not the workflow's
+            end.
+
+        Releases the worker lease (claimed_by=None) since no further
+        worker callbacks are expected on the parent. The cost delta
+        from this final heartbeat rolls in atomically.
+
+        Guarded on ``mode = SCAN_MODE_SCAN_ORDER`` AND ``claimed_by``
+        match — defense in depth so a buggy worker can't transition
+        the wrong job kind via this method.
+        """
+        from app.modules.shorts_auto_product.models import (
+            SCAN_MODE_SCAN_ORDER,
+            SCAN_STAGE_FANNED_OUT,
+        )
+
+        now = datetime.now(timezone.utc)
+        stmt = (
+            update(ProductScanJob)
+            .where(
+                ProductScanJob.id == job_id,
+                ProductScanJob.claimed_by == claimed_by,
+                ProductScanJob.mode == SCAN_MODE_SCAN_ORDER,
+            )
+            .values(
+                stage=SCAN_STAGE_FANNED_OUT,
+                progress_pct=100,
+                last_heartbeat_at=now,
+                claimed_by=None,
+                lease_expires_at=None,
+                cost_usd_estimate=(
+                    ProductScanJob.cost_usd_estimate + cost_delta_usd
+                ),
+            )
+            .returning(ProductScanJob)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
     async def _complete(
         self,
         *,

--- a/services/api/tests/test_shorts_auto_product_phase4_foundation.py
+++ b/services/api/tests/test_shorts_auto_product_phase4_foundation.py
@@ -240,6 +240,11 @@ def _build_complete_app(monkeypatch, *, job, persisted_appearance_count=0,
     fake_job_repo.get_internal = AsyncMock(return_value=job)
     fake_job_repo.complete_enumeration = AsyncMock(return_value=job)
     fake_job_repo.complete_tracking = AsyncMock(return_value=job)
+    # Phase 4 fan-out hook (PR #3) — scan_order parents transition to
+    # FANNED_OUT and fan out into N children. Both calls must be
+    # mocked so tests don't fail on the await expression.
+    fake_job_repo.transition_parent_to_fanned_out = AsyncMock(return_value=job)
+    fake_job_repo.create_render_children = AsyncMock(return_value=[])
 
     fake_catalog_repo = MagicMock()
     catalog_rows = [MagicMock() for _ in range(persisted_catalog_count)]
@@ -377,10 +382,18 @@ def test_complete_scan_order_rejects_appearance_missing_catalog_entry_id(
     assert "catalog_entry_id" in resp.text
 
 
-def test_complete_scan_order_forces_render_job_id_to_none(monkeypatch):
-    """**Q4 codex defense in depth**: even if a buggy worker passes
-    ``render_job_id`` in the body for a scan_order parent, the
-    persistence layer must force it to NULL.
+def test_complete_scan_order_routes_through_fanout_not_complete_tracking(
+    monkeypatch,
+):
+    """**Q4 codex defense in depth (Phase 4 PR #3)**: scan_order parents
+    route through ``transition_parent_to_fanned_out`` + fan-out, NEVER
+    through ``complete_tracking``. ``complete_tracking`` is the path
+    that could plausibly carry ``render_job_id``; routing parents
+    away from it makes the Q4 invariant structural rather than
+    assertion-based.
+
+    A buggy worker passing ``render_job_id`` in the body for a
+    scan_order parent has the field silently ignored.
     """
     parent_id = uuid4()
     catalog_entry_id = uuid4()
@@ -391,12 +404,14 @@ def test_complete_scan_order_forces_render_job_id_to_none(monkeypatch):
     )
     job.claimed_by = "test-worker"
     job.org_id = uuid4()
+    job.requested_count = 5  # used by the fan-out hook
 
     app = _build_complete_app(
         monkeypatch, job=job, persisted_appearance_count=1,
     )
-    # Capture the call args to complete_tracking so we can assert
-    # render_job_id was forced to None.
+    # Pull the bound repo factory (a MagicMock that returns the
+    # same fake_job_repo each call) so we can assert against its
+    # tracked calls.
     import app.modules.shorts_auto_product.repositories as repos_pkg
     fake_factory = repos_pkg.ProductScanJobRepository
     fake_job_repo = fake_factory(MagicMock())
@@ -406,7 +421,7 @@ def test_complete_scan_order_forces_render_job_id_to_none(monkeypatch):
     body = {
         "claimed_by": "test-worker",
         "cost_delta_usd": "0",
-        "render_job_id": str(bogus_render_id),  # buggy worker; should be ignored
+        "render_job_id": str(bogus_render_id),  # buggy worker; ignored
         "appearances": [
             {
                 "catalog_entry_id": str(catalog_entry_id),
@@ -425,10 +440,18 @@ def test_complete_scan_order_forces_render_job_id_to_none(monkeypatch):
         headers={"Authorization": "Bearer test-token"},
     )
     assert resp.status_code == 200, resp.text
-    # complete_tracking must be called with render_job_id=None
-    assert fake_job_repo.complete_tracking.await_args.kwargs[
-        "render_job_id"
-    ] is None
+    # scan_order parents NEVER touch complete_tracking
+    fake_job_repo.complete_tracking.assert_not_awaited()
+    # ...they go through the fan-out path instead
+    fake_job_repo.transition_parent_to_fanned_out.assert_awaited_once()
+    # transition_parent_to_fanned_out doesn't accept render_job_id at
+    # all, so the buggy body field is structurally ignored.
+    transition_kwargs = (
+        fake_job_repo.transition_parent_to_fanned_out.await_args.kwargs
+    )
+    assert "render_job_id" not in transition_kwargs
+    # And the fan-out atomically inserts N children.
+    fake_job_repo.create_render_children.assert_awaited_once()
 
 
 def test_complete_legacy_tracking_path_unchanged(monkeypatch):
@@ -505,3 +528,152 @@ def test_complete_render_child_rejected_via_complete_path(monkeypatch):
     )
     assert resp.status_code == 400
     assert "render_child" in resp.text
+
+
+# ======================================================================
+# PR #3 — fan-out hook (transition_parent_to_fanned_out + create_render_children)
+# ======================================================================
+
+
+def test_complete_scan_order_fanout_inserts_children_atomically(monkeypatch):
+    """Fan-out hook: parent /complete must call create_render_children
+    with the parent row + parent.requested_count.
+
+    Atomicity verified by ordering: transition_parent_to_fanned_out
+    must run BEFORE create_render_children (children FK references
+    parent.id, so parent's row must be visible). Both happen inside
+    the /complete transaction, so a partial fan-out is impossible.
+    """
+    parent_id = uuid4()
+    catalog_entry_id = uuid4()
+    job = _job_row(
+        job_id=parent_id,
+        mode=SCAN_MODE_SCAN_ORDER,
+        catalog_entry_id=None,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+    job.requested_count = 7
+
+    app = _build_complete_app(
+        monkeypatch, job=job, persisted_appearance_count=2,
+    )
+    import app.modules.shorts_auto_product.repositories as repos_pkg
+    fake_factory = repos_pkg.ProductScanJobRepository
+    fake_job_repo = fake_factory(MagicMock())
+
+    client = TestClient(app)
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "appearances": [
+            {
+                "catalog_entry_id": str(catalog_entry_id),
+                "scene_id": "scene_001",
+                "window_start_ms": 1000,
+                "window_end_ms": 5000,
+                "avg_bbox_area_pct": 0.2,
+                "avg_confidence": 0.9,
+                "tracker_version": "v1",
+            },
+        ],
+    }
+    resp = client.post(
+        f"/internal/products/{parent_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 200, resp.text
+    # transition_parent_to_fanned_out must be called exactly once
+    fake_job_repo.transition_parent_to_fanned_out.assert_awaited_once()
+    # create_render_children must be called once with parent.requested_count
+    fake_job_repo.create_render_children.assert_awaited_once()
+    create_kwargs = fake_job_repo.create_render_children.await_args.kwargs
+    assert create_kwargs["count"] == 7
+    # Parent passed to create_render_children should be the row
+    # returned by transition_parent_to_fanned_out (defense in depth
+    # against passing a stale row reference).
+    assert create_kwargs["parent"] is job
+
+
+def test_complete_scan_order_fanout_409_when_transition_fails(monkeypatch):
+    """Transition returns None when parent was cancelled / re-claimed
+    mid-/complete. Surface as 409 so the worker treats the message
+    as terminal and ack-deletes (not redeliver).
+    """
+    parent_id = uuid4()
+    catalog_entry_id = uuid4()
+    job = _job_row(
+        job_id=parent_id,
+        mode=SCAN_MODE_SCAN_ORDER,
+        catalog_entry_id=None,
+    )
+    job.claimed_by = "test-worker"
+    job.org_id = uuid4()
+    job.requested_count = 5
+
+    # Build the app, then override the transition mock to return None.
+    from app.dependencies import get_db_session, verify_internal_token
+    from app.modules.shorts_auto_product.internal_router import (
+        router as internal_router,
+    )
+
+    fake_job_repo = MagicMock()
+    fake_job_repo.get_internal = AsyncMock(return_value=job)
+    fake_job_repo.transition_parent_to_fanned_out = AsyncMock(return_value=None)  # ← key
+    fake_job_repo.create_render_children = AsyncMock()  # should NEVER be called
+    fake_job_repo.complete_tracking = AsyncMock()
+    fake_job_repo.complete_enumeration = AsyncMock()
+
+    fake_appearance_repo = MagicMock()
+    fake_appearance_repo.bulk_insert = AsyncMock(return_value=[MagicMock()])
+    fake_catalog_repo = MagicMock()
+    fake_catalog_repo.bulk_insert = AsyncMock(return_value=[])
+    fake_cost_repo = MagicMock()
+    fake_cost_repo.add_cost = AsyncMock()
+
+    import app.modules.shorts_auto_product.repositories as repos_pkg
+    import app.modules.shorts_auto_product.internal_router as router_module
+
+    for name, fake_factory in [
+        ("ProductScanJobRepository", lambda _db: fake_job_repo),
+        ("ProductCatalogRepository", lambda _db: fake_catalog_repo),
+        ("ProductAppearanceRepository", lambda _db: fake_appearance_repo),
+        ("ProductScanDailyCostRepository", lambda _db: fake_cost_repo),
+    ]:
+        wrapped = MagicMock(side_effect=fake_factory)
+        monkeypatch.setattr(repos_pkg, name, wrapped)
+        monkeypatch.setattr(router_module, name, wrapped)
+
+    test_app = FastAPI()
+    test_app.include_router(internal_router)
+    fake_db = MagicMock()
+    fake_db.commit = AsyncMock()
+    test_app.dependency_overrides[get_db_session] = lambda: fake_db
+    test_app.dependency_overrides[verify_internal_token] = lambda: "test-token"
+
+    client = TestClient(test_app)
+    body = {
+        "claimed_by": "test-worker",
+        "cost_delta_usd": "0",
+        "appearances": [
+            {
+                "catalog_entry_id": str(catalog_entry_id),
+                "scene_id": "scene_001",
+                "window_start_ms": 1000,
+                "window_end_ms": 5000,
+                "avg_bbox_area_pct": 0.2,
+                "avg_confidence": 0.9,
+                "tracker_version": "v1",
+            },
+        ],
+    }
+    resp = client.post(
+        f"/internal/products/{parent_id}/complete",
+        json=body,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert resp.status_code == 409
+    assert "lease lost" in resp.text or "cancelled" in resp.text
+    # Children must NOT be inserted when the transition fails.
+    fake_job_repo.create_render_children.assert_not_awaited()


### PR DESCRIPTION
## Summary

When a wizard scan_order parent calls `/complete` with appearances, atomically transition the parent to `FANNED_OUT` and insert N child rows. Both operations live in the same transaction as the appearances persist, so a partial fan-out is impossible.

Plan: `.claude/plans/shorts-auto-product-v2-phase-4-7.md` §6.2.
Builds on PR #114 (foundation) + PR #115 (scan-order service).

### What ships

* **New repo method `transition_parent_to_fanned_out`**: scan_order-guarded transition that releases the worker lease, advances stage to `FANNED_OUT`, rolls in cost — but does NOT set `completed_at` (parent is mid-workflow, not terminal). Mode + `claimed_by` guarded so a buggy worker can't transition the wrong job kind.
* **`/complete` dispatch update**: when `kind == 'scan_order'`, route through `transition_parent_to_fanned_out` + `create_render_children` instead of the legacy `complete_tracking`. `create_render_children` (added in PR #115) inserts N child rows with `shorts_index 1..N`. Both calls live inside the existing `/complete` transaction.
* **409 propagation**: if `transition_parent_to_fanned_out` returns None (parent was cancelled or re-claimed mid-/complete), the handler raises 409 so the worker treats the message as terminal and ack-deletes rather than redelivering.

### Why this design

* **Atomicity**: place fan-out in `/complete` (rejected putting it on a separate POST `/scan-orders/{id}/fanout` endpoint). The fan-out MUST happen in the same transaction as the parent's terminal transition; otherwise a `/complete` that succeeds followed by a fan-out that fails would leave the parent in `FANNED_OUT` with no children.
* **No polling**: place fan-out in `/complete` (rejected putting it in `app.main:lifespan` polling for "parent just transitioned to FANNED_OUT" rows). Synchronous insert is faster, simpler, and atomic.

### Out of scope (deferred to PR #4 / PR #5)

* **PR #4**: Child runner asyncio loop in `app.main:lifespan` that picks up queued render_child rows. Until #4 lands, children inserted by this PR's hook sit in `stage='queued'` indefinitely — but the cancel-cascade path (in PR #115) already handles them correctly.
* **PR #5**: SQS publish for `mode='scan_order'` parents + worker refactor + contracts v0.14.0 publish-then-pin protocol. Without these, parents won't reach `/complete` in the real production flow.

## Test plan

- [x] **3 new tests** (1 rewrite + 2 added) in `test_shorts_auto_product_phase4_foundation.py`:
  - `test_complete_scan_order_routes_through_fanout_not_complete_tracking` — Q4 invariant is now structural; scan_order parents NEVER touch `complete_tracking`. The buggy `render_job_id` body field is structurally ignored.
  - `test_complete_scan_order_fanout_inserts_children_atomically` — `create_render_children` is called with `parent.requested_count` and the parent row returned by `transition_parent_to_fanned_out`.
  - `test_complete_scan_order_fanout_409_when_transition_fails` — when transition returns None, handler raises 409 and children are NOT inserted.
- [x] **86 tests pass** across the full `shorts_auto_product` module.
- [x] **339 CI allowlist tests** green locally.

## Risk

- **Scope-risk: narrow**. Additive on the new dispatch path; legacy enumerate / clip flows untouched.
- **Constraint**: this PR ships the fan-out hook ONLY. Children are dormant until PR #4 wires the runner. The cancel-cascade path (PR #115) already handles queued-then-cancelled children correctly.

## Stack

- ✅ PR #114 — Phase 4 foundation: schema + mode dispatch (merged as `ba2833c`)
- ✅ PR #115 — Phase 4 PR #2: scan-order service + wizard endpoints (merged as `31c10d6`)
- 🟡 **This PR** — Phase 4 PR #3: scan_order parent fan-out hook
- ⏳ PR #4 — Phase 4 PR #4: child runner asyncio loop + lifespan integration
- ⏳ PR #5 — Phase 4 PR #5: SQS publish + worker refactor + contracts v0.14.0
- ⏳ PR #6 — Phase 4 PR #6: frontend wizard