### PR TITLE
Phase 4 PR #4: wizard child runner infrastructure (stub)

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -93,6 +93,22 @@ async def lifespan(app: FastAPI):
     await _ensure_search_event_partitions(engine)
     await _ensure_worker_event_partitions(engine)
 
+    # Phase 4 wizard child runner — picks up queued ``mode='render_child'``
+    # rows produced by the parent fan-out hook in
+    # ``shorts_auto_product.internal_router.complete``. One runner per
+    # API replica; DB-atomic claim resolves the race across replicas.
+    # Stub processing in PR #4 (claim → /complete with render_job_id=None);
+    # real picker + render-service integration in PR #5.
+    from app.db.base import get_async_session_factory
+    from app.modules.shorts_auto_product.children import create_child_runner
+
+    child_runner = create_child_runner(
+        settings=settings,
+        session_factory=get_async_session_factory(),
+    )
+    child_runner.start()
+    app.state.product_v2_child_runner = child_runner
+
     if settings.embedding_use_mock:
         logger.warning(
             "embedding_mock_mode_active",
@@ -117,6 +133,15 @@ async def lifespan(app: FastAPI):
     await scene_opensearch_client.close()
     app.state.opensearch_client = None
     app.state.scene_opensearch_client = None
+
+    # Drain the wizard child runner before disposing the engine.
+    # In-flight children get up to 30s to /complete; tasks still
+    # running after the timeout are cancelled and the lease will
+    # expire so another replica re-claims on its next poll.
+    runner = getattr(app.state, "product_v2_child_runner", None)
+    if runner is not None:
+        await runner.stop(drain_timeout_seconds=30.0)
+        app.state.product_v2_child_runner = None
 
     await engine.dispose()
 

--- a/services/api/app/modules/shorts_auto_product/children/__init__.py
+++ b/services/api/app/modules/shorts_auto_product/children/__init__.py
@@ -1,0 +1,31 @@
+"""Wizard child runner — Phase 4 PR #4.
+
+This sub-package is a closed boundary inside ``app.modules.shorts_auto_product``.
+The child runner is the in-API-process consumer of ``mode='render_child'``
+rows produced by the parent fan-out hook (``internal_router.complete``).
+
+Loose-coupling rules (plan §15):
+* The runner does NOT cross-import other ``app.modules.*`` packages.
+* The runner CAN import ``heimdex_media_pipelines.product_track``
+  (picker + stitch_plan) and ``app.dependencies.get_shorts_render_service``
+  — both are explicitly allowed exceptions per the plan, since the
+  runner is the API's reuse seam for the same logic that the worker
+  uses on the GPU side.
+* The runner uses its own module's repos + models for DB ops.
+
+Phase 4 PR #4 (this PR) ships the infrastructure with a STUB processing
+step. PR #5 replaces the stub with the real picker + render-enqueue
+integration once contracts v0.14.0 is published and the worker refactor
+exists to actually populate the parent's appearances. Until PR #5
+lands, children claimed by this runner /complete with
+``render_job_id=None`` — the wizard frontend (PR #6) is the first
+caller that observes this state, so the stubbed semantics never reach
+production users.
+"""
+
+from app.modules.shorts_auto_product.children.runner import (
+    ChildRunner,
+    create_child_runner,
+)
+
+__all__ = ["ChildRunner", "create_child_runner"]

--- a/services/api/app/modules/shorts_auto_product/children/runner.py
+++ b/services/api/app/modules/shorts_auto_product/children/runner.py
@@ -1,0 +1,414 @@
+"""Wizard child runner — Phase 4 PR #4.
+
+Long-lived asyncio background task that picks up queued
+``mode='render_child'`` rows produced by the parent fan-out hook
+(``internal_router.complete``), claims them via the existing
+DB-atomic lease machinery, and processes them.
+
+## Architecture
+
+* **Single instance per API replica.** The runner is started once in
+  ``app.main:lifespan``. Multiple replicas of the API run multiple
+  runners concurrently; the DB-atomic ``ProductScanJobRepository.claim``
+  is the race resolver — exactly one replica wins each child.
+* **Bounded concurrency** via ``asyncio.Semaphore``. Default 4 per
+  replica (tunable via ``auto_shorts_product_v2_child_runner_max_concurrency``).
+* **Polling cadence** = 5s (tunable). The poll query is cheap (partial
+  index ``ix_product_scan_jobs_child_queue`` covers it) so we can
+  afford a short interval without burning DB cycles on idle replicas.
+* **No work-stealing across replicas mid-flight**. Once a replica
+  claims a child, the lease (default 300s) gives it that long to
+  /complete. If it crashes mid-flight, the lease eventually expires
+  and another replica re-claims via the same poll path.
+
+## Loose-coupling boundary (plan §15)
+
+The runner imports:
+
+* ``app.modules.shorts_auto_product.repositories.job`` — its own module's repo.
+* ``app.modules.shorts_auto_product.models`` — its own module's constants.
+* ``app.db.base.get_async_session_factory`` — the shared async session
+  factory (used by every background task in this codebase, mirrors
+  ``app.modules.worker_events.recorder``).
+* ``app.config.Settings`` — read-only.
+* ``app.logging_config`` — structured logger.
+
+The runner does NOT import:
+
+* Any other ``app.modules.*`` package (no cross-module coupling).
+* ``heimdex_media_pipelines`` directly in this PR — the picker
+  integration is wired in PR #5 alongside the worker refactor that
+  populates parent appearances. PR #4 keeps the runner pipeline-lib-free
+  so the API doesn't grow a new ML dependency until the worker side
+  is ready to feed it real data.
+
+## Phase 4 PR #4 stub semantics
+
+PR #4 ships the **infrastructure only**. The processing step is
+deliberately stubbed: claim → noop → /complete with
+``render_job_id=None``. This:
+
+* Proves the runner's claim race + bounded concurrency + lease lifecycle
+  work end-to-end.
+* Lets the wizard frontend (PR #6) be developed against a runner that
+  actually transitions children through the full state machine.
+* Avoids dragging the heimdex-media-pipelines dependency into the API
+  service before contracts v0.14.0 ships in PR #5.
+
+PR #5 replaces the stub with the real picker + stitch-plan + render
+service call. The dispatch is intentionally narrow (one method —
+``_process_child_payload``) so PR #5's diff is contained.
+
+The runner is gated behind ``auto_shorts_product_v2_child_runner_enabled``
+which **defaults to True** but is easy to flip off if PR #4 rolls out
+ahead of the rest of the wizard surface area.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from typing import AsyncIterator, Awaitable, Callable
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.config import Settings
+from app.modules.shorts_auto_product.models import (
+    SCAN_STAGE_ASSEMBLING,
+)
+from app.modules.shorts_auto_product.repositories.job import (
+    ProductScanJobRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Type alias for an async session-yielding callable. Production wires
+# this to ``app.db.base.get_async_session_factory()``; tests inject a
+# stub that yields a mock session.
+SessionFactory = Callable[[], AsyncIterator[AsyncSession]]
+
+
+def _default_instance_id() -> str:
+    """Identifier embedded in ``claimed_by`` so logs trace which API
+    replica processed a given child. ``HOSTNAME`` is set by every
+    container runtime we deploy on (Docker, Aircloud, ECS); fall
+    back to the OS hostname for dev.
+    """
+    return os.getenv("HOSTNAME") or socket.gethostname() or "api-unknown"
+
+
+class ChildRunner:
+    """In-API-process child runner for the Phase 4 wizard.
+
+    Lifecycle:
+
+      1. ``start()`` schedules the main loop as an asyncio task and
+         returns immediately. The caller (app.main:lifespan) awaits
+         the returned task at shutdown.
+      2. The loop polls every ``poll_seconds`` for queued children,
+         dispatches them via ``asyncio.create_task`` under the bounded
+         semaphore.
+      3. ``stop()`` sets the shutdown event. The loop exits at the
+         next poll boundary; in-flight tasks finish their current
+         iteration (lease-protected, so a hard kill at this point
+         would just cause the lease to expire and another replica
+         to re-claim — no orphaned rows).
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        session_factory: async_sessionmaker[AsyncSession],
+        instance_id: str | None = None,
+        process_child_fn: Callable[[UUID], Awaitable[None]] | None = None,
+    ) -> None:
+        self.settings = settings
+        self.session_factory = session_factory
+        self.instance_id = instance_id or _default_instance_id()
+        # Allow tests to inject a fake processor that doesn't actually
+        # call repo / render service. Production callers leave this
+        # None and the real ``_process_child_payload`` runs.
+        self._process_child_fn = process_child_fn or self._process_child_payload
+        self._stop_event = asyncio.Event()
+        self._semaphore = asyncio.Semaphore(
+            settings.auto_shorts_product_v2_child_runner_max_concurrency
+        )
+        self._task: asyncio.Task[None] | None = None
+        self._inflight: set[asyncio.Task[None]] = set()
+
+    @property
+    def claimed_by(self) -> str:
+        """Identifier persisted on ``ProductScanJob.claimed_by`` —
+        ``api-child-{instance_id}``. The ``api-child-`` prefix
+        distinguishes this runner from worker-side claims (which use
+        ``settings.worker_id``).
+        """
+        return f"api-child-{self.instance_id}"
+
+    def start(self) -> asyncio.Task[None]:
+        """Schedule the main loop. Idempotent — calling start twice
+        on the same instance is a no-op (returns the existing task).
+        """
+        if self._task is not None and not self._task.done():
+            return self._task
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._loop(), name="shorts-child-runner")
+        return self._task
+
+    async def stop(self, *, drain_timeout_seconds: float = 30.0) -> None:
+        """Request shutdown. Waits up to ``drain_timeout_seconds`` for
+        in-flight children to complete; tasks still running after the
+        timeout will be cancelled (the lease will eventually expire
+        and another replica will re-claim).
+        """
+        self._stop_event.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=drain_timeout_seconds)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "child_runner_stop_timeout_cancelling",
+                    extra={
+                        "drain_timeout_seconds": drain_timeout_seconds,
+                        "inflight": len(self._inflight),
+                    },
+                )
+                self._task.cancel()
+                # Best-effort cancel of in-flight per-child tasks.
+                for t in list(self._inflight):
+                    t.cancel()
+
+    async def _loop(self) -> None:
+        """Main poll loop. Exits when ``_stop_event`` is set."""
+        poll_seconds = self.settings.auto_shorts_product_v2_child_runner_poll_seconds
+        if not self.settings.auto_shorts_product_v2_child_runner_enabled:
+            logger.info(
+                "child_runner_disabled_at_boot",
+                extra={
+                    "reason": "AUTO_SHORTS_PRODUCT_V2_CHILD_RUNNER_ENABLED is False",
+                },
+            )
+            return
+
+        logger.info(
+            "child_runner_started",
+            extra={
+                "instance_id": self.instance_id,
+                "max_concurrency": (
+                    self.settings.auto_shorts_product_v2_child_runner_max_concurrency
+                ),
+                "poll_seconds": poll_seconds,
+            },
+        )
+        while not self._stop_event.is_set():
+            try:
+                await self._poll_and_dispatch()
+            except Exception:
+                logger.exception(
+                    "child_runner_poll_iteration_failed",
+                    extra={"instance_id": self.instance_id},
+                )
+                # Don't let a single failed poll kill the loop. Sleep
+                # before retrying so we don't hot-loop on a persistent
+                # error (e.g. DB outage).
+
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=poll_seconds,
+                )
+            except asyncio.TimeoutError:
+                # Normal poll-interval expiry — continue.
+                pass
+
+        # Drain in-flight tasks before returning.
+        if self._inflight:
+            logger.info(
+                "child_runner_draining",
+                extra={"inflight": len(self._inflight)},
+            )
+            await asyncio.gather(*self._inflight, return_exceptions=True)
+
+        logger.info(
+            "child_runner_stopped",
+            extra={"instance_id": self.instance_id},
+        )
+
+    async def _poll_and_dispatch(self) -> None:
+        """One poll iteration.
+
+        Reads up to ``max_concurrency * 2`` candidate child ids in
+        FIFO order (no DB lock — claim is the race resolver) and
+        dispatches each as an asyncio task. The semaphore bounds
+        actual concurrent processing.
+        """
+        max_concurrency = (
+            self.settings.auto_shorts_product_v2_child_runner_max_concurrency
+        )
+        async with self.session_factory() as session:
+            repo = ProductScanJobRepository(session)
+            candidates = await repo.find_queued_render_children(
+                limit=max_concurrency * 2,
+            )
+        for child_id in candidates:
+            task = asyncio.create_task(self._run_one_child(child_id))
+            self._inflight.add(task)
+            task.add_done_callback(self._inflight.discard)
+
+    async def _run_one_child(self, child_id: UUID) -> None:
+        """Per-child wrapper that respects the bounded semaphore and
+        catches exceptions so one bad child can't kill the loop.
+        """
+        async with self._semaphore:
+            try:
+                await self._process_child_fn(child_id)
+            except Exception:
+                logger.exception(
+                    "child_runner_process_child_failed",
+                    extra={
+                        "child_id": str(child_id),
+                        "instance_id": self.instance_id,
+                    },
+                )
+                # Best-effort: try to mark the child as failed so it
+                # doesn't get re-polled forever. If even this fails,
+                # the lease will eventually expire and another replica
+                # will retry.
+                await self._mark_child_failed(
+                    child_id=child_id,
+                    error_message="child runner crashed mid-process",
+                )
+
+    async def _process_child_payload(self, child_id: UUID) -> None:
+        """The actual child-processing step.
+
+        **Phase 4 PR #4 stub**: claim → /complete with
+        ``render_job_id=None``. Real picker + render-service call
+        lands in PR #5.
+
+        The split of repo work across two transactions (claim ↔
+        complete) is intentional:
+
+          * The first transaction commits the claim so the row is
+            visible as ``claimed_by=api-child-…`` to other replicas.
+            Without this commit, two replicas could each see the
+            row as queued and both try to claim — though the second
+            UPDATE would still fail and return None, the wasted
+            poll cycle is avoidable.
+          * The second transaction holds the actual work + /complete.
+            PR #5 will widen this transaction to include the picker
+            cost rollup and render-service call.
+        """
+        # ── 1. Claim ──────────────────────────────────────────────
+        async with self.session_factory() as session:
+            repo = ProductScanJobRepository(session)
+            claimed = await repo.claim(
+                job_id=child_id,
+                claimed_by=self.claimed_by,
+                lease_seconds=(
+                    self.settings.auto_shorts_product_v2_child_lease_seconds
+                ),
+                next_stage=SCAN_STAGE_ASSEMBLING,
+            )
+            if claimed is None:
+                # Another replica already claimed this child OR the
+                # row is no longer in 'queued' (already processed,
+                # cancelled, etc.). No-op.
+                logger.debug(
+                    "child_already_claimed_or_terminal",
+                    extra={
+                        "child_id": str(child_id),
+                        "instance_id": self.instance_id,
+                    },
+                )
+                return
+            await session.commit()
+
+        # ── 2. Stub work (PR #4) ──────────────────────────────────
+        # PR #5 replaces this section with:
+        #   - read parent + active appearances
+        #   - run select_subset / build_stitch_plan via heimdex_media_pipelines
+        #   - call shorts_render_service.create_render_job
+        #   - persist render_job_id in the /complete call below
+        logger.info(
+            "child_runner_processed_child_stub",
+            extra={
+                "child_id": str(child_id),
+                "instance_id": self.instance_id,
+                "note": "PR #4 stub; real render integration pending PR #5",
+            },
+        )
+
+        # ── 3. Complete ───────────────────────────────────────────
+        async with self.session_factory() as session:
+            repo = ProductScanJobRepository(session)
+            completed = await repo.complete_tracking(
+                job_id=child_id,
+                claimed_by=self.claimed_by,
+                cost_delta_usd=Decimal("0"),
+                # PR #5: replace with the actual ShortsRenderJob.id from
+                # the render service. None for now means the wizard UI
+                # shows "render not produced" — acceptable for the stub.
+                render_job_id=None,
+            )
+            if completed is None:
+                # Lease lost between claim and complete (cancel cascade
+                # ran, or this replica's clock skewed past the lease).
+                # Nothing to do here; the row is in its terminal state
+                # already.
+                logger.warning(
+                    "child_complete_lease_lost",
+                    extra={
+                        "child_id": str(child_id),
+                        "instance_id": self.instance_id,
+                    },
+                )
+                return
+            await session.commit()
+
+    async def _mark_child_failed(
+        self,
+        *,
+        child_id: UUID,
+        error_message: str,
+    ) -> None:
+        """Best-effort failure path for the catch-all handler."""
+        try:
+            async with self.session_factory() as session:
+                repo = ProductScanJobRepository(session)
+                await repo.fail(
+                    job_id=child_id,
+                    claimed_by=self.claimed_by,
+                    error_code="internal_error",
+                    error_message=error_message[:1900],
+                    cost_delta_usd=Decimal("0"),
+                )
+                await session.commit()
+        except Exception:
+            logger.exception(
+                "child_runner_mark_failed_failed",
+                extra={"child_id": str(child_id)},
+            )
+
+
+def create_child_runner(
+    *,
+    settings: Settings,
+    session_factory: async_sessionmaker[AsyncSession],
+    instance_id: str | None = None,
+) -> ChildRunner:
+    """Factory used by ``app.main:lifespan``. Tests construct
+    ``ChildRunner`` directly with their own session factory + injected
+    ``process_child_fn``.
+    """
+    return ChildRunner(
+        settings=settings,
+        session_factory=session_factory,
+        instance_id=instance_id,
+    )

--- a/services/api/tests/test_shorts_auto_product_child_runner.py
+++ b/services/api/tests/test_shorts_auto_product_child_runner.py
@@ -1,0 +1,372 @@
+"""Phase 4 PR #4 — child runner tests.
+
+Covers the in-API-process child runner that picks up queued
+``mode='render_child'`` rows produced by the parent fan-out hook.
+
+Tests are unit-scope (no real Postgres). The DB-atomic claim race is
+simulated by mocking the repo's ``claim`` method to return None on
+the losing call — sufficient to verify the runner's behavior since
+the actual race resolution is Postgres's atomic UPDATE, not anything
+the runner itself does.
+
+NOT in CI allowlist (consistent with the rest of the
+test_shorts_auto_product_*.py suite).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.modules.shorts_auto_product.children.runner import ChildRunner
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+def _settings_stub(
+    *,
+    max_concurrency: int = 4,
+    poll_seconds: float = 0.05,
+    lease_seconds: int = 300,
+    enabled: bool = True,
+):
+    s = MagicMock()
+    s.auto_shorts_product_v2_child_runner_max_concurrency = max_concurrency
+    s.auto_shorts_product_v2_child_runner_poll_seconds = poll_seconds
+    s.auto_shorts_product_v2_child_lease_seconds = lease_seconds
+    s.auto_shorts_product_v2_child_runner_enabled = enabled
+    return s
+
+
+def _mock_session_factory(repo_factory):
+    """Build a session factory that yields a MagicMock session and
+    arranges for ``ProductScanJobRepository(session)`` to return the
+    fake repo built by ``repo_factory``.
+
+    Uses Pattern B test patching (D53) — the runner constructs
+    ``ProductScanJobRepository(session)`` directly, so we monkeypatch
+    the class to return the fake.
+    """
+
+    @asynccontextmanager
+    async def factory():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        yield session
+
+    return factory
+
+
+def _patch_repo(monkeypatch, fake_repo):
+    """Patch ``ProductScanJobRepository`` to return ``fake_repo``
+    regardless of the session it's constructed with."""
+    import app.modules.shorts_auto_product.children.runner as runner_module
+
+    monkeypatch.setattr(
+        runner_module,
+        "ProductScanJobRepository",
+        MagicMock(return_value=fake_repo),
+    )
+
+
+def _build_runner(monkeypatch, *, settings=None, fake_repo=None,
+                  process_child_fn=None, instance_id="test-replica"):
+    """Construct a ChildRunner with all deps mocked."""
+    settings = settings or _settings_stub()
+    fake_repo = fake_repo or MagicMock()
+    fake_repo.find_queued_render_children = AsyncMock(return_value=[])
+    fake_repo.claim = AsyncMock(return_value=MagicMock())
+    fake_repo.complete_tracking = AsyncMock(return_value=MagicMock())
+    fake_repo.fail = AsyncMock()
+    _patch_repo(monkeypatch, fake_repo)
+    return ChildRunner(
+        settings=settings,
+        session_factory=_mock_session_factory(fake_repo),
+        instance_id=instance_id,
+        process_child_fn=process_child_fn,
+    ), fake_repo
+
+
+# ======================================================================
+# claimed_by identifier
+# ======================================================================
+
+
+def test_claimed_by_includes_instance_id(monkeypatch):
+    runner, _ = _build_runner(monkeypatch, instance_id="api-replica-7")
+    assert runner.claimed_by == "api-child-api-replica-7"
+
+
+def test_default_instance_id_uses_hostname(monkeypatch):
+    """If HOSTNAME is set (every container runtime sets this), the
+    runner uses it. Otherwise falls back to socket.gethostname()."""
+    monkeypatch.setenv("HOSTNAME", "ec2-host-42")
+    from app.modules.shorts_auto_product.children.runner import _default_instance_id
+
+    assert _default_instance_id() == "ec2-host-42"
+
+
+# ======================================================================
+# Stub processing (PR #4): claim → /complete with render_job_id=None
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_process_child_payload_claims_then_completes(monkeypatch):
+    """Happy path: claim returns the claimed row → /complete with
+    render_job_id=None (PR #4 stub) → both repo calls awaited."""
+    runner, fake_repo = _build_runner(monkeypatch)
+    child_id = uuid4()
+    fake_repo.claim = AsyncMock(return_value=MagicMock())  # claim wins
+    fake_repo.complete_tracking = AsyncMock(return_value=MagicMock())
+
+    await runner._process_child_payload(child_id)
+
+    fake_repo.claim.assert_awaited_once()
+    claim_kwargs = fake_repo.claim.await_args.kwargs
+    assert claim_kwargs["job_id"] == child_id
+    assert claim_kwargs["claimed_by"] == "api-child-test-replica"
+    assert claim_kwargs["next_stage"] == "assembling"
+
+    fake_repo.complete_tracking.assert_awaited_once()
+    complete_kwargs = fake_repo.complete_tracking.await_args.kwargs
+    assert complete_kwargs["job_id"] == child_id
+    assert complete_kwargs["claimed_by"] == "api-child-test-replica"
+    # PR #4 stub: render_job_id is None until PR #5 wires real renders.
+    assert complete_kwargs["render_job_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_process_child_payload_skips_when_already_claimed(monkeypatch):
+    """Race-loser path: claim returns None (another replica already
+    claimed) → no /complete call, silent no-op."""
+    runner, fake_repo = _build_runner(monkeypatch)
+    fake_repo.claim = AsyncMock(return_value=None)  # claim lost the race
+
+    await runner._process_child_payload(uuid4())
+
+    fake_repo.claim.assert_awaited_once()
+    fake_repo.complete_tracking.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_child_payload_lease_lost_during_complete(monkeypatch):
+    """Lease lost between claim and complete (e.g. cancel cascade ran
+    mid-process) → warn but don't crash. The row is already in its
+    terminal state from the cancel — nothing for us to do."""
+    runner, fake_repo = _build_runner(monkeypatch)
+    fake_repo.claim = AsyncMock(return_value=MagicMock())
+    fake_repo.complete_tracking = AsyncMock(return_value=None)  # lease lost
+
+    # Should not raise; quietly returns.
+    await runner._process_child_payload(uuid4())
+
+    fake_repo.complete_tracking.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_one_child_marks_failed_on_exception(monkeypatch):
+    """If the processing step raises, the runner catches the exception
+    and best-effort marks the child as failed. Without this, a single
+    bad child would leave the row in 'assembling' until the lease
+    expires (5 min) and another replica retries — wasted cycles.
+    """
+    runner, fake_repo = _build_runner(monkeypatch)
+    child_id = uuid4()
+
+    # Inject a process_child_fn that always raises.
+    async def failing_process(_id):
+        raise ValueError("bang")
+
+    runner._process_child_fn = failing_process
+
+    await runner._run_one_child(child_id)
+
+    # _mark_child_failed should have been called and called repo.fail
+    fake_repo.fail.assert_awaited_once()
+    fail_kwargs = fake_repo.fail.await_args.kwargs
+    assert fail_kwargs["job_id"] == child_id
+    assert fail_kwargs["error_code"] == "internal_error"
+    assert "crashed" in fail_kwargs["error_message"]
+
+
+# ======================================================================
+# Multi-replica race simulation
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_two_replicas_race_only_one_wins(monkeypatch):
+    """Simulate two replicas seeing the same queued child id. The
+    DB-atomic claim only succeeds once; the second replica's claim
+    returns None and silently no-ops.
+
+    This isn't a real race test (no concurrent DB) — it's a behavior
+    contract test: prove the runner correctly handles ``claim ==
+    None`` as the lost-race signal.
+    """
+    child_id = uuid4()
+
+    # Replica A: claim succeeds
+    runner_a, repo_a = _build_runner(
+        monkeypatch, instance_id="replica-A",
+    )
+    repo_a.claim = AsyncMock(return_value=MagicMock())
+    repo_a.complete_tracking = AsyncMock(return_value=MagicMock())
+
+    # Replica B: claim loses
+    repo_b = MagicMock()
+    repo_b.find_queued_render_children = AsyncMock(return_value=[])
+    repo_b.claim = AsyncMock(return_value=None)
+    repo_b.complete_tracking = AsyncMock()
+    repo_b.fail = AsyncMock()
+    runner_b = ChildRunner(
+        settings=_settings_stub(),
+        session_factory=_mock_session_factory(repo_b),
+        instance_id="replica-B",
+    )
+
+    # Each replica processes the same child_id (this is what would
+    # happen if both polls returned overlapping candidates).
+    # Patch repo into runner_b too — _build_runner already patched
+    # for runner_a, so we need to overwrite with repo_b.
+    import app.modules.shorts_auto_product.children.runner as runner_module
+    original_repo_class = runner_module.ProductScanJobRepository
+
+    # Use a side_effect to alternate between repos based on call order
+    # since both runners share the patched class. Simpler: process
+    # serially with explicit class swaps.
+    monkeypatch.setattr(
+        runner_module,
+        "ProductScanJobRepository",
+        MagicMock(return_value=repo_a),
+    )
+    await runner_a._process_child_payload(child_id)
+
+    monkeypatch.setattr(
+        runner_module,
+        "ProductScanJobRepository",
+        MagicMock(return_value=repo_b),
+    )
+    await runner_b._process_child_payload(child_id)
+
+    # Replica A: claimed, completed.
+    repo_a.complete_tracking.assert_awaited_once()
+    # Replica B: claim returned None, no /complete call.
+    repo_b.complete_tracking.assert_not_awaited()
+
+
+# ======================================================================
+# Bounded concurrency
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_bounded_concurrency_caps_inflight(monkeypatch):
+    """Dispatch 10 children with max_concurrency=2; at most 2 should
+    be in-flight at any time. Verified by counting concurrent
+    process_child_fn invocations.
+    """
+    settings = _settings_stub(max_concurrency=2)
+    inflight_now = 0
+    max_seen = 0
+
+    async def slow_process(_child_id):
+        nonlocal inflight_now, max_seen
+        inflight_now += 1
+        max_seen = max(max_seen, inflight_now)
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            inflight_now -= 1
+
+    runner, _ = _build_runner(
+        monkeypatch, settings=settings, process_child_fn=slow_process,
+    )
+
+    # Fire 10 children directly via _run_one_child.
+    tasks = [
+        asyncio.create_task(runner._run_one_child(uuid4()))
+        for _ in range(10)
+    ]
+    await asyncio.gather(*tasks)
+
+    assert max_seen <= 2, (
+        f"max_concurrency=2 violated; saw {max_seen} concurrent processes"
+    )
+
+
+# ======================================================================
+# Disabled flag
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_runner_disabled_exits_loop_immediately(monkeypatch):
+    """When ``auto_shorts_product_v2_child_runner_enabled`` is False,
+    the loop logs and returns without polling. Lets operators
+    suspend wizard fan-out without redeploying."""
+    settings = _settings_stub(enabled=False)
+    runner, fake_repo = _build_runner(monkeypatch, settings=settings)
+
+    runner.start()
+    await asyncio.wait_for(runner._task, timeout=1.0)
+
+    # find_queued_render_children should never have been called.
+    fake_repo.find_queued_render_children.assert_not_awaited()
+
+
+# ======================================================================
+# Lifecycle: start / stop drain
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_start_then_stop_drains_inflight(monkeypatch):
+    """In-flight children at shutdown finish their current iteration
+    before the runner returns.
+    """
+    settings = _settings_stub(poll_seconds=0.01)
+    completed_ids: list[UUID] = []
+
+    async def slow_process(child_id):
+        await asyncio.sleep(0.05)
+        completed_ids.append(child_id)
+
+    runner, fake_repo = _build_runner(
+        monkeypatch, settings=settings, process_child_fn=slow_process,
+    )
+    queued = [uuid4(), uuid4(), uuid4()]
+    # First poll returns 3 candidates; subsequent polls return [].
+    fake_repo.find_queued_render_children = AsyncMock(
+        side_effect=[queued, [], [], [], []],
+    )
+
+    runner.start()
+    # Give the runner time to dispatch all 3 children.
+    await asyncio.sleep(0.05)
+    # Stop and drain. Drain timeout > slow_process duration so all
+    # 3 children complete cleanly.
+    await runner.stop(drain_timeout_seconds=2.0)
+
+    assert len(completed_ids) == 3
+    # Tasks should all be cleaned up from the inflight set.
+    assert len(runner._inflight) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent(monkeypatch):
+    """Calling stop twice is safe."""
+    runner, _ = _build_runner(monkeypatch)
+    runner.start()
+    await asyncio.sleep(0.01)
+    await runner.stop(drain_timeout_seconds=0.5)
+    await runner.stop(drain_timeout_seconds=0.5)  # second call no-ops


### PR DESCRIPTION
## Summary

In-API-process long-lived asyncio task that picks up queued `mode='render_child'` rows produced by the parent fan-out hook (PR #116). One runner per API replica; the DB-atomic `ProductScanJobRepository.claim` is the cross-replica race resolver.

**This PR ships INFRASTRUCTURE ONLY** — the processing step is a deliberate stub: claim → `/complete` with `render_job_id=None`. PR #5 swaps the stub for real picker + render-service integration once contracts v0.14.0 is published and the worker refactor populates parent appearances.

Plan: `.claude/plans/shorts-auto-product-v2-phase-4-7.md` §6.2.

### What ships

* **New sub-package `app.modules.shorts_auto_product.children/`** — closed boundary; loose-coupling rules documented in `__init__.py`. The runner imports its own module's repos + `app.db.base.get_async_session_factory` only — no cross-module coupling.
* **`ChildRunner` class** — start/stop lifecycle, bounded concurrency via `asyncio.Semaphore` (default 4 per replica), poll-and-dispatch loop with configurable cadence (default 5s). Tests inject `process_child_fn` for clean DI.
* **`app.main:lifespan` wiring** — runner starts after engine init + worker_event partitions are ensured. On shutdown, up to 30s drain for in-flight children before tasks are cancelled (lease then expires; another replica re-claims via the same poll path — no orphan rows).
* **`_default_instance_id` reads HOSTNAME** — every container runtime sets this; OS hostname fallback for dev. `claimed_by` lands as `api-child-{instance_id}` so logs trace which API replica processed each child (and distinguishes from worker-side claims that use `settings.worker_id`).
* **Best-effort failure path** — exceptions in the per-child processor are caught + the child is marked failed via `repo.fail`, so a single bad row doesn't sit in 'assembling' until the lease expires (5 min).

### Why a stub in PR #4

Splitting the runner work from the picker + render-service integration keeps each diff bounded and reviewable. The runner's claim race + bounded concurrency + lease lifecycle all need infrastructure tests; bundling those with the picker integration would make a 1500-LOC PR. The stub:

* Proves the runner's contract end-to-end (claim race, bounded concurrency, lifecycle).
* Lets the wizard frontend (PR #6) be developed against a runner that actually transitions children through the full state machine.
* Avoids dragging the `heimdex_media_pipelines` dep into the API service before the worker side (PR #5) is ready to feed it real data.

The `auto_shorts_product_v2_child_runner_enabled` flag (default True, configurable per env) lets operators flip the runner off if PRs land out-of-order.

### Out of scope (PR #5)

* `heimdex_media_pipelines` dep on the API service.
* `SingleProductSubsetPicker` integration (round-robin window distribution by `shorts_index`).
* Real render-service call via `app.dependencies.get_shorts_render_service` (allowed exception per plan §15).
* Worker parent-flow refactor + contracts v0.14.0 publish.

## Test plan

- [x] **11 new unit tests** in `test_shorts_auto_product_child_runner.py`:
  - `claimed_by` formatting (`api-child-{instance_id}`).
  - `_default_instance_id` reads HOSTNAME.
  - PR #4 stub processing path: claim → `/complete` with `render_job_id=None`.
  - Race-loser path: claim returns None → no `/complete` call.
  - Lease lost between claim and complete: warn but don't crash.
  - Exception in `process_child_fn` → best-effort mark failed.
  - Multi-replica race simulation: replica A claims, replica B's claim returns None.
  - Bounded concurrency cap respected (max=2 with 10 children → at most 2 concurrent).
  - Disabled flag exits loop without polling.
  - Lifecycle: start → process N children → stop drains in-flight.
  - Stop is idempotent.
- [x] **97 tests pass** across the full `shorts_auto_product` module locally.
- [x] **339 CI allowlist tests** green locally.

## Risk

- **Scope-risk: narrow**. The runner is a new background task with no shared state. Worst case: a bug crashes the runner loop, in which case children stay queued (visible) and the cancel-cascade path (PR #115) still works.
- **Constraint**: PR #4 stub means children `/complete` with `render_job_id=None` until PR #5 lands. The wizard frontend (PR #6) is the first caller that observes this — the stub never reaches production users. SQS publish for parents (PR #5) is also still off, so children can't actually fan out in the real flow until PR #5 lands.

## Stack

- ✅ PR #114 — Phase 4 foundation: schema + mode dispatch
- ✅ PR #115 — Phase 4 PR #2: scan-order service + wizard endpoints
- 🟡 PR #116 — Phase 4 PR #3: scan_order parent fan-out hook (open, independent of this PR)
- 🟡 **This PR** — Phase 4 PR #4: child runner infrastructure (stub)
- ⏳ PR #5 — Phase 4 PR #5: real picker + render-service integration in runner + worker refactor + contracts v0.14.0
- ⏳ PR #6 — Phase 4 PR #6: frontend wizard