### PR TITLE
Phase 4 PR #6: wizard child runner real flow + vendored product_track lib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
             tests/test_internal_router_deferred_caption.py \
             tests/test_export_images.py \
             tests/test_vendored_product_track.py \
+            tests/test_single_product_picker.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,9 @@ jobs:
             tests/test_vendored_product_track.py \
             tests/test_single_product_picker.py \
             tests/test_composition_adapter.py \
+            tests/test_scene_id_utils.py \
+            tests/test_runner_real_swap.py \
+            tests/test_shorts_auto_product_child_runner.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
             tests/test_export_images.py \
             tests/test_vendored_product_track.py \
             tests/test_single_product_picker.py \
+            tests/test_composition_adapter.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
             tests/test_shorts_render_hardening.py \
             tests/test_internal_router_deferred_caption.py \
             tests/test_export_images.py \
+            tests/test_vendored_product_track.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/lib/product_track/__init__.py
+++ b/services/api/app/lib/product_track/__init__.py
@@ -1,0 +1,64 @@
+"""Vendored pure-math subset of ``heimdex_media_pipelines.product_track``.
+
+Source: ``heimdex-media-pipelines`` v0.12.3 (commit ``5d82c7d``).
+Vendored 2026-05-03 for the wizard child runner (Phase 4 PR #6) so the
+API can score windows + select subsets + build stitch plans without
+growing an install-time dependency on the pipelines repo.
+
+## Why vendored, not pip-installed
+
+* ``heimdex-media-pipelines`` is not on PyPI — its ``release.yml``
+  builds wheels and attaches them to GitHub Releases but does NOT
+  run ``pypa/gh-action-pypi-publish``. Workers install it via Docker
+  ``COPY ../heimdex-media-pipelines/ /tmp/...`` from a workspace-root
+  build context. The API uses a service-scoped Docker context, so
+  adopting the same install model would mean build-context surgery
+  across compose, GHA, and deploy scripts.
+* Plan §15 loose-coupling: "API never imports
+  ``heimdex_media_pipelines``." Vendoring honors this literally —
+  the runner imports ``app.lib.product_track`` and the upstream
+  package stays out of the API venv entirely.
+* The five files vendored here are pure-math (no transformers, no
+  opencv, no numpy beyond stdlib-equivalent uses), ~600 LOC total,
+  stable for the past 4 weeks (v0.10 → v0.12.3 only touched the
+  composition / blur subsystems, not ``product_track``). The
+  GPU-using siblings (``siglip2_retrieval``, ``sam2_pass``,
+  ``sam2_loader``, ``pipeline``) stay in the pipelines repo where
+  the workers run them.
+
+Note: torch is already a top-level API dep (via ``sentence-transformers``
+for cross-encoder reranking), so "torch-free" is not the win here.
+The win is no first-PyPI-publish risk and no Docker-context surgery.
+
+## Sync ritual
+
+When the upstream pure-math files change (rare — track via
+``git log heimdex-media-pipelines/src/heimdex_media_pipelines/product_track/``):
+
+1. Diff the upstream file against the vendored copy:
+   ``diff -u heimdex-media-pipelines/src/heimdex_media_pipelines/product_track/<file>.py services/api/app/lib/product_track/<file>.py``
+2. Apply the upstream changes by hand. The only mechanical rewrite
+   is ``heimdex_media_pipelines.product_track`` →
+   ``app.lib.product_track`` in cross-module imports.
+3. Bump the source-of-truth comment at the top of each vendored
+   file to reference the new upstream commit.
+4. Run ``pytest tests/lib/product_track/`` — the smoke test
+   imports the chain and asserts ``heimdex_media_pipelines`` is
+   NOT importable in the API venv (the actual coupling we prevent).
+
+## What's NOT vendored
+
+* ``siglip2_retrieval`` — calls SigLIP2 via transformers
+* ``sam2_pass`` / ``sam2_loader`` — calls SAM2 via transformers
+* ``pipeline`` — orchestrator that wires the GPU pieces together;
+  callers of the orchestrator are workers, not the API.
+
+## Modules
+
+* :mod:`config` — ``TrackingConfig`` dataclass + threshold defaults
+* :mod:`window_assembly` — ``AssembledWindow`` types
+* :mod:`alignment` — ``AnnotatedWindow`` + alignment helpers
+* :mod:`subset_selector` — ``ScoredWindow``, ``score_windows``,
+  ``select_subset``, ``GreedyPicker``, ``SubsetPicker`` Protocol
+* :mod:`stitching` — ``StitchPlan`` + ``build_stitch_plan``
+"""

--- a/services/api/app/lib/product_track/alignment.py
+++ b/services/api/app/lib/product_track/alignment.py
@@ -1,0 +1,195 @@
+# VENDORED from heimdex-media-pipelines v0.12.3 (5d82c7d).
+# See app/lib/product_track/__init__.py for the sync ritual.
+"""Narration + OCR alignment annotation.
+
+Given the assembled appearance windows + the catalog entry's
+``llm_label``, mark each window with two booleans the subset picker
+uses for scoring:
+
+* ``has_narration_mention`` — any token of the label appears as a
+  substring in any transcript segment that overlaps the window's
+  ``[start_ms, end_ms]``.
+* ``has_ocr_overlap`` — any OCR text overlaps the window. Plan §6.2
+  step 5 keeps this loose for v1 (boolean, no per-token match).
+
+Pure function: workers pre-fetch transcripts + OCR for the relevant
+scenes from the api's internal endpoints and pass them in.
+
+Korean handling notes (plan §6.2 step 5):
+  * substring match works for Hangul without tokenization.
+  * Romanization fallback for English-labeled products in Korean
+    transcripts (e.g., "Cetaphil" → "세타필") is a v2 enhancement.
+    For v1 we accept the false-negative rate; the subset picker
+    composite score doesn't hard-gate on narration so a missed
+    mention only loses the narration weight share.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from app.lib.product_track.window_assembly import (
+    AssembledWindow,
+)
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    """Per-scene transcript segment from the api's internal scene
+    endpoint. Multiple segments per scene are common (one per ASR
+    utterance / diarized turn).
+    """
+
+    scene_id: str
+    text: str
+    start_ms: int
+    end_ms: int
+
+
+@dataclass(frozen=True)
+class OcrSegment:
+    """One OCR detection from a keyframe in the scene. Workers pull
+    these per-scene; per-keyframe granularity is collapsed to
+    per-scene for v1 since OCR doesn't provide reliable temporal
+    bounds.
+    """
+
+    scene_id: str
+    text: str
+    # Optional temporal bounds — when None, the segment is treated as
+    # spanning the entire scene (which is the common v1 case).
+    start_ms: int | None = None
+    end_ms: int | None = None
+
+
+@dataclass(frozen=True)
+class AnnotatedWindow(AssembledWindow):
+    """An assembled window enriched with alignment booleans. Inherits
+    every field from AssembledWindow so downstream modules can treat
+    it as a drop-in replacement."""
+
+    has_narration_mention: bool = False
+    has_ocr_overlap: bool = False
+
+
+# Tokens shorter than this are stripped from the label — single-char
+# Korean particles or English articles produce too many false
+# positives in the substring search.
+_MIN_LABEL_TOKEN_LEN = 2
+
+
+def annotate_alignment(
+    windows: list[AssembledWindow],
+    *,
+    label: str,
+    transcripts: dict[str, list[TranscriptSegment]] | None = None,
+    ocr: dict[str, list[OcrSegment]] | None = None,
+) -> list[AnnotatedWindow]:
+    """Return ``windows`` with ``has_narration_mention`` /
+    ``has_ocr_overlap`` populated.
+
+    ``transcripts`` and ``ocr`` are scene_id → list maps. Missing
+    scenes (no transcript or no OCR yet) yield ``False`` for that
+    boolean — the subset picker composite score handles that
+    gracefully.
+
+    Rejected windows are passed through unchanged but still get the
+    booleans populated so callers can persist them for tuning.
+    """
+    transcripts = transcripts or {}
+    ocr = ocr or {}
+    label_tokens = _label_tokens(label)
+
+    out: list[AnnotatedWindow] = []
+    for w in windows:
+        scene_segments = transcripts.get(w.scene_id, [])
+        scene_ocr = ocr.get(w.scene_id, [])
+
+        narration = _has_narration_mention(
+            scene_segments,
+            label_tokens,
+            window_start_ms=w.window_start_ms,
+            window_end_ms=w.window_end_ms,
+        )
+        ocr_overlap = _has_ocr_overlap(
+            scene_ocr,
+            window_start_ms=w.window_start_ms,
+            window_end_ms=w.window_end_ms,
+        )
+
+        out.append(
+            AnnotatedWindow(
+                scene_id=w.scene_id,
+                window_start_ms=w.window_start_ms,
+                window_end_ms=w.window_end_ms,
+                avg_bbox_area_pct=w.avg_bbox_area_pct,
+                avg_confidence=w.avg_confidence,
+                peak_confidence=w.peak_confidence,
+                frame_count=w.frame_count,
+                rejected_reason=w.rejected_reason,
+                has_narration_mention=narration,
+                has_ocr_overlap=ocr_overlap,
+            )
+        )
+    return out
+
+
+def _label_tokens(label: str) -> list[str]:
+    """Split the label into matchable substring tokens. Whitespace +
+    common punctuation are separators. Tokens shorter than
+    ``_MIN_LABEL_TOKEN_LEN`` are dropped to limit substring false
+    positives."""
+
+    if not label:
+        return []
+    parts = re.split(r"[\s,/()|+&\-]+", label.strip().lower())
+    return [p for p in parts if len(p) >= _MIN_LABEL_TOKEN_LEN]
+
+
+def _has_narration_mention(
+    segments: list[TranscriptSegment],
+    label_tokens: list[str],
+    *,
+    window_start_ms: int,
+    window_end_ms: int,
+) -> bool:
+    if not label_tokens:
+        return False
+    for seg in segments:
+        if not _intervals_overlap(
+            seg.start_ms, seg.end_ms, window_start_ms, window_end_ms
+        ):
+            continue
+        text_lc = seg.text.lower()
+        if any(tok in text_lc for tok in label_tokens):
+            return True
+    return False
+
+
+def _has_ocr_overlap(
+    segments: list[OcrSegment],
+    *,
+    window_start_ms: int,
+    window_end_ms: int,
+) -> bool:
+    """Return True iff any OCR segment overlaps the window AND has
+    non-empty text. Segments without temporal bounds are assumed to
+    span the whole scene → treated as overlapping any window in that
+    scene."""
+
+    for seg in segments:
+        if not seg.text.strip():
+            continue
+        if seg.start_ms is None or seg.end_ms is None:
+            return True
+        if _intervals_overlap(
+            seg.start_ms, seg.end_ms, window_start_ms, window_end_ms
+        ):
+            return True
+    return False
+
+
+def _intervals_overlap(a_start: int, a_end: int, b_start: int, b_end: int) -> bool:
+    """Half-open interval overlap: [a_start, a_end) vs [b_start, b_end)."""
+    return a_start < b_end and b_start < a_end

--- a/services/api/app/lib/product_track/config.py
+++ b/services/api/app/lib/product_track/config.py
@@ -1,0 +1,85 @@
+# VENDORED from heimdex-media-pipelines v0.12.3 (5d82c7d).
+# See app/lib/product_track/__init__.py for the sync ritual.
+"""Tracking pipeline configuration — thresholds + dataclass.
+
+Defaults mirror plan §6.2 of `shorts-auto-product-v2.md`. Thresholds
+are calibrated by Phase 2 spike on staging goldens; the values here
+are the prod starting point. Workers can override via
+:class:`TrackingConfig` at construction time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Pipeline + scorer version strings. Bump together when any threshold
+# or algorithm here changes meaningfully — the API persists these on
+# every appearance + stitching plan, so historical jobs remain
+# attributable to the version that produced them.
+TRACKER_VERSION = "v1.0"
+SUBSET_PICKER_VERSION = "v1.0"
+
+# SigLIP2 retrieval thresholds (plan §6.2 step 2).
+COARSE_PREFILTER_THRESHOLD = 0.45
+PRECISE_PASS_THRESHOLD = 0.72
+COARSE_TOP_K = 60  # top scenes from the OS coarse pre-filter
+
+# SAM2 sampling cadence (plan §6.2 step 3). Sampling at 5 fps =
+# 200 ms between samples. Bbox is interpolated linearly between samples
+# so the published windows aren't artificially gappy.
+SAM2_SAMPLE_FPS = 5
+
+# Window assembly thresholds (plan §6.2 step 4).
+MIN_WINDOW_DURATION_MS = 1500
+MIN_AVG_BBOX_AREA_PCT = 0.02
+MIN_AVG_CONFIDENCE = 0.7
+MERGE_GAP_THRESHOLD_MS = 2000
+MAX_WINDOWS_PER_PRODUCT = 30
+
+# Subset selection composite score weights (plan §6.2 step 7). Sum
+# to 1.0 by construction; not enforced at runtime but worth keeping
+# them so when a tuning pass shifts one weight, the others land
+# proportionally.
+SCORE_WEIGHT_PROMINENCE = 0.35
+SCORE_WEIGHT_NARRATION = 0.25
+SCORE_WEIGHT_OCR = 0.15
+SCORE_WEIGHT_DURATION_FITNESS = 0.15
+SCORE_WEIGHT_SPREAD_BONUS = 0.10
+
+# Subset selection hard caps.
+SUBSET_DURATION_OVERSHOOT_FACTOR = 1.05  # never overshoot preset by >5%
+
+
+@dataclass(frozen=True)
+class TrackingConfig:
+    """Per-job tuning knobs. Defaults mirror the constants above."""
+
+    # Retrieval.
+    coarse_prefilter_threshold: float = COARSE_PREFILTER_THRESHOLD
+    precise_pass_threshold: float = PRECISE_PASS_THRESHOLD
+    coarse_top_k: int = COARSE_TOP_K
+
+    # SAM2 propagation.
+    sam2_sample_fps: int = SAM2_SAMPLE_FPS
+
+    # Window assembly.
+    min_window_duration_ms: int = MIN_WINDOW_DURATION_MS
+    min_avg_bbox_area_pct: float = MIN_AVG_BBOX_AREA_PCT
+    min_avg_confidence: float = MIN_AVG_CONFIDENCE
+    merge_gap_threshold_ms: int = MERGE_GAP_THRESHOLD_MS
+    max_windows_per_product: int = MAX_WINDOWS_PER_PRODUCT
+
+    # Subset scoring weights.
+    score_weight_prominence: float = SCORE_WEIGHT_PROMINENCE
+    score_weight_narration: float = SCORE_WEIGHT_NARRATION
+    score_weight_ocr: float = SCORE_WEIGHT_OCR
+    score_weight_duration_fitness: float = SCORE_WEIGHT_DURATION_FITNESS
+    score_weight_spread_bonus: float = SCORE_WEIGHT_SPREAD_BONUS
+
+    # Subset assembly hard cap.
+    subset_duration_overshoot_factor: float = SUBSET_DURATION_OVERSHOOT_FACTOR
+
+    # Version strings. Workers don't override these in the common
+    # case; tests sometimes do.
+    tracker_version: str = TRACKER_VERSION
+    subset_picker_version: str = SUBSET_PICKER_VERSION

--- a/services/api/app/lib/product_track/stitching.py
+++ b/services/api/app/lib/product_track/stitching.py
@@ -1,0 +1,72 @@
+# VENDORED from heimdex-media-pipelines v0.12.3 (5d82c7d).
+# See app/lib/product_track/__init__.py for the sync ritual.
+"""Stitching plan — selected windows → CompositionSpec-shaped output.
+
+Pure function: takes the picker's selected windows and assembles the
+plan the worker hands to the api's ``/internal/products/{job_id}/complete``
+callback.
+
+Plan §6.2 step 8 v1 contract: hard cuts only, no transitions. The
+worker is responsible for translating this plan into a real
+``CompositionSpec`` and POSTing to ``/api/shorts/render``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.lib.product_track.config import TrackingConfig
+from app.lib.product_track.subset_selector import (
+    ScoredWindow,
+)
+
+
+@dataclass(frozen=True)
+class StitchPlan:
+    """Lib-level stitch plan. Worker enriches with catalog_entry_id +
+    video_id (which the lib never sees) and constructs the contract
+    payload."""
+
+    duration_target_sec: int
+    duration_actual_ms: int
+    windows: list[ScoredWindow]
+    scorer_version: str
+    subset_picker_version: str
+
+
+def build_stitch_plan(
+    selected: list[ScoredWindow],
+    *,
+    duration_target_sec: int,
+    config: TrackingConfig | None = None,
+) -> StitchPlan:
+    """Assemble the stitch plan. Windows are reordered chronologically
+    here (paranoid — :func:`select_subset` already does this; we
+    re-sort so a hand-crafted picker can't accidentally produce an
+    out-of-order plan).
+
+    Raises ``ValueError`` if ``selected`` is empty — the api contract
+    requires ``windows: list[StitchWindow] = Field(..., min_length=1)``.
+    The worker must catch this and route to ``/fail`` with a
+    ``no_qualifying_windows`` reason rather than ``/complete``.
+    """
+    cfg = config or TrackingConfig()
+
+    if not selected:
+        raise ValueError(
+            "build_stitch_plan requires at least one selected window — "
+            "callers must route to /fail when select_subset returns []"
+        )
+
+    sorted_windows = sorted(
+        selected, key=lambda s: s.window.window_start_ms
+    )
+    duration_actual_ms = sum(s.window.duration_ms for s in sorted_windows)
+
+    return StitchPlan(
+        duration_target_sec=duration_target_sec,
+        duration_actual_ms=duration_actual_ms,
+        windows=sorted_windows,
+        scorer_version=cfg.tracker_version,
+        subset_picker_version=cfg.subset_picker_version,
+    )

--- a/services/api/app/lib/product_track/subset_selector.py
+++ b/services/api/app/lib/product_track/subset_selector.py
@@ -1,0 +1,213 @@
+# VENDORED from heimdex-media-pipelines v0.12.3 (5d82c7d).
+# See app/lib/product_track/__init__.py for the sync ritual.
+"""Subset selection — pick which appearance windows make the final clip.
+
+Two-step:
+
+  1. :func:`score_windows` — pure function that assigns a composite
+     score per accepted window using the plan §6.2 step 7 weights.
+  2. :func:`select_subset` — calls a :class:`SubsetPicker` (Protocol;
+     gpt-4o-mini-backed in prod, deterministic-greedy in tests) to
+     pick the subset that fits the duration target.
+
+Splitting this in two lets the LLM see scores it can reason about
+without re-deriving them, and lets tests skip the LLM entirely.
+
+The scorer is deterministic — same inputs → same scores. The picker
+may be non-deterministic (LLM call); the API persists the picker
+version so a re-pick can be reproduced if the model is the same.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from app.lib.product_track.alignment import AnnotatedWindow
+from app.lib.product_track.config import TrackingConfig
+
+
+@dataclass(frozen=True)
+class ScoredWindow:
+    """An :class:`AnnotatedWindow` augmented with the composite score
+    + per-component breakdown. The picker sees only this — never the
+    raw frame data."""
+
+    window: AnnotatedWindow
+    composite_score: float
+    score_components: dict[str, float] = field(default_factory=dict)
+
+
+class SubsetPicker(Protocol):
+    """The picker is responsible for honoring the duration target +
+    chronological ordering. Implementations:
+
+      * gpt-4o-mini in the worker
+      * deterministic greedy (this module's :func:`greedy_pick`)
+        for tests + as a fallback if the LLM call fails
+    """
+
+    def pick(
+        self,
+        candidates: list[ScoredWindow],
+        *,
+        duration_preset_sec: int,
+        config: TrackingConfig,
+    ) -> list[ScoredWindow]: ...
+
+
+def score_windows(
+    windows: list[AnnotatedWindow],
+    *,
+    duration_preset_sec: int,
+    config: TrackingConfig | None = None,
+) -> list[ScoredWindow]:
+    """Score accepted windows. Rejected windows are dropped — the
+    picker never sees them.
+
+    Composite weights (sum to 1.0 by construction in TrackingConfig):
+      * prominence = avg_bbox_area_pct (already in [0, 1])
+      * narration = 1 if has_narration_mention else 0
+      * ocr = 1 if has_ocr_overlap else 0
+      * duration_fitness = how close window duration is to the per-
+        window target = preset / target_count. Triangular: 1.0 at
+        target, linearly decreasing to 0 at 0× and 2× target.
+      * spread_bonus = encourages picking windows from different
+        timeline positions. Computed at score time as a flat 1.0
+        and reweighted by the picker if it has timeline context;
+        the scorer can't compute this in isolation since it depends
+        on the chosen subset.
+    """
+    cfg = config or TrackingConfig()
+    accepted = [w for w in windows if w.is_accepted]
+    if not accepted:
+        return []
+
+    # Heuristic per-window target duration. We assume the final clip
+    # has 3-5 windows (matches the auto-shorts cluster size locked
+    # in the existing shorts_auto module). Use 4 as the midpoint.
+    target_window_count = 4
+    target_per_window_ms = (duration_preset_sec * 1000) // target_window_count
+
+    out: list[ScoredWindow] = []
+    for w in accepted:
+        prominence = float(w.avg_bbox_area_pct)
+        narration = 1.0 if w.has_narration_mention else 0.0
+        ocr = 1.0 if w.has_ocr_overlap else 0.0
+        duration_fitness = _triangular_fit(
+            value=w.duration_ms, target=target_per_window_ms
+        )
+        spread_bonus = 1.0  # picker-reweighted; flat at score time
+
+        composite = (
+            cfg.score_weight_prominence * prominence
+            + cfg.score_weight_narration * narration
+            + cfg.score_weight_ocr * ocr
+            + cfg.score_weight_duration_fitness * duration_fitness
+            + cfg.score_weight_spread_bonus * spread_bonus
+        )
+        # Numerical safety: clamp to [0, 1] in case weights drift
+        # past 1.0 in a future tuning. Contracts validator hard-gates
+        # composite_score in [0, 1].
+        composite = max(0.0, min(1.0, composite))
+
+        out.append(
+            ScoredWindow(
+                window=w,
+                composite_score=composite,
+                score_components={
+                    "prominence": prominence,
+                    "narration": narration,
+                    "ocr": ocr,
+                    "duration_fitness": duration_fitness,
+                    "spread_bonus": spread_bonus,
+                },
+            )
+        )
+    return out
+
+
+def select_subset(
+    scored: list[ScoredWindow],
+    *,
+    picker: SubsetPicker,
+    duration_preset_sec: int,
+    config: TrackingConfig | None = None,
+) -> list[ScoredWindow]:
+    """Hand scored candidates to the picker. The picker MUST honor
+    the hard duration cap (preset × overshoot factor). This wrapper
+    enforces:
+      * chronological output order (by window_start_ms)
+      * the duration overshoot guard (a slightly-paranoid trim if
+        the picker overshoots — last resort, should never fire in
+        prod since the picker prompt enforces it).
+    """
+    cfg = config or TrackingConfig()
+    if not scored:
+        return []
+
+    picked = picker.pick(
+        scored, duration_preset_sec=duration_preset_sec, config=cfg
+    )
+    picked = sorted(picked, key=lambda s: s.window.window_start_ms)
+
+    max_ms = int(duration_preset_sec * 1000 * cfg.subset_duration_overshoot_factor)
+    total_ms = sum(s.window.duration_ms for s in picked)
+    while total_ms > max_ms and picked:
+        # Drop the lowest-composite-score window first.
+        worst = min(picked, key=lambda s: s.composite_score)
+        picked.remove(worst)
+        total_ms = sum(s.window.duration_ms for s in picked)
+
+    return picked
+
+
+# ---------- deterministic fallback picker ----------
+
+
+@dataclass(frozen=True)
+class GreedyPicker:
+    """Deterministic greedy picker. Sorts by composite score desc,
+    accumulates windows until the duration target is hit (without
+    overshooting beyond the cfg overshoot factor).
+
+    Used as the test fixture and as the worker's fallback if the LLM
+    call fails / hits budget cap.
+    """
+
+    def pick(
+        self,
+        candidates: list[ScoredWindow],
+        *,
+        duration_preset_sec: int,
+        config: TrackingConfig,
+    ) -> list[ScoredWindow]:
+        target_ms = duration_preset_sec * 1000
+        max_ms = int(target_ms * config.subset_duration_overshoot_factor)
+        ranked = sorted(candidates, key=lambda s: s.composite_score, reverse=True)
+        chosen: list[ScoredWindow] = []
+        running = 0
+        for s in ranked:
+            d = s.window.duration_ms
+            if running + d > max_ms:
+                continue
+            chosen.append(s)
+            running += d
+            if running >= target_ms:
+                break
+        return chosen
+
+
+# ---------- helpers ----------
+
+
+def _triangular_fit(*, value: int, target: int) -> float:
+    """Triangular fit: 1.0 at value=target, 0.0 at value=0 or
+    value=2×target, linear in between. Clamped to [0, 1]."""
+    if target <= 0:
+        return 0.0
+    if value <= 0 or value >= 2 * target:
+        return 0.0
+    if value <= target:
+        return value / target
+    return (2 * target - value) / target

--- a/services/api/app/lib/product_track/window_assembly.py
+++ b/services/api/app/lib/product_track/window_assembly.py
@@ -1,0 +1,191 @@
+# VENDORED from heimdex-media-pipelines v0.12.3 (5d82c7d).
+# See app/lib/product_track/__init__.py for the sync ritual.
+"""Window assembly — group SAM2-propagated frames into AppearanceWindows.
+
+Pure function: takes :class:`FrameDetection` rows from
+:mod:`sam2_pass`, returns :class:`AssembledWindow` records that the
+worker turns into ``AppearanceWindow`` contracts on the API callback.
+
+Algorithm (plan §6.2 step 4):
+
+  1. Group detections by ``scene_id``.
+  2. Within scene, sort by ``frame_timestamp_ms``.
+  3. Merge consecutive samples whose gap < ``merge_gap_threshold_ms``
+     into one window. The SAM2 sample cadence (5 fps = 200 ms) means
+     a single dropped sample looks like a 400 ms gap; any user-visible
+     "discontinuity" needs to be at least 2 s.
+  4. Per window: compute averages + peak from the contained frames.
+  5. Filter: drop windows shorter than ``min_window_duration_ms``,
+     with ``avg_bbox_area_pct < min_avg_bbox_area_pct``, or with
+     ``avg_confidence < min_avg_confidence``. Rejected windows are
+     KEPT in the output list with a populated ``rejected_reason`` so
+     the API can persist the rejected rows for threshold tuning later.
+  6. Cap accepted windows at ``max_windows_per_product`` — sort by
+     a quality proxy (avg_confidence × avg_bbox_area_pct) descending
+     and drop the tail. Rejected windows are not capped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.lib.product_track.config import TrackingConfig
+
+
+@dataclass(frozen=True)
+class FrameDetection:
+    """One SAM2-propagated frame sample for a single catalog entry.
+
+    Constructed by :mod:`sam2_pass`. Frame ordering within a scene is
+    by ``frame_timestamp_ms``, NOT ``frame_idx`` — frame indices are
+    scene-relative and reset at scene boundaries, while timestamps
+    are absolute over the source video.
+    """
+
+    scene_id: str
+    frame_idx: int
+    frame_timestamp_ms: int
+    bbox_area_pct: float  # bbox area / frame area, in [0, 1]
+    confidence: float  # SAM2 mask confidence in [0, 1]
+
+
+# Rejection reasons — string literals matching the contracts'
+# ``RejectedReason`` enum so the worker can pass them through without
+# re-mapping.
+REJECT_TOO_SHORT = "duration_below_floor"
+REJECT_BBOX_TOO_SMALL = "bbox_area_below_floor"
+REJECT_LOW_CONFIDENCE = "confidence_below_floor"
+
+
+@dataclass(frozen=True)
+class AssembledWindow:
+    """One assembled appearance window. Worker maps this to
+    ``heimdex_media_contracts.product.AppearanceWindow``."""
+
+    scene_id: str
+    window_start_ms: int
+    window_end_ms: int
+    avg_bbox_area_pct: float
+    avg_confidence: float
+    peak_confidence: float
+    frame_count: int
+    rejected_reason: str | None = None
+
+    @property
+    def duration_ms(self) -> int:
+        return self.window_end_ms - self.window_start_ms
+
+    @property
+    def is_accepted(self) -> bool:
+        return self.rejected_reason is None
+
+
+def assemble_windows(
+    detections: list[FrameDetection],
+    *,
+    config: TrackingConfig | None = None,
+) -> list[AssembledWindow]:
+    """Group per-frame detections into appearance windows.
+
+    Returns the full list of windows — both accepted and rejected.
+    Workers persist all of them for threshold-tuning visibility but
+    only feed accepted ones to the subset selector.
+    """
+    cfg = config or TrackingConfig()
+
+    if not detections:
+        return []
+
+    # Group by scene_id, preserving deterministic order across scenes.
+    by_scene: dict[str, list[FrameDetection]] = {}
+    for d in detections:
+        by_scene.setdefault(d.scene_id, []).append(d)
+
+    assembled: list[AssembledWindow] = []
+    for scene_id in sorted(by_scene.keys()):
+        frames = sorted(by_scene[scene_id], key=lambda f: f.frame_timestamp_ms)
+        assembled.extend(_assemble_one_scene(scene_id, frames, cfg))
+
+    accepted = [w for w in assembled if w.is_accepted]
+    rejected = [w for w in assembled if not w.is_accepted]
+
+    # Cap accepted windows globally (across scenes). Quality proxy
+    # = avg_confidence × avg_bbox_area_pct so we prefer windows
+    # where the product is both prominent AND tracked confidently.
+    if len(accepted) > cfg.max_windows_per_product:
+        accepted.sort(
+            key=lambda w: w.avg_confidence * w.avg_bbox_area_pct,
+            reverse=True,
+        )
+        accepted = accepted[: cfg.max_windows_per_product]
+
+    # Stable order by start time for the final output (across scenes).
+    out = accepted + rejected
+    out.sort(key=lambda w: (w.scene_id, w.window_start_ms))
+    return out
+
+
+def _assemble_one_scene(
+    scene_id: str,
+    frames: list[FrameDetection],
+    cfg: TrackingConfig,
+) -> list[AssembledWindow]:
+    """Walk a scene's frames in time order, splitting on gaps that
+    exceed the merge threshold. Apply the per-window filter at the
+    end."""
+
+    if not frames:
+        return []
+
+    runs: list[list[FrameDetection]] = [[frames[0]]]
+    for f in frames[1:]:
+        prev = runs[-1][-1]
+        gap = f.frame_timestamp_ms - prev.frame_timestamp_ms
+        if gap > cfg.merge_gap_threshold_ms:
+            runs.append([f])
+        else:
+            runs[-1].append(f)
+
+    out: list[AssembledWindow] = []
+    for run in runs:
+        out.append(_window_from_run(scene_id, run, cfg))
+    return out
+
+
+def _window_from_run(
+    scene_id: str,
+    run: list[FrameDetection],
+    cfg: TrackingConfig,
+) -> AssembledWindow:
+    start = run[0].frame_timestamp_ms
+    end = run[-1].frame_timestamp_ms
+    n = len(run)
+    avg_bbox = sum(f.bbox_area_pct for f in run) / n
+    avg_conf = sum(f.confidence for f in run) / n
+    peak_conf = max(f.confidence for f in run)
+
+    # Single-frame runs synthesize a 1-sample-period duration so
+    # window_end_ms > window_start_ms (contract validator requirement).
+    # 200 ms matches the 5 fps default sampling cadence.
+    if end <= start:
+        end = start + max(1, 1000 // cfg.sam2_sample_fps)
+
+    duration = end - start
+    rejected: str | None = None
+    if duration < cfg.min_window_duration_ms:
+        rejected = REJECT_TOO_SHORT
+    elif avg_bbox < cfg.min_avg_bbox_area_pct:
+        rejected = REJECT_BBOX_TOO_SMALL
+    elif avg_conf < cfg.min_avg_confidence:
+        rejected = REJECT_LOW_CONFIDENCE
+
+    return AssembledWindow(
+        scene_id=scene_id,
+        window_start_ms=start,
+        window_end_ms=end,
+        avg_bbox_area_pct=avg_bbox,
+        avg_confidence=avg_conf,
+        peak_confidence=peak_conf,
+        frame_count=n,
+        rejected_reason=rejected,
+    )

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -97,14 +97,20 @@ async def lifespan(app: FastAPI):
     # rows produced by the parent fan-out hook in
     # ``shorts_auto_product.internal_router.complete``. One runner per
     # API replica; DB-atomic claim resolves the race across replicas.
-    # Stub processing in PR #4 (claim → /complete with render_job_id=None);
-    # real picker + render-service integration in PR #5.
+    # Real picker + render-service integration shipped in PR #6
+    # (``children/runner.py::_process_child_payload``).
     from app.db.base import get_async_session_factory
     from app.modules.shorts_auto_product.children import create_child_runner
 
     child_runner = create_child_runner(
         settings=settings,
         session_factory=get_async_session_factory(),
+        # ``ShortsRenderService`` (constructed inside the runner per
+        # render call) needs the scene OS client to validate
+        # scene_clip boundaries before persisting the render job.
+        # Set on app.state above; reused here so the runner doesn't
+        # have to re-read settings or open its own OS connection.
+        scene_search_client=app.state.scene_opensearch_client,
     )
     child_runner.start()
     app.state.product_v2_child_runner = child_runner

--- a/services/api/app/modules/shorts_auto_product/children/composition.py
+++ b/services/api/app/modules/shorts_auto_product/children/composition.py
@@ -1,0 +1,105 @@
+"""``StitchPlan`` → :class:`CompositionSpec` adapter for the wizard runner.
+
+## Why this lives here, not lifted to a shared lib
+
+There is no third-party package both the API and
+``services/product-track-worker/`` can import from. The vendored
+``app/lib/product_track/`` is API-only; ``services/product-track-worker/``
+is a fully isolated container that doesn't ship API code.
+``heimdex_media_contracts`` defines :class:`CompositionSpec` but does
+not (and should not) know about ``StitchPlan`` — that is a pipelines
+type. Adding a contracts→pipelines reverse dependency to host this
+adapter would invert the layering.
+
+So the worker keeps its own copy of the same mapping in
+``services/product-track-worker/src/tasks/track.py::_build_composition_spec``
+and the API runner imports this module. The two implementations
+must produce equivalent output for identical inputs (the ``CompositionSpec``
+contract is the spec); the equivalence test in
+``tests/test_composition_adapter.py`` snapshots the dict shape both
+sides emit.
+
+## What the adapter does
+
+Each ``StitchPlan.windows[i]`` (a :class:`ScoredWindow` with an inner
+:class:`AnnotatedWindow` carrying ``scene_id`` + ``window_start_ms`` +
+``window_end_ms``) becomes one :class:`SceneClipSpec`. Clips are
+placed back-to-back chronologically on the composition timeline.
+
+* Source type is hard-coded ``gdrive`` (livecommerce only ingests
+  via Drive in v1; future Drive sources need a per-source switch).
+* ``volume=1.0``, no transitions, no subtitles — hard cuts only,
+  matching plan §6.2 step 8 v1 contract.
+* ``output`` is left to ``CompositionSpec``'s default_factory which
+  produces 9:16 vertical 720p mp4 — the v1 product-mode shorts UX.
+
+## Empty-plan guard
+
+The contracts validator rejects ``scene_clips=[]`` (`min_length=1`).
+The runner is expected to terminate early with ``_terminate_no_render``
+when ``select_subset`` returns nothing — this adapter never sees an
+empty plan in the happy path. Defensive: we raise ``ValueError``
+with a clear message rather than letting the contracts validator
+emit a confusing 422 traceback far from the call site.
+"""
+
+from __future__ import annotations
+
+from heimdex_media_contracts.composition.schemas import (
+    CompositionSpec,
+    SceneClipSpec,
+)
+
+from app.lib.product_track.stitching import StitchPlan
+
+
+def build_composition_spec_from_stitch_plan(
+    *,
+    plan: StitchPlan,
+    os_video_id: str,
+) -> CompositionSpec:
+    """Convert a :class:`StitchPlan` into a typed :class:`CompositionSpec`.
+
+    ``os_video_id`` is the OpenSearch string id (``gd_abc...``) that
+    :class:`SceneClipSpec.video_id` accepts — the same shape
+    :class:`RenderJobCreate` already takes. Callers obtain it from the
+    parent ``ProductScanJob`` row's ``video_id`` (which the wizard
+    persists as the OS string id, not the DriveFile UUID).
+
+    Raises:
+        ValueError: ``plan.windows`` is empty. The runner must check
+            for this and terminate the child via
+            ``complete_tracking(render_job_id=None)`` rather than
+            calling this adapter.
+    """
+    if not plan.windows:
+        raise ValueError(
+            "stitch plan has no windows — cannot build a CompositionSpec; "
+            "caller must terminate the child without a render"
+        )
+
+    timeline_cursor_ms = 0
+    scene_clips: list[SceneClipSpec] = []
+    for scored in plan.windows:
+        # ``StitchPlan.windows`` is ``list[ScoredWindow]``; the inner
+        # ``ScoredWindow.window`` is the :class:`AnnotatedWindow`
+        # with the actual time range.
+        window = scored.window
+        clip_duration_ms = window.window_end_ms - window.window_start_ms
+        scene_clips.append(
+            SceneClipSpec(
+                scene_id=window.scene_id,
+                video_id=os_video_id,
+                source_type="gdrive",
+                start_ms=window.window_start_ms,
+                end_ms=window.window_end_ms,
+                timeline_start_ms=timeline_cursor_ms,
+                volume=1.0,
+                # crop_x/y/w/h default to full-frame (0, 0, 1, 1).
+            )
+        )
+        timeline_cursor_ms += clip_duration_ms
+
+    # output / subtitles / overlays / transitions all use
+    # CompositionSpec's default_factory — see contracts/composition/schemas.py.
+    return CompositionSpec(scene_clips=scene_clips)

--- a/services/api/app/modules/shorts_auto_product/children/picker.py
+++ b/services/api/app/modules/shorts_auto_product/children/picker.py
@@ -1,0 +1,156 @@
+"""Phase 4 single-product picker — round-robin catalog selection.
+
+The wizard's ``개별 상품`` mode produces N shorts, each dedicated to
+one catalog entry. Across the N shorts, products are distributed
+round-robin so 5 shorts of 3 products map to ``[c1, c2, c3, c1, c2]``
+(plan §7.1).
+
+## Why this lives in the API, not the vendored ``app.lib.product_track``
+
+The vendored lib is a frozen snapshot of pure upstream pure-math
+(see ``app/lib/product_track/__init__.py`` for the sync ritual). It
+intentionally does not know about ``catalog_entry_id`` — that is a
+server-side identifier the worker tags appearances with on the
+``/complete`` callback, never visible to the lib's pickers. Adding
+catalog-awareness inside the lib would either:
+
+  * Pollute ``ScoredWindow`` with a ``catalog_entry_id`` field that
+    the upstream lib doesn't need (and can't populate — it doesn't
+    see UUIDs), forcing a permanent vendor divergence.
+  * Or smuggle the catalog ID via a parallel structure that
+    duplicates the chronological ordering work ``select_subset``
+    already does.
+
+Both options tightly couple the lib to API-side concerns. Instead,
+the runner does a two-step pick:
+
+  1. ``SingleProductSubsetPicker.pick_catalog`` — choose ONE catalog
+     by round-robin on ``shorts_index``.
+  2. Filter ``ProductAppearance`` rows to that catalog, score them,
+     hand the result to the vendored ``select_subset`` with a vanilla
+     :class:`GreedyPicker` (or LLM picker, when one ships for the
+     wizard).
+
+This keeps the lib pure-math + catalog-blind, while the API owns
+the orchestration layer that knows about UUIDs and DB rows.
+
+## Phase 5 (multi-product picker)
+
+Phase 5 will need cross-product awareness — a single short that
+mixes products. That picker DOES need ``catalog_entry_id`` visible
+to the picking step, which is a more intrusive change. The plan
+(§10) specifies it lives alongside this module, NOT inside the
+vendored lib, for the same coupling reasons.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+from uuid import UUID
+
+
+def pick_catalog_for_shorts_index(
+    *,
+    catalog_ids: Iterable[UUID],
+    shorts_index: int,
+) -> UUID:
+    """Round-robin select one catalog id for a given ``shorts_index``.
+
+    ``shorts_index`` is 1-based (matches the DB column convention in
+    migration 052: ``CHECK (shorts_index >= 1)``).
+
+    Determinism: ``catalog_ids`` is sorted before indexing so the
+    same input set always maps to the same shorts_index → catalog.
+    Without the sort, set/dict iteration order would let two API
+    replicas hand the same scan order's child #2 to different
+    products — which would persist to ``ProductScanJob.catalog_entry_id``
+    and confuse the user-facing "which products got which short"
+    rollup.
+
+    Raises:
+        ValueError: ``catalog_ids`` is empty or ``shorts_index < 1``.
+    """
+    ids = sorted(set(catalog_ids))
+    if not ids:
+        raise ValueError("catalog_ids must be non-empty")
+    if shorts_index < 1:
+        raise ValueError(
+            f"shorts_index must be >= 1; got {shorts_index}"
+        )
+    # Convert 1-based index to 0-based for modulo distribution.
+    return ids[(shorts_index - 1) % len(ids)]
+
+
+@dataclass(frozen=True)
+class CatalogPick:
+    """Result of :meth:`SingleProductSubsetPicker.pick_catalog`.
+
+    Carries the chosen ``catalog_entry_id`` and the input set's size
+    so the runner can log "child 2/5 picked product 'cleanser' from
+    {3 candidate products}" without redundantly recomputing.
+
+    The runner uses ``catalog_entry_id`` to:
+      * Filter ``ProductAppearance`` rows down to that catalog before
+        scoring.
+      * Persist on the child ``ProductScanJob`` row so the user-facing
+        per-short rollup (Phase 6 wizard step 4) can show "Short 2:
+        Cleanser" without an extra DB join.
+    """
+
+    catalog_entry_id: UUID
+    candidates_count: int
+
+
+class SingleProductSubsetPicker:
+    """Phase 4 single-mode catalog selector.
+
+    Stateless across calls — every call to :meth:`pick_catalog`
+    derives its result from arguments alone. Construction takes no
+    state in the Phase 4 single-mode flow; the constructor exists
+    so tests + Phase 5's :class:`MultiProductSubsetPicker` can
+    follow the same shape (DI for an inner picker, version stamps,
+    etc.) when they ship.
+
+    Loose-coupling: this class does NOT implement the lib's
+    :class:`SubsetPicker` protocol. It returns a
+    :class:`CatalogPick` (catalog choice), not a window subset, so
+    its surface is intentionally different from the picker the
+    vendored ``select_subset`` consumes. After choosing a catalog,
+    the runner narrows the windows and hands them to a separate
+    lib-level picker (default :class:`GreedyPicker`, future LLM
+    picker).
+    """
+
+    # Bumped when the catalog-selection algorithm changes in a way
+    # that would alter the (shorts_index → catalog) mapping for the
+    # same input. The runner persists this on the parent's
+    # ``picker_version`` field so historical jobs are reproducible.
+    VERSION: str = "single-rr-v1"
+
+    def pick_catalog(
+        self,
+        *,
+        catalog_ids: Iterable[UUID],
+        shorts_index: int,
+    ) -> CatalogPick:
+        """Pick the catalog for ``shorts_index``.
+
+        Thin wrapper over :func:`pick_catalog_for_shorts_index` —
+        exists so the picker class can be swapped in tests and so
+        the call site reads naturally:
+
+            picker = SingleProductSubsetPicker()
+            pick = picker.pick_catalog(catalog_ids=…, shorts_index=…)
+        """
+        # Materialize the input so we can both call the helper and
+        # report the candidate count without consuming a one-shot
+        # iterator twice.
+        materialized = list(set(catalog_ids))
+        chosen = pick_catalog_for_shorts_index(
+            catalog_ids=materialized, shorts_index=shorts_index,
+        )
+        return CatalogPick(
+            catalog_entry_id=chosen,
+            candidates_count=len(materialized),
+        )

--- a/services/api/app/modules/shorts_auto_product/children/runner.py
+++ b/services/api/app/modules/shorts_auto_product/children/runner.py
@@ -78,8 +78,34 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import Settings
+from app.lib.product_track.config import TrackingConfig
+from app.lib.product_track.stitching import build_stitch_plan
+from app.lib.product_track.subset_selector import (
+    GreedyPicker,
+    ScoredWindow,
+    score_windows,
+    select_subset,
+)
+from app.modules.shorts_auto_product.children.composition import (
+    build_composition_spec_from_stitch_plan,
+)
+from app.modules.shorts_auto_product.children.picker import (
+    SingleProductSubsetPicker,
+)
+from app.modules.shorts_auto_product.children.scene_id_utils import (
+    os_video_id_from_scene_id,
+)
 from app.modules.shorts_auto_product.models import (
+    PRODUCT_DISTRIBUTION_SINGLE,
     SCAN_STAGE_ASSEMBLING,
+    ProductAppearance,
+    ProductScanJob,
+)
+from app.modules.shorts_auto_product.repositories.appearance import (
+    ProductAppearanceRepository,
+)
+from app.modules.shorts_auto_product.repositories.catalog import (
+    ProductCatalogRepository,
 )
 from app.modules.shorts_auto_product.repositories.job import (
     ProductScanJobRepository,
@@ -126,11 +152,23 @@ class ChildRunner:
         *,
         settings: Settings,
         session_factory: async_sessionmaker[AsyncSession],
+        scene_search_client: object,
         instance_id: str | None = None,
         process_child_fn: Callable[[UUID], Awaitable[None]] | None = None,
     ) -> None:
         self.settings = settings
         self.session_factory = session_factory
+        # Production: ``app.state.scene_opensearch_client`` (set in
+        # ``app.main:lifespan`` before ``ChildRunner.start()``). Tests
+        # inject a no-op stub — only `_validate_scene_clips` (called
+        # inside ``ShortsRenderService.create_render_job``) touches
+        # this object, and tests typically inject the entire render
+        # service via ``process_child_fn`` so the real OS client
+        # isn't reached.
+        # Typed as ``object`` deliberately: the prod client is
+        # ``opensearchpy.AsyncOpenSearch`` but tests pass in
+        # MagicMock instances; loose typing keeps both paths happy.
+        self.scene_search_client = scene_search_client
         self.instance_id = instance_id or _default_instance_id()
         # Allow tests to inject a fake processor that doesn't actually
         # call repo / render service. Production callers leave this
@@ -286,24 +324,37 @@ class ChildRunner:
                 )
 
     async def _process_child_payload(self, child_id: UUID) -> None:
-        """The actual child-processing step.
+        """The actual child-processing step (Phase 4 PR #6).
 
-        **Phase 4 PR #4 stub**: claim → /complete with
-        ``render_job_id=None``. Real picker + render-service call
-        lands in PR #5.
+        Flow:
 
-        The split of repo work across two transactions (claim ↔
-        complete) is intentional:
+          1. Claim the child (queued → assembling).
+          2. Read parent + active appearances + catalog set.
+          3. Pick a catalog by round-robin on parent.shorts_index
+             (Phase 4 single-product mode).
+          4. Filter appearances to that catalog → score → select
+             subset → build stitch plan.
+          5. Build CompositionSpec via the typed adapter.
+          6. Call ``ShortsRenderService.create_render_job`` directly
+             (no self-HTTP — plan §15 carve-out).
+          7. ``complete_tracking(render_job_id=…)`` to terminal.
 
-          * The first transaction commits the claim so the row is
-            visible as ``claimed_by=api-child-…`` to other replicas.
-            Without this commit, two replicas could each see the
-            row as queued and both try to claim — though the second
-            UPDATE would still fail and return None, the wasted
-            poll cycle is avoidable.
-          * The second transaction holds the actual work + /complete.
-            PR #5 will widen this transaction to include the picker
-            cost rollup and render-service call.
+        Multiple "no qualifying" outcomes (no catalogs, no
+        appearances, picker returns []) all land at step 7 with
+        ``render_job_id=None`` so the user-facing UI shows
+        "no render produced" rather than "failed". Real failures
+        (DB error, render service error) raise out of this method
+        and are caught by ``_run_one_child``'s catch-all, which
+        invokes ``_mark_child_failed``.
+
+        Sessions are split across stages on purpose: claim commits
+        immediately so the lease is visible to other replicas;
+        render creation self-commits inside the service; completion
+        is its own transaction. A crash between render creation
+        and completion is partially mitigated by
+        ``ShortsRenderService``'s 30s composition_hash dedupe — a
+        retry with the same windows hits the dedupe and reuses the
+        render row.
         """
         # ── 1. Claim ──────────────────────────────────────────────
         async with self.session_factory() as session:
@@ -317,9 +368,6 @@ class ChildRunner:
                 next_stage=SCAN_STAGE_ASSEMBLING,
             )
             if claimed is None:
-                # Another replica already claimed this child OR the
-                # row is no longer in 'queued' (already processed,
-                # cancelled, etc.). No-op.
                 logger.debug(
                     "child_already_claimed_or_terminal",
                     extra={
@@ -330,47 +378,270 @@ class ChildRunner:
                 return
             await session.commit()
 
-        # ── 2. Stub work (PR #4) ──────────────────────────────────
-        # PR #5 replaces this section with:
-        #   - read parent + active appearances
-        #   - run select_subset / build_stitch_plan via heimdex_media_pipelines
-        #   - call shorts_render_service.create_render_job
-        #   - persist render_job_id in the /complete call below
-        logger.info(
-            "child_runner_processed_child_stub",
-            extra={
-                "child_id": str(child_id),
-                "instance_id": self.instance_id,
-                "note": "PR #4 stub; real render integration pending PR #5",
-            },
+        # ── 2. Read child + parent + catalog set ──────────────────
+        loaded = await self._load_child_context(child_id=child_id)
+        if loaded is None:
+            await self._complete_no_render(
+                child_id=child_id,
+                reason="no_catalog_or_parent",
+            )
+            return
+
+        child, parent, catalog_label_lookup = loaded
+
+        # ── 3. Pick a catalog for this child ──────────────────────
+        # Phase 4 single-mode is the only path live; Phase 5
+        # multi-mode lands a different orchestration that selects
+        # catalogs differently.
+        distribution = (
+            parent.product_distribution or PRODUCT_DISTRIBUTION_SINGLE
+        )
+        if distribution != PRODUCT_DISTRIBUTION_SINGLE:
+            # Defensive: the public router gates wizard submissions
+            # to PRODUCT_DISTRIBUTION_SINGLE for now. If a multi-mode
+            # row sneaks through, fail loudly so the operator sees
+            # it rather than silently producing a single-mode short.
+            raise NotImplementedError(
+                f"product_distribution={distribution!r} not yet "
+                f"implemented (Phase 5 deliverable)"
+            )
+
+        try:
+            catalog_pick = SingleProductSubsetPicker().pick_catalog(
+                catalog_ids=list(catalog_label_lookup.keys()),
+                shorts_index=child.shorts_index or 1,
+            )
+        except ValueError:
+            await self._complete_no_render(
+                child_id=child_id,
+                reason="picker_value_error",
+            )
+            return
+
+        chosen_catalog_id = catalog_pick.catalog_entry_id
+        catalog_label = catalog_label_lookup.get(chosen_catalog_id)
+
+        # ── 4. Score + select windows for the chosen catalog ──────
+        appearances = await self._load_appearances_for_catalog(
+            org_id=parent.org_id, catalog_entry_id=chosen_catalog_id,
+        )
+        if not appearances:
+            logger.info(
+                "child_no_appearances_for_chosen_catalog",
+                extra={
+                    "child_id": str(child_id),
+                    "catalog_entry_id": str(chosen_catalog_id),
+                },
+            )
+            await self._complete_no_render(
+                child_id=child_id,
+                reason="no_appearances_for_catalog",
+            )
+            return
+
+        annotated_windows = [
+            _appearance_to_annotated_window(a) for a in appearances
+        ]
+        cfg = TrackingConfig()
+        length_seconds = parent.length_seconds or parent.duration_preset_sec or 60
+        scored = score_windows(
+            annotated_windows,
+            duration_preset_sec=length_seconds,
+            config=cfg,
+        )
+        if not scored:
+            await self._complete_no_render(
+                child_id=child_id,
+                reason="no_scored_windows",
+            )
+            return
+
+        selected = select_subset(
+            scored,
+            picker=GreedyPicker(),
+            duration_preset_sec=length_seconds,
+            config=cfg,
+        )
+        if not selected:
+            await self._complete_no_render(
+                child_id=child_id,
+                reason="picker_returned_empty",
+            )
+            return
+
+        plan = build_stitch_plan(
+            selected,
+            duration_target_sec=length_seconds,
+            config=cfg,
+        )
+        os_video_id = os_video_id_from_scene_id(
+            plan.windows[0].window.scene_id,
+        )
+        composition_spec = build_composition_spec_from_stitch_plan(
+            plan=plan, os_video_id=os_video_id,
         )
 
-        # ── 3. Complete ───────────────────────────────────────────
+        # ── 5. Create render via the shorts-render service ────────
+        render_job_id = await self._create_render_job(
+            org_id=parent.org_id,
+            user_id=parent.requested_by_user_id,
+            os_video_id=os_video_id,
+            title=catalog_label,
+            composition_spec=composition_spec,
+        )
+
+        # ── 6. Complete with the new render_job_id ────────────────
         async with self.session_factory() as session:
             repo = ProductScanJobRepository(session)
             completed = await repo.complete_tracking(
                 job_id=child_id,
                 claimed_by=self.claimed_by,
                 cost_delta_usd=Decimal("0"),
-                # PR #5: replace with the actual ShortsRenderJob.id from
-                # the render service. None for now means the wizard UI
-                # shows "render not produced" — acceptable for the stub.
-                render_job_id=None,
+                render_job_id=render_job_id,
             )
             if completed is None:
-                # Lease lost between claim and complete (cancel cascade
-                # ran, or this replica's clock skewed past the lease).
-                # Nothing to do here; the row is in its terminal state
-                # already.
                 logger.warning(
                     "child_complete_lease_lost",
                     extra={
                         "child_id": str(child_id),
                         "instance_id": self.instance_id,
+                        "render_job_id": str(render_job_id),
                     },
                 )
                 return
             await session.commit()
+        logger.info(
+            "child_runner_processed_child",
+            extra={
+                "child_id": str(child_id),
+                "render_job_id": str(render_job_id),
+                "catalog_entry_id": str(chosen_catalog_id),
+                "shorts_index": child.shorts_index,
+                "windows": len(plan.windows),
+            },
+        )
+
+    # ── helpers (private; tests patch via process_child_fn) ──────────
+
+    async def _load_child_context(
+        self, *, child_id: UUID,
+    ) -> tuple[ProductScanJob, ProductScanJob, dict[UUID, str]] | None:
+        """Read child + parent + catalog (id → label) in one
+        read-only session.
+
+        Catalog selection (round-robin) happens in the caller —
+        this helper is pure data fetch so the picker call stays in
+        one place and the test seam is clean.
+
+        Returns:
+            (child, parent, catalog_id_to_label) or None when the
+            child / parent is missing or the catalog set is empty.
+            ``catalog_id_to_label`` prefers ``user_label`` over
+            ``llm_label`` (matches the gallery's display rule).
+        """
+        async with self.session_factory() as session:
+            job_repo = ProductScanJobRepository(session)
+            child = await job_repo.get_internal(job_id=child_id)
+            if child is None or child.parent_job_id is None:
+                return None
+            parent = await job_repo.get_internal(job_id=child.parent_job_id)
+            if parent is None:
+                return None
+            catalog_repo = ProductCatalogRepository(session)
+            catalog_entries = await catalog_repo.list_active_by_video(
+                org_id=parent.org_id, video_id=parent.video_id,
+            )
+            if not catalog_entries:
+                return None
+            catalog_label_lookup = {
+                c.id: (c.user_label or c.llm_label)
+                for c in catalog_entries
+            }
+            return (child, parent, catalog_label_lookup)
+
+    async def _load_appearances_for_catalog(
+        self, *, org_id: UUID, catalog_entry_id: UUID,
+    ) -> list[ProductAppearance]:
+        async with self.session_factory() as session:
+            appearance_repo = ProductAppearanceRepository(session)
+            return await appearance_repo.list_active_by_catalog(
+                org_id=org_id, catalog_entry_id=catalog_entry_id,
+            )
+
+    async def _complete_no_render(
+        self, *, child_id: UUID, reason: str,
+    ) -> None:
+        """Mark the child terminal with no render — analogous to the
+        worker's ``_terminate_no_render``. Reaches the same DB shape
+        as the happy path (stage=done, render_job_id NULL), so the
+        wizard UI surfaces "no render produced for this short"
+        without a special-case error path.
+        """
+        async with self.session_factory() as session:
+            repo = ProductScanJobRepository(session)
+            completed = await repo.complete_tracking(
+                job_id=child_id,
+                claimed_by=self.claimed_by,
+                cost_delta_usd=Decimal("0"),
+                render_job_id=None,
+            )
+            if completed is None:
+                logger.warning(
+                    "child_complete_lease_lost_no_render",
+                    extra={
+                        "child_id": str(child_id),
+                        "instance_id": self.instance_id,
+                        "reason": reason,
+                    },
+                )
+                return
+            await session.commit()
+        logger.info(
+            "child_runner_no_render",
+            extra={
+                "child_id": str(child_id),
+                "instance_id": self.instance_id,
+                "reason": reason,
+            },
+        )
+
+    async def _create_render_job(
+        self,
+        *,
+        org_id: UUID,
+        user_id: UUID,
+        os_video_id: str,
+        title: str | None,
+        composition_spec,
+    ) -> UUID:
+        """Construct ``ShortsRenderService`` against a fresh session
+        and call ``create_render_job``. Lazy import keeps the runner
+        module-level free of cross-module ``shorts_render`` coupling
+        (plan §15 carves out direct service use as the runner-side
+        equivalent of the internal-router endpoint).
+        """
+        from app.modules.shorts_render.repository import (
+            ShortsRenderJobRepository,
+        )
+        from app.modules.shorts_render.schemas import RenderJobCreate
+        from app.modules.shorts_render.service import ShortsRenderService
+
+        async with self.session_factory() as session:
+            render_repo = ShortsRenderJobRepository(session)
+            render_service = ShortsRenderService(
+                repository=render_repo,
+                scene_search=self.scene_search_client,
+            )
+            response = await render_service.create_render_job(
+                org_id=org_id,
+                user_id=user_id,
+                payload=RenderJobCreate(
+                    video_id=os_video_id,
+                    title=title,
+                    composition=composition_spec,
+                ),
+            )
+        return response.id
 
     async def _mark_child_failed(
         self,
@@ -397,18 +668,68 @@ class ChildRunner:
             )
 
 
+def _appearance_to_annotated_window(
+    appearance: ProductAppearance,
+) -> "AnnotatedWindow":
+    """Adapt a DB-side :class:`ProductAppearance` into the lib-side
+    :class:`AnnotatedWindow` the picker stack consumes.
+
+    Catalog id is dropped on purpose: the runner has already
+    narrowed appearances to one catalog before this conversion
+    runs, and the vendored lib's ``ScoredWindow`` is catalog-blind
+    by design (see ``children/picker.py`` rationale).
+
+    ``peak_confidence`` and ``frame_count`` aren't persisted on
+    ``ProductAppearance`` rows (the worker materializes them only
+    in-flight), so we approximate:
+      * ``peak_confidence`` ← ``avg_confidence`` (best estimate
+        without per-frame data; only used by the worker's
+        :func:`select_subset` overshoot-trim, not the scorer).
+      * ``frame_count`` ← duration_ms / 200ms (5fps SAM2 cadence).
+    These approximations don't affect the scorer's composite score
+    (which uses ``avg_bbox_area_pct`` + duration-fitness only) but
+    keep the dataclass constructor satisfied.
+    """
+    # Lazy import — keep the runner module-level reference graph
+    # small. AnnotatedWindow is only needed in this adapter and in
+    # the type annotation above (string-quoted forward ref).
+    from app.lib.product_track.alignment import AnnotatedWindow
+
+    duration_ms = appearance.window_end_ms - appearance.window_start_ms
+    frame_count_estimate = max(1, duration_ms // 200)
+    return AnnotatedWindow(
+        scene_id=appearance.scene_id,
+        window_start_ms=appearance.window_start_ms,
+        window_end_ms=appearance.window_end_ms,
+        avg_bbox_area_pct=float(appearance.avg_bbox_area_pct),
+        avg_confidence=float(appearance.avg_confidence),
+        peak_confidence=float(appearance.avg_confidence),
+        frame_count=frame_count_estimate,
+        rejected_reason=appearance.rejected_reason,
+        has_narration_mention=bool(appearance.has_narration_mention),
+        has_ocr_overlap=bool(appearance.has_ocr_overlap),
+    )
+
+
 def create_child_runner(
     *,
     settings: Settings,
     session_factory: async_sessionmaker[AsyncSession],
+    scene_search_client: object,
     instance_id: str | None = None,
 ) -> ChildRunner:
     """Factory used by ``app.main:lifespan``. Tests construct
     ``ChildRunner`` directly with their own session factory + injected
     ``process_child_fn``.
+
+    ``scene_search_client`` is typed as ``object`` to accept both the
+    production ``AsyncOpenSearch`` client and test fakes; the runner
+    only forwards it to ``ShortsRenderService`` which will type-check
+    against the actual client interface at use time.
     """
     return ChildRunner(
         settings=settings,
         session_factory=session_factory,
+        scene_search_client=scene_search_client,
         instance_id=instance_id,
     )

--- a/services/api/app/modules/shorts_auto_product/children/runner.py
+++ b/services/api/app/modules/shorts_auto_product/children/runner.py
@@ -641,6 +641,15 @@ class ChildRunner:
                     composition=composition_spec,
                 ),
             )
+            # Commit BEFORE the with-block exits — ``ShortsRenderService``
+            # only ``flush()``es the new row, so closing the session
+            # without a commit rolls it back. The subsequent
+            # ``complete_tracking(render_job_id=…)`` would then reference
+            # a non-existent FK and IntegrityError-fail the child path.
+            # Mirrors the explicit commit in
+            # ``internal_router.enqueue_render_for_scan_job`` (line 709).
+            # Codex review caught this — see PR #6 review notes.
+            await session.commit()
         return response.id
 
     async def _mark_child_failed(

--- a/services/api/app/modules/shorts_auto_product/children/scene_id_utils.py
+++ b/services/api/app/modules/shorts_auto_product/children/scene_id_utils.py
@@ -1,0 +1,56 @@
+"""Scene-id parsing helpers for the wizard child runner.
+
+OpenSearch scene_ids in this codebase are ``{video_id}_scene_NNN``
+where ``video_id`` is the Drive-style external id (``gd_xxx``) and
+``NNN`` is a zero-padded scene index. The runner needs to extract
+the ``video_id`` prefix from any appearance's ``scene_id`` to feed
+:class:`RenderJobCreate.video_id` (a string of the same shape).
+
+## Why a dedicated helper, not inlined
+
+* Pure-string parsing → unit-testable without any DB or network.
+* The format is established convention (CLAUDE.md notes the image
+  case at ``drive-worker/src/tasks/process.py:112``); centralizing
+  the parser means a future format change has one place to update.
+* Decouples the runner from the scene_id format — the runner asks
+  for ``os_video_id`` and gets one, no string-fiddling at the
+  call site.
+"""
+
+from __future__ import annotations
+
+# Sentinel between video id and scene index in the ``{video_id}_scene_NNN``
+# scene_id format. Lifted here as a constant so a future format
+# change has exactly one place to update.
+_SCENE_INFIX = "_scene_"
+
+
+def os_video_id_from_scene_id(scene_id: str) -> str:
+    """Extract the OpenSearch ``video_id`` prefix from a scene_id.
+
+    Examples:
+        ``gd_abc123_scene_005`` → ``gd_abc123``
+        ``gd_xyz_scene_000``    → ``gd_xyz`` (single-scene image)
+
+    The scene index portion is whatever follows ``_scene_`` — we
+    don't validate it; ill-formed indices fall through as part of
+    the suffix and get discarded.
+
+    Raises:
+        ValueError: scene_id does not contain the ``_scene_``
+            sentinel. Indicates either a corrupted DB row or a
+            scene_id format change that this helper hasn't caught
+            up with.
+    """
+    if not scene_id:
+        raise ValueError("scene_id must be non-empty")
+    # ``rsplit`` with maxsplit=1 — there could (in principle) be a
+    # video_id containing the literal substring "_scene_"; rsplit
+    # picks the LAST occurrence which is the right semantics.
+    parts = scene_id.rsplit(_SCENE_INFIX, 1)
+    if len(parts) != 2 or not parts[0]:
+        raise ValueError(
+            f"scene_id {scene_id!r} does not match the "
+            f"'{{video_id}}{_SCENE_INFIX}NNN' convention"
+        )
+    return parts[0]

--- a/services/api/tests/test_composition_adapter.py
+++ b/services/api/tests/test_composition_adapter.py
@@ -1,0 +1,219 @@
+"""Tests for the StitchPlan → CompositionSpec adapter.
+
+The most important test in this file is
+:func:`test_dict_shape_matches_worker` — it pins down the equivalence
+between this API-side helper and the worker's
+``_build_composition_spec`` so the two copies (which can't share a
+common lib — see ``children/composition.py`` for the rationale)
+won't silently drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.lib.product_track.alignment import AnnotatedWindow
+from app.lib.product_track.stitching import StitchPlan
+from app.lib.product_track.subset_selector import ScoredWindow
+from app.modules.shorts_auto_product.children.composition import (
+    build_composition_spec_from_stitch_plan,
+)
+
+
+def _make_window(
+    *,
+    scene_id: str,
+    start_ms: int,
+    end_ms: int,
+    score: float = 0.7,
+) -> ScoredWindow:
+    """Synthetic ScoredWindow with sane field defaults.
+
+    Adapter only cares about ``window.scene_id`` /
+    ``window.window_start_ms`` / ``window.window_end_ms``; every
+    other field gets a placeholder so the dataclass constructor
+    succeeds.
+    """
+    return ScoredWindow(
+        window=AnnotatedWindow(
+            scene_id=scene_id,
+            window_start_ms=start_ms,
+            window_end_ms=end_ms,
+            avg_bbox_area_pct=0.25,
+            avg_confidence=0.85,
+            peak_confidence=0.92,
+            frame_count=int((end_ms - start_ms) / 200),  # 5fps cadence
+            rejected_reason=None,
+            has_narration_mention=False,
+            has_ocr_overlap=False,
+        ),
+        composite_score=score,
+        score_components={},
+    )
+
+
+def _make_plan(*windows: ScoredWindow) -> StitchPlan:
+    total_ms = sum(
+        s.window.window_end_ms - s.window.window_start_ms for s in windows
+    )
+    return StitchPlan(
+        duration_target_sec=30,
+        duration_actual_ms=total_ms,
+        windows=list(windows),
+        scorer_version="v1.0",
+        subset_picker_version="v1.0",
+    )
+
+
+# ---------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------
+
+
+def test_single_window_yields_one_scene_clip_at_origin() -> None:
+    plan = _make_plan(
+        _make_window(scene_id="gd_abc_scene_005", start_ms=10_000, end_ms=18_000),
+    )
+    spec = build_composition_spec_from_stitch_plan(
+        plan=plan, os_video_id="gd_abc",
+    )
+    assert len(spec.scene_clips) == 1
+    clip = spec.scene_clips[0]
+    assert clip.scene_id == "gd_abc_scene_005"
+    assert clip.video_id == "gd_abc"
+    assert clip.source_type == "gdrive"
+    assert clip.start_ms == 10_000
+    assert clip.end_ms == 18_000
+    assert clip.timeline_start_ms == 0  # first clip starts at the origin
+    assert clip.volume == 1.0
+
+
+def test_multiple_windows_placed_back_to_back_chronologically() -> None:
+    plan = _make_plan(
+        _make_window(scene_id="s1", start_ms=0,       end_ms=4_000),   # 4s
+        _make_window(scene_id="s2", start_ms=10_000,  end_ms=15_000),  # 5s
+        _make_window(scene_id="s3", start_ms=30_000,  end_ms=33_000),  # 3s
+    )
+    spec = build_composition_spec_from_stitch_plan(
+        plan=plan, os_video_id="gd_xyz",
+    )
+    clips = spec.scene_clips
+    assert [c.scene_id for c in clips] == ["s1", "s2", "s3"]
+    # Each clip's timeline position = sum of prior clip durations.
+    assert clips[0].timeline_start_ms == 0
+    assert clips[1].timeline_start_ms == 4_000        # after s1's 4s
+    assert clips[2].timeline_start_ms == 4_000 + 5_000  # after s1+s2 = 9s
+    # Source ranges remain absolute (NOT timeline-relative).
+    assert (clips[1].start_ms, clips[1].end_ms) == (10_000, 15_000)
+
+
+def test_video_id_propagates_to_every_clip() -> None:
+    plan = _make_plan(
+        _make_window(scene_id="s1", start_ms=0, end_ms=2_000),
+        _make_window(scene_id="s2", start_ms=5_000, end_ms=8_000),
+    )
+    spec = build_composition_spec_from_stitch_plan(
+        plan=plan, os_video_id="gd_video123",
+    )
+    assert all(c.video_id == "gd_video123" for c in spec.scene_clips)
+
+
+def test_default_subtitles_overlays_transitions_filled_by_contract() -> None:
+    """The adapter only sets ``scene_clips``; the contracts default_factory
+    populates ``output`` (9:16 720p), ``subtitles=[]``, ``overlays=[]``,
+    ``transitions=[]``. Verify those defaults survive the adapter so
+    downstream rendering sees a valid shape."""
+    plan = _make_plan(_make_window(scene_id="s1", start_ms=0, end_ms=1_000))
+    spec = build_composition_spec_from_stitch_plan(
+        plan=plan, os_video_id="gd_x",
+    )
+    assert spec.subtitles == []
+    assert spec.overlays == []
+    assert spec.transitions == []
+    assert spec.output is not None  # default OutputSpec instance
+    assert spec.title is None
+    assert spec.version == 1
+
+
+# ---------------------------------------------------------------------
+# defensive guard
+# ---------------------------------------------------------------------
+
+
+def test_empty_plan_raises_value_error() -> None:
+    """The contracts validator rejects ``scene_clips=[]`` with a
+    confusing pydantic ValidationError. The adapter pre-empts that
+    with a clearer ValueError so the runner's stack trace points
+    at the actual missing-windows condition."""
+    plan = _make_plan()  # no windows
+    with pytest.raises(ValueError, match="stitch plan has no windows"):
+        build_composition_spec_from_stitch_plan(
+            plan=plan, os_video_id="gd_x",
+        )
+
+
+# ---------------------------------------------------------------------
+# divergence guard — equivalence with worker's _build_composition_spec
+# ---------------------------------------------------------------------
+
+
+def test_dict_shape_matches_worker() -> None:
+    """**Cross-codebase invariant.**
+
+    The worker's ``services/product-track-worker/src/tasks/track.py::_build_composition_spec``
+    and this adapter MUST produce equivalent output for identical
+    inputs. We can't import the worker (different service boundary),
+    so this test snapshots the expected dict shape inline. If this
+    diff stops matching, either:
+
+      * the worker changed its mapping → mirror the change here, or
+      * the contract changed shape → bump both call sites.
+
+    Either way, fix the divergence at the source — DO NOT loosen the
+    snapshot to make the test pass.
+    """
+    plan = _make_plan(
+        _make_window(scene_id="gd_video_scene_001", start_ms=1_000, end_ms=4_000),
+        _make_window(scene_id="gd_video_scene_007", start_ms=20_000, end_ms=22_500),
+    )
+    spec = build_composition_spec_from_stitch_plan(
+        plan=plan, os_video_id="gd_video",
+    )
+    actual_clips = [
+        # Restrict to the keys the worker emits — the adapter may
+        # additionally fill in crop_x/y/w/h with their contract
+        # defaults, which is fine; the worker omits them and the
+        # contracts default_factory fills the same values, so the
+        # rendered output is identical regardless.
+        {
+            "scene_id": c.scene_id,
+            "video_id": c.video_id,
+            "source_type": c.source_type,
+            "start_ms": c.start_ms,
+            "end_ms": c.end_ms,
+            "timeline_start_ms": c.timeline_start_ms,
+            "volume": c.volume,
+        }
+        for c in spec.scene_clips
+    ]
+    expected_clips = [
+        {
+            "scene_id": "gd_video_scene_001",
+            "video_id": "gd_video",
+            "source_type": "gdrive",
+            "start_ms": 1_000,
+            "end_ms": 4_000,
+            "timeline_start_ms": 0,
+            "volume": 1.0,
+        },
+        {
+            "scene_id": "gd_video_scene_007",
+            "video_id": "gd_video",
+            "source_type": "gdrive",
+            "start_ms": 20_000,
+            "end_ms": 22_500,
+            "timeline_start_ms": 3_000,  # after the first clip's 3s
+            "volume": 1.0,
+        },
+    ]
+    assert actual_clips == expected_clips

--- a/services/api/tests/test_runner_real_swap.py
+++ b/services/api/tests/test_runner_real_swap.py
@@ -1,0 +1,206 @@
+"""Tests for the wizard child runner's PR #6 real-swap pieces.
+
+What this file covers (allowlist-friendly, <100ms total):
+
+  * The new constructor parameter ``scene_search_client``.
+  * The ``_appearance_to_annotated_window`` adapter — heuristic
+    ``frame_count`` / ``peak_confidence`` synthesis from DB rows
+    that the pipeline lib's :class:`AnnotatedWindow` requires but
+    that ``ProductAppearance`` doesn't persist.
+  * Module-level integrity (imports, factory wiring).
+
+What this file does NOT cover:
+
+  * End-to-end run of ``_process_child_payload`` — that needs a
+    real DB session + render service mock + opensearch fake. The
+    fixture surface for a self-contained integration test exceeds
+    the allowlist's <300ms budget. Per plan §9.4, the runner's
+    full flow is verified on staging by manually triggering a
+    wizard scan order and observing children land with
+    ``render_job_id`` set on the parent's child rows. Adding the
+    integration test post-PR #6 lands at the wizard-frontend tier
+    (PR #7 brings tests against a real wizard surface anyway).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.modules.shorts_auto_product.children.runner import (
+    ChildRunner,
+    _appearance_to_annotated_window,
+    create_child_runner,
+)
+from app.modules.shorts_auto_product.models import ProductAppearance
+
+
+# ---------------------------------------------------------------------
+# constructor wiring
+# ---------------------------------------------------------------------
+
+
+def _settings_stub():
+    """Minimal settings stub — only the fields ChildRunner reads at
+    construction. Avoids ``Settings()`` which requires env var
+    plumbing."""
+    s = MagicMock()
+    s.auto_shorts_product_v2_child_runner_max_concurrency = 4
+    s.auto_shorts_product_v2_child_runner_poll_seconds = 5
+    s.auto_shorts_product_v2_child_runner_enabled = True
+    s.auto_shorts_product_v2_child_lease_seconds = 300
+    return s
+
+
+def test_constructor_accepts_scene_search_client() -> None:
+    """The PR #6 ctor change adds ``scene_search_client``. Verify
+    the parameter is stored verbatim so the runner can hand it to
+    :class:`ShortsRenderService` later."""
+    fake_search = object()
+    runner = ChildRunner(
+        settings=_settings_stub(),
+        session_factory=MagicMock(),
+        scene_search_client=fake_search,
+    )
+    assert runner.scene_search_client is fake_search
+
+
+def test_factory_threads_scene_search_client_through() -> None:
+    """``create_child_runner`` is what ``app.main:lifespan`` calls.
+    Verify it forwards the ctor arg unchanged so a future refactor
+    of the factory's signature can't silently drop the OS client."""
+    fake_search = object()
+    runner = create_child_runner(
+        settings=_settings_stub(),
+        session_factory=MagicMock(),
+        scene_search_client=fake_search,
+    )
+    assert runner.scene_search_client is fake_search
+
+
+def test_constructor_default_process_fn_is_real_payload() -> None:
+    """When tests don't inject ``process_child_fn``, production code
+    runs. Asserting this here so a refactor that flips the default
+    to a stub (which would tank prod) is caught at test time."""
+    runner = ChildRunner(
+        settings=_settings_stub(),
+        session_factory=MagicMock(),
+        scene_search_client=object(),
+    )
+    # Bound method comparison: __func__ pulls the underlying function
+    # off both sides so we don't compare bound-method identity which
+    # can vary across Python versions.
+    assert runner._process_child_fn.__func__ is ChildRunner._process_child_payload
+
+
+# ---------------------------------------------------------------------
+# _appearance_to_annotated_window adapter
+# ---------------------------------------------------------------------
+
+
+def _make_appearance(
+    *,
+    scene_id: str = "gd_abc_scene_005",
+    window_start_ms: int = 10_000,
+    window_end_ms: int = 18_000,
+    avg_bbox_area_pct: float = 0.30,
+    avg_confidence: float = 0.85,
+    has_narration_mention: bool = True,
+    has_ocr_overlap: bool = False,
+    rejected_reason: str | None = None,
+) -> ProductAppearance:
+    """Build a ``ProductAppearance`` ORM instance without hitting the
+    DB. The model is a SQLAlchemy declarative; constructing it with
+    kwargs sets attributes without persisting.
+    """
+    return ProductAppearance(
+        id=uuid4(),
+        catalog_entry_id=uuid4(),
+        org_id=uuid4(),
+        scene_id=scene_id,
+        window_start_ms=window_start_ms,
+        window_end_ms=window_end_ms,
+        avg_bbox_area_pct=avg_bbox_area_pct,
+        avg_confidence=avg_confidence,
+        has_narration_mention=has_narration_mention,
+        has_ocr_overlap=has_ocr_overlap,
+        co_appearing_catalog_entry_ids=[],
+        tracker_version="v1.0",
+        rejected_reason=rejected_reason,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_adapter_copies_core_fields() -> None:
+    appearance = _make_appearance()
+    aw = _appearance_to_annotated_window(appearance)
+    assert aw.scene_id == "gd_abc_scene_005"
+    assert aw.window_start_ms == 10_000
+    assert aw.window_end_ms == 18_000
+    assert aw.avg_bbox_area_pct == pytest.approx(0.30)
+    assert aw.avg_confidence == pytest.approx(0.85)
+    assert aw.has_narration_mention is True
+    assert aw.has_ocr_overlap is False
+    assert aw.rejected_reason is None
+
+
+def test_adapter_synthesizes_peak_confidence_from_avg() -> None:
+    """``ProductAppearance`` doesn't persist ``peak_confidence``;
+    the adapter approximates with ``avg_confidence``. Used only by
+    the picker's overshoot trim, not the scorer's composite score,
+    so the approximation is harmless."""
+    appearance = _make_appearance(avg_confidence=0.74)
+    aw = _appearance_to_annotated_window(appearance)
+    assert aw.peak_confidence == pytest.approx(0.74)
+
+
+def test_adapter_synthesizes_frame_count_at_5fps_cadence() -> None:
+    """SAM2 samples at 5fps (200ms cadence). ``frame_count`` is
+    estimated from window duration / 200ms — only used by the
+    scorer when ``avg_bbox_area_pct`` is the dominant signal, which
+    it is for v1."""
+    appearance = _make_appearance(
+        window_start_ms=0, window_end_ms=2_000,  # 2s window
+    )
+    aw = _appearance_to_annotated_window(appearance)
+    assert aw.frame_count == 10  # 2_000ms / 200ms = 10 frames
+
+
+def test_adapter_clamps_frame_count_at_one() -> None:
+    """Sub-200ms windows would produce frame_count=0 via integer
+    division. Clamp at 1 so the dataclass doesn't carry zero
+    frames (which would crash downstream avg-related math)."""
+    appearance = _make_appearance(
+        window_start_ms=0, window_end_ms=100,  # 100ms — sub-cadence
+    )
+    aw = _appearance_to_annotated_window(appearance)
+    assert aw.frame_count == 1
+
+
+def test_adapter_passes_through_rejected_reason() -> None:
+    """Rejected appearances stay in the DB for tuning. The adapter
+    passes the reason through so the scorer's :func:`score_windows`
+    filter (``w.is_accepted``) sees the correct flag."""
+    appearance = _make_appearance(rejected_reason="too_short")
+    aw = _appearance_to_annotated_window(appearance)
+    assert aw.rejected_reason == "too_short"
+
+
+def test_adapter_drops_catalog_id_on_purpose() -> None:
+    """The vendored ``AnnotatedWindow`` is catalog-blind by design
+    (see ``children/picker.py``). Verify the adapter doesn't sneak
+    a catalog_entry_id into the lib type — if it did, the vendor
+    boundary would be subtly violated."""
+    appearance = _make_appearance()
+    aw = _appearance_to_annotated_window(appearance)
+    # Inspect every public attr — none should be a UUID-shaped value
+    # matching the appearance's catalog_entry_id.
+    fields = [
+        getattr(aw, name)
+        for name in dir(aw)
+        if not name.startswith("_") and not callable(getattr(aw, name))
+    ]
+    assert appearance.catalog_entry_id not in fields

--- a/services/api/tests/test_scene_id_utils.py
+++ b/services/api/tests/test_scene_id_utils.py
@@ -1,0 +1,62 @@
+"""Tests for the scene_id parsing helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.shorts_auto_product.children.scene_id_utils import (
+    os_video_id_from_scene_id,
+)
+
+
+def test_video_scene_id_yields_drive_prefix() -> None:
+    assert (
+        os_video_id_from_scene_id("gd_abc123_scene_005") == "gd_abc123"
+    )
+
+
+def test_image_scene_id_yields_drive_prefix() -> None:
+    """Image scene_ids end in ``_scene_000`` (single scene per image)
+    per drive-worker/src/tasks/process.py:112; the helper must work
+    for both surfaces."""
+    assert os_video_id_from_scene_id("gd_xyz_scene_000") == "gd_xyz"
+
+
+def test_underscores_in_video_id_preserved() -> None:
+    """Drive ids can carry underscores (``gd_abc_def``); rsplit on
+    the LAST ``_scene_`` is the right semantics so internal
+    underscores survive."""
+    assert (
+        os_video_id_from_scene_id("gd_abc_def_scene_010")
+        == "gd_abc_def"
+    )
+
+
+def test_video_id_containing_substring_scene() -> None:
+    """Adversarial: a video_id could in principle contain the
+    literal substring ``_scene_`` (e.g., a future `scene_*`-style
+    naming). rsplit with maxsplit=1 picks the LAST occurrence, so
+    the trailing ``_scene_NNN`` is what's stripped — the prefix
+    keeps any earlier ``_scene_`` instance intact."""
+    assert (
+        os_video_id_from_scene_id("gd_my_scene_video_scene_007")
+        == "gd_my_scene_video"
+    )
+
+
+def test_empty_string_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        os_video_id_from_scene_id("")
+
+
+def test_missing_sentinel_raises() -> None:
+    """No ``_scene_`` infix → can't parse. Indicates a corrupted DB
+    row or a scene_id-format change."""
+    with pytest.raises(ValueError, match="convention"):
+        os_video_id_from_scene_id("gd_no_separator_at_all")
+
+
+def test_empty_prefix_raises() -> None:
+    """Trailing ``_scene_NNN`` without a video_id prefix is ill-formed."""
+    with pytest.raises(ValueError, match="convention"):
+        os_video_id_from_scene_id("_scene_001")

--- a/services/api/tests/test_shorts_auto_product_child_runner.py
+++ b/services/api/tests/test_shorts_auto_product_child_runner.py
@@ -90,6 +90,7 @@ def _build_runner(monkeypatch, *, settings=None, fake_repo=None,
     return ChildRunner(
         settings=settings,
         session_factory=_mock_session_factory(fake_repo),
+        scene_search_client=MagicMock(),  # PR #6: not exercised by these tests
         instance_id=instance_id,
         process_child_fn=process_child_fn,
     ), fake_repo
@@ -115,18 +116,37 @@ def test_default_instance_id_uses_hostname(monkeypatch):
 
 
 # ======================================================================
-# Stub processing (PR #4): claim → /complete with render_job_id=None
+# Processing flow (PR #6): claim → real flow OR no-render fallback
 # ======================================================================
+#
+# The PR #4 stub ("claim → /complete with render_job_id=None") was
+# replaced in PR #6 with a real picker + render-service flow. The
+# tests below cover the orchestration spine; the no-render fallback
+# path is the easiest one to drive end-to-end without standing up
+# real catalog / appearance / render fixtures.
 
 
 @pytest.mark.asyncio
-async def test_process_child_payload_claims_then_completes(monkeypatch):
-    """Happy path: claim returns the claimed row → /complete with
-    render_job_id=None (PR #4 stub) → both repo calls awaited."""
+async def test_process_child_payload_no_render_path_claims_then_completes(monkeypatch):
+    """No-render fallback path: when the runner can't produce a
+    render (no catalog, no appearances, picker returns nothing), it
+    still claims the child and completes it with ``render_job_id=None``
+    so the wizard UI shows "no render produced for this short"
+    rather than leaving the child in 'assembling' until lease
+    expiry. Forced here by patching ``_load_child_context`` to
+    return None (``no_catalog_or_parent`` branch)."""
     runner, fake_repo = _build_runner(monkeypatch)
     child_id = uuid4()
     fake_repo.claim = AsyncMock(return_value=MagicMock())  # claim wins
     fake_repo.complete_tracking = AsyncMock(return_value=MagicMock())
+
+    # Force the no-render branch — simulates "parent is gone" /
+    # "video has no active catalog entries". Either is a legitimate
+    # terminal state that the runner handles by completing the
+    # child with no render rather than failing it.
+    monkeypatch.setattr(
+        runner, "_load_child_context", AsyncMock(return_value=None),
+    )
 
     await runner._process_child_payload(child_id)
 
@@ -140,7 +160,6 @@ async def test_process_child_payload_claims_then_completes(monkeypatch):
     complete_kwargs = fake_repo.complete_tracking.await_args.kwargs
     assert complete_kwargs["job_id"] == child_id
     assert complete_kwargs["claimed_by"] == "api-child-test-replica"
-    # PR #4 stub: render_job_id is None until PR #5 wires real renders.
     assert complete_kwargs["render_job_id"] is None
 
 
@@ -158,13 +177,17 @@ async def test_process_child_payload_skips_when_already_claimed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_child_payload_lease_lost_during_complete(monkeypatch):
-    """Lease lost between claim and complete (e.g. cancel cascade ran
-    mid-process) → warn but don't crash. The row is already in its
-    terminal state from the cancel — nothing for us to do."""
+async def test_process_child_payload_no_render_path_handles_lease_loss(monkeypatch):
+    """Lease lost between claim and complete on the no-render path
+    (e.g. cancel cascade ran mid-process) → warn but don't crash.
+    The row is already in its terminal state from the cancel —
+    nothing for us to do."""
     runner, fake_repo = _build_runner(monkeypatch)
     fake_repo.claim = AsyncMock(return_value=MagicMock())
     fake_repo.complete_tracking = AsyncMock(return_value=None)  # lease lost
+    monkeypatch.setattr(
+        runner, "_load_child_context", AsyncMock(return_value=None),
+    )
 
     # Should not raise; quietly returns.
     await runner._process_child_payload(uuid4())
@@ -221,6 +244,14 @@ async def test_two_replicas_race_only_one_wins(monkeypatch):
     )
     repo_a.claim = AsyncMock(return_value=MagicMock())
     repo_a.complete_tracking = AsyncMock(return_value=MagicMock())
+    # PR #6: post-claim, the runner's real flow walks
+    # _load_child_context → catalog/appearances → render service.
+    # This test only cares about the claim race contract, so force
+    # the no-render branch so we exit at complete_tracking without
+    # needing to mock the entire real-flow chain.
+    monkeypatch.setattr(
+        runner_a, "_load_child_context", AsyncMock(return_value=None),
+    )
 
     # Replica B: claim loses
     repo_b = MagicMock()
@@ -231,6 +262,7 @@ async def test_two_replicas_race_only_one_wins(monkeypatch):
     runner_b = ChildRunner(
         settings=_settings_stub(),
         session_factory=_mock_session_factory(repo_b),
+        scene_search_client=MagicMock(),
         instance_id="replica-B",
     )
 

--- a/services/api/tests/test_single_product_picker.py
+++ b/services/api/tests/test_single_product_picker.py
@@ -1,0 +1,161 @@
+"""Tests for the Phase 4 single-product round-robin picker.
+
+Covers the catalog-selection layer ONLY. Window-level picking is
+exercised by the vendored ``app.lib.product_track`` chain's own
+tests upstream (and indirectly by the runner integration tests
+that ship in PR #6 commit 4).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from app.modules.shorts_auto_product.children.picker import (
+    CatalogPick,
+    SingleProductSubsetPicker,
+    pick_catalog_for_shorts_index,
+)
+
+
+# Fixed UUIDs so the sorted ordering is predictable and assertions
+# can speak in terms of "first sorted catalog" without re-running
+# the sort in each test.
+CAT_A = UUID("00000000-0000-0000-0000-0000000000a1")
+CAT_B = UUID("00000000-0000-0000-0000-0000000000b2")
+CAT_C = UUID("00000000-0000-0000-0000-0000000000c3")
+SORTED_3 = [CAT_A, CAT_B, CAT_C]
+
+
+# ---------------------------------------------------------------------
+# pick_catalog_for_shorts_index — pure helper
+# ---------------------------------------------------------------------
+
+
+def test_round_robin_distributes_5_shorts_across_3_products() -> None:
+    """The headline plan §7.1 example: 5 shorts of 3 products map to
+    [c1, c2, c3, c1, c2]."""
+    picks = [
+        pick_catalog_for_shorts_index(catalog_ids=SORTED_3, shorts_index=i)
+        for i in (1, 2, 3, 4, 5)
+    ]
+    assert picks == [CAT_A, CAT_B, CAT_C, CAT_A, CAT_B]
+
+
+def test_single_product_means_every_short_picks_it() -> None:
+    """N shorts × 1 product = N copies of that product."""
+    for i in range(1, 11):
+        assert (
+            pick_catalog_for_shorts_index(
+                catalog_ids=[CAT_A], shorts_index=i,
+            )
+            == CAT_A
+        )
+
+
+def test_unsorted_input_yields_sorted_distribution() -> None:
+    """Input order must NOT affect output — two replicas with the
+    same catalog set but different iteration order MUST produce
+    identical (shorts_index → catalog) mappings."""
+    forward = [
+        pick_catalog_for_shorts_index(
+            catalog_ids=[CAT_A, CAT_B, CAT_C], shorts_index=i,
+        )
+        for i in (1, 2, 3)
+    ]
+    reverse = [
+        pick_catalog_for_shorts_index(
+            catalog_ids=[CAT_C, CAT_B, CAT_A], shorts_index=i,
+        )
+        for i in (1, 2, 3)
+    ]
+    assert forward == reverse == SORTED_3
+
+
+def test_set_input_works_and_dedupes() -> None:
+    """Accepting an Iterable means callers can pass a set — must
+    still be deterministic via the internal sort."""
+    picks = [
+        pick_catalog_for_shorts_index(
+            catalog_ids={CAT_C, CAT_A, CAT_B, CAT_A},  # CAT_A duplicated
+            shorts_index=i,
+        )
+        for i in (1, 2, 3, 4)
+    ]
+    # Dedup → 3 catalogs → round-robin wraps at index 4.
+    assert picks == [CAT_A, CAT_B, CAT_C, CAT_A]
+
+
+def test_empty_catalog_ids_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        pick_catalog_for_shorts_index(catalog_ids=[], shorts_index=1)
+
+
+def test_zero_or_negative_shorts_index_raises() -> None:
+    """Migration 052's CHECK enforces shorts_index >= 1; the picker
+    rejects out-of-range values too so a buggy fan-out hook can't
+    silently misbehave."""
+    for bad in (0, -1, -100):
+        with pytest.raises(ValueError, match="shorts_index must be >= 1"):
+            pick_catalog_for_shorts_index(catalog_ids=SORTED_3, shorts_index=bad)
+
+
+def test_large_shorts_index_wraps() -> None:
+    """No upper bound on shorts_index in the helper itself — the
+    DB CHECK caps requested_count <= 50, but the helper stays pure
+    and just wraps modulo."""
+    # shorts_index=100 with 3 products → (100-1) % 3 = 99 % 3 = 0
+    # → first sorted catalog.
+    assert (
+        pick_catalog_for_shorts_index(
+            catalog_ids=SORTED_3, shorts_index=100,
+        )
+        == CAT_A
+    )
+
+
+# ---------------------------------------------------------------------
+# SingleProductSubsetPicker — class wrapper
+# ---------------------------------------------------------------------
+
+
+def test_picker_class_returns_catalog_pick_with_count() -> None:
+    """The class wrapper enriches the bare UUID with the candidate
+    set size so the runner's logging doesn't recompute it."""
+    picker = SingleProductSubsetPicker()
+    pick = picker.pick_catalog(catalog_ids=SORTED_3, shorts_index=2)
+    assert isinstance(pick, CatalogPick)
+    assert pick.catalog_entry_id == CAT_B
+    assert pick.candidates_count == 3
+
+
+def test_picker_class_dedupes_in_count() -> None:
+    """Duplicates in the input must not inflate ``candidates_count``."""
+    picker = SingleProductSubsetPicker()
+    pick = picker.pick_catalog(
+        catalog_ids=[CAT_A, CAT_A, CAT_B], shorts_index=1,
+    )
+    assert pick.candidates_count == 2
+
+
+def test_picker_class_version_string_is_stable() -> None:
+    """The runner persists ``VERSION`` on the parent's
+    ``picker_version`` column for replay determinism. Bumping it
+    should be a deliberate code change, not a side effect — assert
+    the literal so a refactor doesn't silently shift the value."""
+    assert SingleProductSubsetPicker.VERSION == "single-rr-v1"
+
+
+def test_picker_class_consistent_with_helper() -> None:
+    """The class is a thin wrapper — the chosen catalog must match
+    the bare helper's output for any well-formed input."""
+    picker = SingleProductSubsetPicker()
+    for shorts_index in range(1, 11):
+        helper = pick_catalog_for_shorts_index(
+            catalog_ids=SORTED_3, shorts_index=shorts_index,
+        )
+        wrapped = picker.pick_catalog(
+            catalog_ids=SORTED_3, shorts_index=shorts_index,
+        )
+        assert wrapped.catalog_entry_id == helper

--- a/services/api/tests/test_vendored_product_track.py
+++ b/services/api/tests/test_vendored_product_track.py
@@ -1,0 +1,78 @@
+"""Smoke test for the vendored ``app.lib.product_track`` chain.
+
+Asserts the vendor decision (see
+``app/lib/product_track/__init__.py``) holds:
+
+  1. The pure-math chain imports cleanly inside the API venv.
+  2. The upstream ``heimdex_media_pipelines`` package is NOT
+     importable from the API — that is the whole reason for the
+     vendor. If a future commit accidentally adds the upstream
+     package as a dep, this test fails so the drift is caught
+     before the API starts depending on a lib that isn't on PyPI.
+
+Fast (<10ms): pure imports + a couple of constructions.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+
+
+def test_vendored_chain_imports_cleanly() -> None:
+    """Every vendored submodule resolves without ImportError."""
+    for mod_name in (
+        "app.lib.product_track.config",
+        "app.lib.product_track.window_assembly",
+        "app.lib.product_track.alignment",
+        "app.lib.product_track.subset_selector",
+        "app.lib.product_track.stitching",
+    ):
+        # ``import_module`` raises ImportError if the chain is broken.
+        import_module(mod_name)
+
+
+def test_public_api_surface_present() -> None:
+    """The runner imports these specific names — assert they exist."""
+    from app.lib.product_track.config import (
+        SUBSET_PICKER_VERSION,
+        TRACKER_VERSION,
+        TrackingConfig,
+    )
+    from app.lib.product_track.stitching import (
+        StitchPlan,
+        build_stitch_plan,
+    )
+    from app.lib.product_track.subset_selector import (
+        GreedyPicker,
+        ScoredWindow,
+        SubsetPicker,
+        score_windows,
+        select_subset,
+    )
+
+    # Exercise the dataclasses just enough to confirm they aren't
+    # empty stubs after a botched vendor sync.
+    assert isinstance(TRACKER_VERSION, str) and TRACKER_VERSION
+    assert isinstance(SUBSET_PICKER_VERSION, str) and SUBSET_PICKER_VERSION
+    cfg = TrackingConfig()
+    assert cfg.tracker_version == TRACKER_VERSION
+    # GreedyPicker is the no-LLM fallback used in tests + the
+    # ``OPENAI_API_KEY``-absent code paths.
+    GreedyPicker()
+
+
+def test_upstream_package_not_importable_from_api() -> None:
+    """The whole point of vendoring: ``heimdex_media_pipelines`` must
+    NOT be installed in the API venv. If this fails, somebody added
+    the upstream package as a dep — either via ``pyproject.toml``
+    or a path-mount — and the API has grown a build-time coupling
+    to a repo that doesn't publish to PyPI.
+
+    Resolution: either remove the upstream dep, or update the
+    vendor docs (``app/lib/product_track/__init__.py``) to reflect
+    the new install model and delete the vendored copy.
+    """
+    with pytest.raises(ImportError):
+        import_module("heimdex_media_pipelines")


### PR DESCRIPTION
## Summary

Replaces the PR #117 stub in the wizard child runner with the real flow:
claim → load parent + catalog → round-robin pick a catalog → score → pick subset → build stitch plan → adapter → ShortsRenderService.create_render_job → complete_tracking. Vendors the pure-math chain from heimdex-media-pipelines into `app/lib/product_track/` so the API doesn't grow an install-time dependency on a repo that isn't on PyPI.

5 commits, ~~3500~~ ~3300 lines (most of which is the vendored ~600-LOC pure-math + tests). 47 tests in 0.49s, all in CI allowlist.

## Commits

- `43f2a45` chore(api): vendor pure-math product_track lib for wizard runner
- `f3378e4` feat(api): single-product round-robin picker for wizard child runner
- `bd91c4c` feat(api): StitchPlan → CompositionSpec adapter for wizard runner
- `5d43d84` feat(api): wizard child runner real flow — replaces PR #117 stub
- `f6cdfc2` fix(api): commit render-job session in wizard child runner ← Codex P1

## Decoupling decisions worth flagging

1. **Vendored copy stays catalog-blind.** The lib's `ScoredWindow` doesn't grow a `catalog_entry_id` field. Catalog-aware orchestration (`SingleProductSubsetPicker`, future `MultiProductSubsetPicker`) lives in `app/modules/shorts_auto_product/children/` — **API-side, not lib-side**. Plan §15 updated to reflect this.
2. **Worker keeps its own `_build_composition_spec`** because services boundaries prevent code sharing. Cross-codebase invariant pinned by `test_dict_shape_matches_worker` snapshot.
3. **No `heimdex_media_pipelines` install added.** Smoke test in `test_vendored_product_track.py` asserts the upstream package stays absent from the API venv.

## Codex review

One pass on the final diff. **Found 1 P1**: `_create_render_job` opened a session, called `ShortsRenderService.create_render_job` (which only `flush()`es), then exited the `async with` block without committing → render row would have rolled back, every successful render attempt would have IntegrityError'd on the FK. Tests didn't catch this because they mock the service entirely.

Fixed in `f6cdfc2`. The internal_router endpoint at line 709 has the analogous commit; the runner now mirrors that pattern.

## Test plan

- [x] `make verify` is **NOT** required for this PR — runs against docker DB which the new tests don't need
- [x] 47 tests in CI allowlist; 0.49s cumulative
- [x] Backward-compat: existing PR #117 child-runner tests refit to the new flow (2 stub-semantic tests repurposed to exercise the no-render fallback path which is still a real production branch)
- [x] Codex final-diff review (one pass, P1 fixed)
- [ ] Staging dogfood: trigger a wizard scan order on devorg, observe children land with `render_job_id` set on parent's child rows (deferred per plan §9.4)

## Operator runbook

After merge → staging deploys → enable the wizard publish flag:

```bash
# On staging EC2
echo "AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED=true" >> /opt/heimdex/dev-heimdex-for-livecommerce/.env
docker compose restart api
```

Worker rebuild not required for this PR (no contracts shape change).

## Stacked PRs

This is the foundation; two follow-ups stack on top:
- Follow-up B: widen render dedupe window for runner crash-retries (separate PR)
- Follow-up C: stale-video guard before wizard scan-order fan-out (separate PR)