### PR TITLE
Phase 4 PR #5a: SQS publish for scan_order parents (worker recognizes mode, stubs handler)

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -439,6 +439,17 @@ class Settings(BaseSettings):
     # wizard inputs don't collide.
     auto_shorts_product_v2_scan_order_idempotency_seconds: int = 60
 
+    # Master flag for the wizard's SQS publish step. Default OFF: the
+    # service creates parent rows in DB but does NOT publish to
+    # ``heimdex-product-track-queue`` until this flips. Required so
+    # we can roll out the API code that knows about scan_order
+    # BEFORE the worker on Aircloud is rebuilt with v0.14.0
+    # contracts. Flipping early would fill the worker's DLQ with
+    # messages it can't parse. Once the worker image is bumped +
+    # redeployed, flip this to True (per-env via Aircloud config or
+    # docker-compose .env override).
+    auto_shorts_product_v2_publish_scan_order_enabled: bool = False
+
     # --- CORS ---
     cors_allow_origin_regex: str = (
         r"^https?://"

--- a/services/api/app/modules/shorts_auto_product/service.py
+++ b/services/api/app/modules/shorts_auto_product/service.py
@@ -658,9 +658,66 @@ class ProductScanService:
         )
         await self.session.flush()
 
-        # TODO(PR#3): publish_product_scan_order_job — wired with the
-        # worker refactor that teaches product-track-worker to handle
-        # mode='scan_order'. Until then, parent rows sit in 'queued'.
+        # Phase 4 PR — publish the parent track job to SQS so the
+        # product-track-worker picks it up and runs the per-catalog
+        # tracking loop. Gated on
+        # ``auto_shorts_product_v2_publish_scan_order_enabled`` so we
+        # can deploy the API code BEFORE the worker is rebuilt with
+        # v0.14.0 contracts. Flipping the flag without the worker
+        # ready would fill the worker DLQ with unparseable messages
+        # (extra='forbid' rejects the new wizard fields on a v0.13.0
+        # contracts pin).
+        if self.settings.auto_shorts_product_v2_publish_scan_order_enabled:
+            try:
+                sqs_producer.publish_product_track_job(
+                    job_id=parent.id,
+                    org_id=org_id,
+                    video_id=video_id,
+                    requested_by_user_id=user_id,
+                    tracker_version=(
+                        self.settings.auto_shorts_product_v2_tracker_version
+                    ),
+                    enumeration_prompt_version=(
+                        self.settings
+                        .auto_shorts_product_v2_enumeration_prompt_version
+                    ),
+                    callback_base_url=(
+                        self.settings.auto_shorts_product_v2_callback_base_url
+                    ),
+                    mode="scan_order",
+                    length_seconds=body.length_seconds,
+                    requested_count=body.requested_count,
+                    time_range_start_ms=body.time_range_start_ms,
+                    time_range_end_ms=body.time_range_end_ms,
+                    product_distribution=body.product_distribution,
+                    language=body.language,
+                    intent=body.intent,
+                    # Legacy fields intentionally omitted — workers on
+                    # v0.14.0+ use ``length_seconds`` and dispatch on
+                    # ``mode='scan_order'`` (not ``catalog_entry_id``).
+                )
+            except Exception:
+                logger.exception(
+                    "product_v2_scan_order_publish_failed",
+                    parent_job_id=str(parent.id),
+                    org_id=str(org_id),
+                )
+                # Mark the parent failed so the wizard UI can render a
+                # retry affordance. The DB row already exists; failing
+                # here matches the legacy enqueue_scan / enqueue_clip
+                # error-handling shape.
+                await self.job_repo.fail(
+                    job_id=parent.id,
+                    claimed_by="api",
+                    error_code="internal_error",
+                    error_message="failed to enqueue scan order; please retry",
+                    cost_delta_usd=Decimal("0"),
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="failed to enqueue scan order; please retry",
+                )
+
         logger.info(
             "product_v2_scan_order_created",
             parent_job_id=str(parent.id),
@@ -673,7 +730,9 @@ class ProductScanService:
             language=body.language,
             intent=body.intent,
             settings_hash=settings_hash,
-            note="SQS publish deferred to PR #3",
+            published=(
+                self.settings.auto_shorts_product_v2_publish_scan_order_enabled
+            ),
         )
         return ScanOrderResponse(parent_job_id=parent.id, deduped=False)
 

--- a/services/api/app/sqs_producer.py
+++ b/services/api/app/sqs_producer.py
@@ -877,37 +877,83 @@ def publish_product_track_job(
     job_id: UUID,
     org_id: UUID,
     video_id: UUID,
-    catalog_entry_id: UUID,
     requested_by_user_id: UUID,
-    duration_preset_sec: int,
     tracker_version: str,
     enumeration_prompt_version: str,
     callback_base_url: str,
+    # Legacy single-product flow (enqueue_clip) — both required.
+    catalog_entry_id: UUID | None = None,
+    duration_preset_sec: int | None = None,
+    # v0.14.0 wizard fields (mode='scan_order' parents) — all Optional;
+    # body dict omits None entries below so the message stays small for
+    # legacy senders.
+    mode: str = "enumerate",
+    length_seconds: int | None = None,
+    requested_count: int | None = None,
+    time_range_start_ms: int | None = None,
+    time_range_end_ms: int | None = None,
+    product_distribution: str | None = None,
+    language: str | None = None,
+    intent: str | None = None,
 ) -> None:
     """Publish a shorts-auto-product track + assembly job.
 
-    Called from ``ProductScanService.enqueue_clip`` after the tracking
-    job row is flushed. Body shape MUST match
-    ``heimdex_media_contracts.product.ProductTrackJob``.
+    Body shape MUST match
+    ``heimdex_media_contracts.product.ProductTrackJob`` v0.14.0+.
+
+    Two callers:
+
+    * ``ProductScanService.enqueue_clip`` (legacy single-product flow)
+      → passes ``catalog_entry_id`` + ``duration_preset_sec``, leaves
+      ``mode='enumerate'`` and the wizard fields unset.
+    * ``ProductScanService.enqueue_scan_order`` (Phase 4 wizard parent)
+      → passes ``mode='scan_order'`` + the full wizard field set,
+      leaves ``catalog_entry_id`` unset (parent processes the whole
+      catalog).
+
+    The body omits None-valued fields so a v0.14.0 worker reading a
+    legacy v0.13.0-shaped publish doesn't see noise. Workers parse via
+    the v0.14.0 ProductTrackJob model which accepts both shapes.
     """
     settings = get_settings()
     if settings.queue_backend != "rabbitmq" and not settings.sqs_enabled:
         return
 
     now = datetime.now(timezone.utc)
-    body = {
+    body: dict[str, object] = {
         "version": "1",
         "type": "product.track_job",
         "timestamp": now.isoformat(),
         "job_id": str(job_id),
         "org_id": str(org_id),
         "video_id": str(video_id),
-        "catalog_entry_id": str(catalog_entry_id),
         "requested_by_user_id": str(requested_by_user_id),
-        "duration_preset_sec": duration_preset_sec,
         "tracker_version": tracker_version,
         "enumeration_prompt_version": enumeration_prompt_version,
         "callback_base_url": callback_base_url,
+        "mode": mode,
     }
+    # Optional fields — included only when the caller set them. Keeps
+    # the wire format tight + makes the legacy vs scan_order
+    # distinction self-evident in CloudWatch logs.
+    if catalog_entry_id is not None:
+        body["catalog_entry_id"] = str(catalog_entry_id)
+    if duration_preset_sec is not None:
+        body["duration_preset_sec"] = duration_preset_sec
+    if length_seconds is not None:
+        body["length_seconds"] = length_seconds
+    if requested_count is not None:
+        body["requested_count"] = requested_count
+    if time_range_start_ms is not None:
+        body["time_range_start_ms"] = time_range_start_ms
+    if time_range_end_ms is not None:
+        body["time_range_end_ms"] = time_range_end_ms
+    if product_distribution is not None:
+        body["product_distribution"] = product_distribution
+    if language is not None:
+        body["language"] = language
+    if intent is not None:
+        body["intent"] = intent
+
     dedup_id = f"{job_id}:product-track:{now.strftime('%Y%m%dT%H%M')}"
     _publish("product_track", body, dedup_id)

--- a/services/api/tests/test_shorts_auto_product_publish.py
+++ b/services/api/tests/test_shorts_auto_product_publish.py
@@ -1,0 +1,290 @@
+"""Phase 4 PR #5a — SQS publish + service-flag tests.
+
+Covers:
+
+* ``sqs_producer.publish_product_track_job`` body shape — legacy flow
+  (catalog_entry_id + duration_preset_sec) AND scan_order parent
+  flow (mode='scan_order' + wizard fields). The body dict omits
+  None-valued fields so the wire stays tight.
+* ``ProductScanService.enqueue_scan_order`` publish flag —
+  ``auto_shorts_product_v2_publish_scan_order_enabled=False`` skips
+  the publish; True calls it; publisher exception → 503 + parent
+  marked failed.
+
+NOT in CI allowlist (consistent with the rest of the
+test_shorts_auto_product_*.py suite).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app import sqs_producer
+from app.modules.shorts_auto_product.schemas import ScanOrderCreateRequest
+from app.modules.shorts_auto_product.service import ProductScanService
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+def _settings_stub(*, publish_enabled: bool = True):
+    s = MagicMock()
+    s.auto_shorts_product_v2_enabled = True
+    s.auto_shorts_product_v2_rollout_pct = 100
+    s.auto_shorts_product_v2_daily_budget_usd = 50.0
+    s.auto_shorts_product_v2_max_concurrent_per_org = 3
+    s.auto_shorts_product_v2_scan_order_idempotency_seconds = 60
+    s.auto_shorts_product_v2_tracker_version = "v1.0"
+    s.auto_shorts_product_v2_enumeration_prompt_version = "v1.0"
+    s.auto_shorts_product_v2_callback_base_url = "https://api.example.com"
+    s.auto_shorts_product_v2_publish_scan_order_enabled = publish_enabled
+    return s
+
+
+def _build_service(*, publish_enabled: bool = True):
+    svc = ProductScanService(
+        session=MagicMock(),
+        settings=_settings_stub(publish_enabled=publish_enabled),
+    )
+    svc.session.flush = AsyncMock()
+    svc.catalog_repo = MagicMock()
+    svc.catalog_repo.list_active_by_video = AsyncMock(return_value=[])
+    svc.appearance_repo = MagicMock()
+    svc.job_repo = MagicMock()
+    svc.cost_repo = MagicMock()
+    svc.cost_repo.get_today_cost = AsyncMock(return_value=Decimal("0"))
+    svc.job_repo.count_active_for_org = AsyncMock(return_value=0)
+    svc.job_repo.find_recent_scan_order_duplicate = AsyncMock(return_value=None)
+
+    parent = MagicMock()
+    parent.id = uuid4()
+    svc.job_repo.create_scan_order_parent = AsyncMock(return_value=parent)
+    svc.job_repo.fail = AsyncMock()
+    return svc, parent
+
+
+def _scan_order_body(**overrides):
+    defaults = {
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+    }
+    defaults.update(overrides)
+    return ScanOrderCreateRequest(**defaults)
+
+
+# ======================================================================
+# sqs_producer.publish_product_track_job — body shape
+# ======================================================================
+
+
+def _capture_publish_body():
+    """Patch the underlying ``_publish`` and capture the body dict
+    for inspection."""
+    captured = {}
+
+    def fake_publish(queue_name, body, dedup_id):
+        captured["queue_name"] = queue_name
+        captured["body"] = body
+        captured["dedup_id"] = dedup_id
+
+    return captured, fake_publish
+
+
+def test_publish_legacy_flow_carries_catalog_entry_id(monkeypatch):
+    """Legacy single-product path: catalog_entry_id + duration_preset_sec
+    set, mode defaults to 'enumerate', no wizard fields in the body."""
+    captured, fake = _capture_publish_body()
+    monkeypatch.setattr(sqs_producer, "_publish", fake)
+
+    settings = MagicMock()
+    settings.queue_backend = "sqs"
+    settings.sqs_enabled = True
+    monkeypatch.setattr(sqs_producer, "get_settings", lambda: settings)
+
+    catalog_id = uuid4()
+    sqs_producer.publish_product_track_job(
+        job_id=uuid4(),
+        org_id=uuid4(),
+        video_id=uuid4(),
+        requested_by_user_id=uuid4(),
+        tracker_version="v1.0",
+        enumeration_prompt_version="v1.0",
+        callback_base_url="https://x",
+        catalog_entry_id=catalog_id,
+        duration_preset_sec=60,
+    )
+
+    body = captured["body"]
+    assert body["mode"] == "enumerate"
+    assert body["catalog_entry_id"] == str(catalog_id)
+    assert body["duration_preset_sec"] == 60
+    # Wizard fields MUST be absent for legacy senders.
+    for k in (
+        "length_seconds", "requested_count",
+        "time_range_start_ms", "time_range_end_ms",
+        "product_distribution", "language", "intent",
+    ):
+        assert k not in body, f"{k!r} leaked into legacy publish body"
+
+
+def test_publish_scan_order_flow_carries_wizard_fields(monkeypatch):
+    """Wizard parent path: mode='scan_order' + full wizard field set;
+    no catalog_entry_id, no duration_preset_sec."""
+    captured, fake = _capture_publish_body()
+    monkeypatch.setattr(sqs_producer, "_publish", fake)
+
+    settings = MagicMock()
+    settings.queue_backend = "sqs"
+    settings.sqs_enabled = True
+    monkeypatch.setattr(sqs_producer, "get_settings", lambda: settings)
+
+    sqs_producer.publish_product_track_job(
+        job_id=uuid4(),
+        org_id=uuid4(),
+        video_id=uuid4(),
+        requested_by_user_id=uuid4(),
+        tracker_version="v1.0",
+        enumeration_prompt_version="v1.0",
+        callback_base_url="https://x",
+        mode="scan_order",
+        length_seconds=60,
+        requested_count=5,
+        time_range_start_ms=0,
+        time_range_end_ms=600_000,
+        product_distribution="single",
+        language="ko",
+        intent="commit",
+    )
+
+    body = captured["body"]
+    assert body["mode"] == "scan_order"
+    assert body["length_seconds"] == 60
+    assert body["requested_count"] == 5
+    assert body["time_range_start_ms"] == 0
+    assert body["time_range_end_ms"] == 600_000
+    assert body["product_distribution"] == "single"
+    assert body["language"] == "ko"
+    assert body["intent"] == "commit"
+    # Legacy fields MUST be absent for scan_order parents.
+    assert "catalog_entry_id" not in body
+    assert "duration_preset_sec" not in body
+
+
+def test_publish_skips_when_queue_disabled(monkeypatch):
+    """Off-switch — neither RabbitMQ nor SQS enabled → no-op."""
+    captured, fake = _capture_publish_body()
+    monkeypatch.setattr(sqs_producer, "_publish", fake)
+
+    settings = MagicMock()
+    settings.queue_backend = "sqs"
+    settings.sqs_enabled = False
+    monkeypatch.setattr(sqs_producer, "get_settings", lambda: settings)
+
+    sqs_producer.publish_product_track_job(
+        job_id=uuid4(),
+        org_id=uuid4(),
+        video_id=uuid4(),
+        requested_by_user_id=uuid4(),
+        tracker_version="v1.0",
+        enumeration_prompt_version="v1.0",
+        callback_base_url="https://x",
+        mode="scan_order",
+        length_seconds=60,
+        requested_count=5,
+    )
+    assert captured == {}
+
+
+# ======================================================================
+# ProductScanService.enqueue_scan_order — publish flag
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_publishes_when_flag_on():
+    svc, parent = _build_service(publish_enabled=True)
+    org_id = uuid4()
+    video_id = uuid4()
+    user_id = uuid4()
+
+    with patch(
+        "app.modules.shorts_auto_product.service.sqs_producer."
+        "publish_product_track_job"
+    ) as mock_publish:
+        resp = await svc.enqueue_scan_order(
+            org_id=org_id,
+            video_id=video_id,
+            user_id=user_id,
+            body=_scan_order_body(),
+        )
+
+    assert resp.parent_job_id == parent.id
+    mock_publish.assert_called_once()
+    call_kwargs = mock_publish.call_args.kwargs
+    assert call_kwargs["mode"] == "scan_order"
+    assert call_kwargs["job_id"] == parent.id
+    assert call_kwargs["length_seconds"] == 60
+    assert call_kwargs["requested_count"] == 5
+    assert "catalog_entry_id" not in call_kwargs or call_kwargs["catalog_entry_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_skips_publish_when_flag_off():
+    svc, parent = _build_service(publish_enabled=False)
+
+    with patch(
+        "app.modules.shorts_auto_product.service.sqs_producer."
+        "publish_product_track_job"
+    ) as mock_publish:
+        resp = await svc.enqueue_scan_order(
+            org_id=uuid4(),
+            video_id=uuid4(),
+            user_id=uuid4(),
+            body=_scan_order_body(),
+        )
+
+    assert resp.parent_job_id == parent.id
+    # Parent row created but publish skipped — wizard UI shows
+    # 'queued' until the operator flips the flag on.
+    mock_publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_scan_order_503_when_publish_fails():
+    """Publisher raises (e.g. SQS outage) → service marks parent as
+    failed and raises 503 so the wizard UI can render a retry
+    affordance.
+    """
+    svc, parent = _build_service(publish_enabled=True)
+
+    with patch(
+        "app.modules.shorts_auto_product.service.sqs_producer."
+        "publish_product_track_job",
+        side_effect=RuntimeError("sqs offline"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await svc.enqueue_scan_order(
+                org_id=uuid4(),
+                video_id=uuid4(),
+                user_id=uuid4(),
+                body=_scan_order_body(),
+            )
+
+    assert exc.value.status_code == 503
+    # Parent row was marked failed via repo.fail.
+    svc.job_repo.fail.assert_awaited_once()
+    fail_kwargs = svc.job_repo.fail.await_args.kwargs
+    assert fail_kwargs["job_id"] == parent.id
+    assert fail_kwargs["error_code"] == "internal_error"

--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -203,32 +203,85 @@ class _CountingSam2Tracker:
 @dataclass
 class TrackJobMessage:
     """Decoded SQS body — matches
-    ``heimdex_media_contracts.product.ProductTrackJob``."""
+    ``heimdex_media_contracts.product.ProductTrackJob`` (v0.14.0+).
+
+    Fields ``catalog_entry_id`` and ``duration_preset_sec`` are
+    Optional in v0.14.0 to support the wizard scan_order parent flow,
+    which has no single catalog entry to anchor on.
+
+    Mode dispatch (in ``handle_track_job`` below):
+      * ``mode='enumerate'`` (default) AND ``catalog_entry_id`` set
+        → legacy single-product flow (existing track pipeline).
+      * ``mode='scan_order'`` AND ``catalog_entry_id`` is None
+        → wizard parent — process the whole video catalog. Real
+        per-catalog loop lands in PR #5b; PR #5a stubs this with a
+        clear ``not_yet_implemented`` failure so the dispatcher
+        doesn't crash on unknown shapes.
+      * ``mode='render_child'`` → reserved; render_child rows are
+        processed in-API by the child runner, NOT via SQS. If we
+        ever see one here, it's a bug — fail loudly.
+    """
 
     job_id: UUID
     org_id: UUID
     video_id: UUID  # DriveFile UUID, NOT the OS string id
-    catalog_entry_id: UUID
+    catalog_entry_id: UUID | None
     requested_by_user_id: UUID
-    duration_preset_sec: int
+    duration_preset_sec: int | None
     tracker_version: str
     enumeration_prompt_version: str
     callback_base_url: str
 
+    # v0.14.0 wizard fields — None for legacy senders.
+    mode: str = "enumerate"
+    length_seconds: int | None = None
+    requested_count: int | None = None
+    time_range_start_ms: int | None = None
+    time_range_end_ms: int | None = None
+    product_distribution: str | None = None
+    language: str | None = None
+    intent: str | None = None
+
     @classmethod
     def from_dict(cls, body: dict[str, Any]) -> "TrackJobMessage":
+        catalog_entry_id_raw = body.get("catalog_entry_id")
+        duration_preset_raw = body.get("duration_preset_sec")
         return cls(
             job_id=UUID(body["job_id"]),
             org_id=UUID(body["org_id"]),
             video_id=UUID(body["video_id"]),
-            catalog_entry_id=UUID(body["catalog_entry_id"]),
+            catalog_entry_id=(
+                UUID(catalog_entry_id_raw) if catalog_entry_id_raw else None
+            ),
             requested_by_user_id=UUID(body["requested_by_user_id"]),
-            duration_preset_sec=int(body["duration_preset_sec"]),
+            duration_preset_sec=(
+                int(duration_preset_raw) if duration_preset_raw is not None else None
+            ),
             tracker_version=str(body["tracker_version"]),
             enumeration_prompt_version=str(body["enumeration_prompt_version"]),
             # SECURITY (F3): tolerated-but-ignored. Future contract
             # bump should drop this field entirely.
             callback_base_url=str(body.get("callback_base_url", "")),
+            mode=str(body.get("mode", "enumerate")),
+            length_seconds=(
+                int(body["length_seconds"]) if "length_seconds" in body else None
+            ),
+            requested_count=(
+                int(body["requested_count"]) if "requested_count" in body else None
+            ),
+            time_range_start_ms=(
+                int(body["time_range_start_ms"])
+                if "time_range_start_ms" in body
+                else None
+            ),
+            time_range_end_ms=(
+                int(body["time_range_end_ms"])
+                if "time_range_end_ms" in body
+                else None
+            ),
+            product_distribution=body.get("product_distribution"),
+            language=body.get("language"),
+            intent=body.get("intent"),
         )
 
 
@@ -293,6 +346,58 @@ def handle_track_job(
                 )
                 return
             raise
+
+        # ─── 1.5 mode dispatch (Phase 4 PR #5a stub) ───────────────
+        # The wizard scan_order parent flow runs the per-catalog loop
+        # implemented in PR #5b. PR #5a only ships the publish path
+        # (API → SQS → here) so dispatcher integration can be verified
+        # without the full handler. Until #5b lands, scan_order
+        # messages /fail cleanly with a recognizable error_code so
+        # operators can confirm the message reached the worker.
+        if decoded.mode != "enumerate":
+            logger.warning(
+                "track_worker_unimplemented_mode",
+                extra={
+                    "job_id": str(decoded.job_id),
+                    "mode": decoded.mode,
+                    "note": (
+                        "PR #5a stub: real handler for mode=%s lands in "
+                        "PR #5b" % decoded.mode
+                    ),
+                },
+            )
+            api.fail(
+                job_id=decoded.job_id,
+                claimed_by=settings.worker_id,
+                cost_delta_usd=Decimal("0"),
+                error_code="internal_error",
+                error_message=(
+                    f"track-worker mode={decoded.mode!r} is recognized but "
+                    f"the per-catalog handler is not yet wired (Phase 4 "
+                    f"PR #5b). The API publishes scan_order messages only "
+                    f"when AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED "
+                    f"is set; flip it off until #5b is deployed."
+                ),
+            )
+            return
+
+        # Legacy single-product flow requires both fields. Defensive
+        # check: if the API somehow published a mode='enumerate'
+        # message without ``catalog_entry_id`` (shouldn't happen post
+        # #5a since publish_product_track_job branches on mode), fail
+        # clearly rather than crashing on the None-deref later.
+        if decoded.catalog_entry_id is None:
+            api.fail(
+                job_id=decoded.job_id,
+                claimed_by=settings.worker_id,
+                cost_delta_usd=Decimal("0"),
+                error_code="internal_error",
+                error_message=(
+                    "legacy track flow requires catalog_entry_id but the "
+                    "message body had it unset"
+                ),
+            )
+            return
 
         # ─── 2. heartbeat: resolving ───────────────────────────────
         api.heartbeat(


### PR DESCRIPTION
## Summary

Wires the wizard parent's track-job publish path. Service-side: `enqueue_scan_order` publishes to SQS after the parent DB row is created, gated on `auto_shorts_product_v2_publish_scan_order_enabled` (default OFF). Worker-side: `TrackJobMessage` decodes the v0.14.0 wizard fields and `handle_track_job` branches on `mode` — `mode='scan_order'` fails cleanly with a recognizable `error_code` until PR #5b ships the real per-catalog loop.

Plan: `.claude/plans/shorts-auto-product-v2-phase-4-7.md` §4-§6.

### What ships

**API side**:
* `sqs_producer.publish_product_track_job` extended with v0.14.0 wizard fields. `catalog_entry_id` and `duration_preset_sec` made Optional. The body dict omits None-valued fields so legacy senders don't leak noise onto the wire.
* `ProductScanService.enqueue_scan_order` publishes the parent track job after DB flush. Failure → marks parent failed via `repo.fail` + 503 response (wizard UI can render a retry affordance).
* New config flag `auto_shorts_product_v2_publish_scan_order_enabled` (default `False`).

**Worker side**:
* `TrackJobMessage` decoder accepts the v0.14.0 schema (Optional `catalog_entry_id` + new wizard fields).
* `handle_track_job` branches on `mode`. `mode='scan_order'` fails with `error_code=internal_error` and a clear `error_message` indicating PR #5b is pending. Defensive check on legacy flow (`mode='enumerate' AND catalog_entry_id IS NULL`) also fails cleanly.

### Why flag-gated

`extra='forbid'` on `ProductTrackJob` means a v0.13.0 worker reading a v0.14.0 message with new fields would 422. Operators must:

1. Land this PR (API publishes when flag is ON, but flag defaults OFF).
2. Trigger `build-gpu-images.yml` to rebuild the worker image with v0.14.0 contracts (sibling COPY in Dockerfile picks up `549abe1` automatically).
3. Deploy the new worker image to Aircloud.
4. **Then** flip `AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED=true` per env.

Skipping any of these = DLQ noise.

### Out of scope (PR #5b)

* Real per-catalog loop for `mode='scan_order'` in the worker.
* New internal endpoint `GET /internal/products/by-video/{video_id}` for the worker to enumerate active catalog entries.
* Aggregating appearances tagged by `catalog_entry_id`.
* Wizard end-to-end test on staging.

## Test plan

- [x] **6 new tests** in `tests/test_shorts_auto_product_publish.py`:
  - `publish_product_track_job` legacy body shape (catalog_entry_id + duration_preset_sec; no wizard fields).
  - `publish_product_track_job` scan_order body shape (mode + wizard fields; no legacy fields).
  - `publish_product_track_job` no-op when queue disabled.
  - `enqueue_scan_order` publishes when flag ON.
  - `enqueue_scan_order` skips publish when flag OFF.
  - `enqueue_scan_order` 503 when publisher raises (parent marked failed).
- [x] **90 tests pass** across the full `shorts_auto_product` module locally.
- [x] **339 CI allowlist tests** green locally.

## Risk

- **Scope-risk: narrow**. Worker stub fails cleanly on `mode='scan_order'` — no DLQ noise even if flag accidentally flips on before PR #5b lands (just visible failures with a clear error message).
- **Constraint**: flag default OFF + worker-rebuild-first protocol prevents the DLQ-flood failure mode.

## Stack

- ✅ Contracts v0.14.0 published to PyPI
- ✅ PR #114 / #115 / #118 — schema + service + scan-order endpoints + pin bump
- 🟡 PR #116 — fan-out hook (open)
- 🟡 PR #117 — child runner stub (open)
- 🟡 **This PR** — SQS publish + worker mode-dispatch stub
- ⏳ PR #5b — real per-catalog loop in worker + new internal endpoint
- ⏳ PR #6 — runner stub→real swap + pipeline lib helpers
- ⏳ PR #7 — frontend wizard