### PR TITLE
follow-up B: widen render dedupe window for runner crash-retries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
             tests/test_scene_id_utils.py \
             tests/test_runner_real_swap.py \
             tests/test_shorts_auto_product_child_runner.py \
+            tests/test_shorts_render_dedupe_window.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/modules/shorts_auto_product/children/runner.py
+++ b/services/api/app/modules/shorts_auto_product/children/runner.py
@@ -626,6 +626,16 @@ class ChildRunner:
         from app.modules.shorts_render.schemas import RenderJobCreate
         from app.modules.shorts_render.service import ShortsRenderService
 
+        # Widen the render-service dedupe window past our lease horizon.
+        # If this replica crashes between create_render_job and
+        # complete_tracking, the lease (default 300s) takes that long to
+        # expire before another replica re-claims and retries. The
+        # service's default 30s window would have closed by then →
+        # duplicate render row + orphan S3 output. Adding a 60s buffer
+        # covers small clock skew and DB write latency.
+        retry_safe_dedupe_seconds = (
+            self.settings.auto_shorts_product_v2_child_lease_seconds + 60
+        )
         async with self.session_factory() as session:
             render_repo = ShortsRenderJobRepository(session)
             render_service = ShortsRenderService(
@@ -640,6 +650,7 @@ class ChildRunner:
                     title=title,
                     composition=composition_spec,
                 ),
+                dedupe_within_seconds=retry_safe_dedupe_seconds,
             )
             # Commit BEFORE the with-block exits — ``ShortsRenderService``
             # only ``flush()``es the new row, so closing the session

--- a/services/api/app/modules/shorts_render/service.py
+++ b/services/api/app/modules/shorts_render/service.py
@@ -277,21 +277,60 @@ class ShortsRenderService:
         org_id: UUID,
         user_id: UUID,
         payload: RenderJobCreate,
+        *,
+        dedupe_within_seconds: int | None = None,
     ) -> RenderJobResponse:
         """Create a render job after validating scene boundaries.
 
         Implements implicit idempotency: if the same user submits a job
-        with the same composition_hash within _DEDUPE_WINDOW_SECONDS,
-        returns the existing job instead of creating a new one. Kills
-        accidental double-clicks without blocking intentional re-renders.
+        with the same composition_hash within ``dedupe_within_seconds``
+        (default :data:`_DEDUPE_WINDOW_SECONDS` = 30s), returns the
+        existing job instead of creating a new one. Kills accidental
+        double-clicks without blocking intentional re-renders.
+
+        ``dedupe_within_seconds`` lets server-side retry paths widen the
+        window past their lease horizon. Two concrete consumers:
+
+        * The wizard child runner (``shorts_auto_product.children.runner``)
+          claims a child for ``lease_seconds`` (default 300s); a crashed
+          replica's lease takes that long to expire before another
+          replica re-claims and retries the render. With the default 30s
+          window the retry would fire AFTER the dedupe closed → duplicate
+          render row. The runner passes ``lease_seconds + 60``.
+        * The track-worker's ``/internal/products/{id}/render`` callback
+          has the same lease-expiry retry shape (separate PR).
+
+        HTTP-initiated callers (``POST /api/shorts/render`` from the web
+        client, the highlight-reel router, the v1 auto-shorts service)
+        leave ``dedupe_within_seconds=None`` to keep the user-visible
+        anti-double-click semantics — a longer window there would block
+        legitimate re-submissions when the user edits + resubmits.
+
+        Raises:
+            ValueError: ``dedupe_within_seconds`` is negative. Zero is
+                permitted and effectively disables dedupe (no row can
+                be created in the future of "now").
         """
+        if dedupe_within_seconds is not None and dedupe_within_seconds < 0:
+            raise ValueError(
+                f"dedupe_within_seconds must be >= 0; got "
+                f"{dedupe_within_seconds}"
+            )
+        effective_dedupe_seconds = (
+            dedupe_within_seconds
+            if dedupe_within_seconds is not None
+            else _DEDUPE_WINDOW_SECONDS
+        )
+
         # 1. Validate scene boundaries via OpenSearch mget
         await self._validate_scene_clips(org_id, payload)
 
         # 2. Dedupe check — if this user just submitted the same
         #    composition, return that job instead of spawning a duplicate.
         composition_hash = compute_composition_hash(payload.composition)
-        dedupe_since = datetime.now(timezone.utc) - timedelta(seconds=_DEDUPE_WINDOW_SECONDS)
+        dedupe_since = datetime.now(timezone.utc) - timedelta(
+            seconds=effective_dedupe_seconds,
+        )
         existing = await self.repository.find_recent_duplicate(
             org_id=org_id,
             user_id=user_id,

--- a/services/api/tests/test_shorts_render_dedupe_window.py
+++ b/services/api/tests/test_shorts_render_dedupe_window.py
@@ -1,0 +1,189 @@
+"""Tests for the configurable ``dedupe_within_seconds`` parameter on
+:meth:`ShortsRenderService.create_render_job`.
+
+The service has a 30s default that's right for HTTP-initiated callers
+(anti-double-click). Server-side retry paths — the wizard child runner
+and the track-worker — need a wider window because their lease horizon
+(default 300s) is well past the default. Without the override, a
+crashed-then-relaunched render attempt creates a duplicate render row
++ orphan S3 output.
+
+These tests cover the parameter's contract directly. Real DB-backed
+end-to-end coverage exists in the existing
+``test_shorts_render_hardening.py`` allowlist test which exercises the
+default 30s path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+
+def _make_service():
+    """Build a ShortsRenderService with mocked deps. Constructed lazily
+    so tests can run without docker / opensearch."""
+    from app.modules.shorts_render.service import ShortsRenderService
+
+    repo = MagicMock()
+    repo.find_recent_duplicate = AsyncMock(return_value=None)
+    # ``_to_response`` reads ``job.input_spec.get("scene_clips", [])``
+    # — give it a real dict so the auto-MagicMock attribute doesn't
+    # leak into Pydantic validation.
+    fake_job = MagicMock(
+        id=uuid4(),
+        status="rendering",
+        created_at=datetime.now(timezone.utc),
+        completed_at=None,
+        render_time_ms=None,
+        output_duration_ms=None,
+        output_size_bytes=None,
+        error=None,
+        video_id="gd_test",
+        title=None,
+        org_id=uuid4(),
+        user_id=uuid4(),
+        output_s3_key=None,
+    )
+    fake_job.input_spec = {"scene_clips": []}
+    repo.create = AsyncMock(return_value=fake_job)
+    repo.update_status = AsyncMock()
+    scene_search = MagicMock()
+    service = ShortsRenderService(repository=repo, scene_search=scene_search)
+    # Patch internal validate to a no-op so we don't hit OpenSearch.
+    service._validate_scene_clips = AsyncMock()
+    return service, repo
+
+
+def _make_payload():
+    """Minimal RenderJobCreate satisfying contracts validation."""
+    from heimdex_media_contracts.composition.schemas import (
+        CompositionSpec, SceneClipSpec,
+    )
+    from app.modules.shorts_render.schemas import RenderJobCreate
+
+    return RenderJobCreate(
+        video_id="gd_test",
+        title=None,
+        composition=CompositionSpec(scene_clips=[
+            SceneClipSpec(
+                scene_id="gd_test_scene_001",
+                video_id="gd_test",
+                source_type="gdrive",
+                start_ms=0,
+                end_ms=2_000,
+                timeline_start_ms=0,
+                volume=1.0,
+            ),
+        ]),
+    )
+
+
+# ---------------------------------------------------------------------
+# default behavior (HTTP callers)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_dedupe_window_is_30_seconds(monkeypatch):
+    """When callers omit ``dedupe_within_seconds``, the service uses
+    its 30s anti-double-click default. Verify by inspecting the
+    ``since`` value passed to the repo's dedupe lookup."""
+    # Patch publish_shorts_render_job to a no-op so we don't try to
+    # publish to SQS during the test.
+    monkeypatch.setattr(
+        "app.sqs_producer.publish_shorts_render_job",
+        MagicMock(),
+    )
+    service, repo = _make_service()
+    org_id, user_id = uuid4(), uuid4()
+    payload = _make_payload()
+
+    before = datetime.now(timezone.utc)
+    await service.create_render_job(
+        org_id=org_id, user_id=user_id, payload=payload,
+    )
+    after = datetime.now(timezone.utc)
+
+    repo.find_recent_duplicate.assert_awaited_once()
+    since = repo.find_recent_duplicate.await_args.kwargs["since"]
+    # ``since`` should be ~30s before "now" — bounded by before/after to
+    # tolerate test-runner clock drift.
+    assert before - timedelta(seconds=30, milliseconds=100) <= since
+    assert since <= after - timedelta(seconds=29, milliseconds=900)
+
+
+# ---------------------------------------------------------------------
+# explicit override (server-side retry callers)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explicit_dedupe_window_widens_lookup(monkeypatch):
+    """Server-side retry paths (runner, track-worker) pass
+    ``dedupe_within_seconds`` past their lease horizon to absorb
+    crash-recovery retries. Verify the override propagates to the
+    repo lookup."""
+    monkeypatch.setattr(
+        "app.sqs_producer.publish_shorts_render_job",
+        MagicMock(),
+    )
+    service, repo = _make_service()
+
+    before = datetime.now(timezone.utc)
+    await service.create_render_job(
+        org_id=uuid4(), user_id=uuid4(), payload=_make_payload(),
+        dedupe_within_seconds=360,
+    )
+    after = datetime.now(timezone.utc)
+
+    since = repo.find_recent_duplicate.await_args.kwargs["since"]
+    # 360s window — verify the lookup spans past the 30s default.
+    assert before - timedelta(seconds=360, milliseconds=100) <= since
+    assert since <= after - timedelta(seconds=359, milliseconds=900)
+
+
+@pytest.mark.asyncio
+async def test_dedupe_window_zero_is_permitted(monkeypatch):
+    """Zero is the "now" boundary — any prior row is outside it.
+    Effectively disables dedupe (intentional escape hatch for
+    callers who want guaranteed-fresh creates). Permitted, not
+    rejected."""
+    monkeypatch.setattr(
+        "app.sqs_producer.publish_shorts_render_job",
+        MagicMock(),
+    )
+    service, repo = _make_service()
+
+    await service.create_render_job(
+        org_id=uuid4(), user_id=uuid4(), payload=_make_payload(),
+        dedupe_within_seconds=0,
+    )
+
+    since = repo.find_recent_duplicate.await_args.kwargs["since"]
+    # ``since`` ≈ now — 0s. The repo will find no rows because no row's
+    # created_at >= future-of-now (modulo clock skew on the floor).
+    now = datetime.now(timezone.utc)
+    assert now - timedelta(milliseconds=100) <= since <= now + timedelta(milliseconds=100)
+
+
+@pytest.mark.asyncio
+async def test_dedupe_window_negative_raises_value_error(monkeypatch):
+    """Negative windows make no sense — would query rows with
+    ``created_at >= now + Xs`` (in the future). Reject loudly so
+    a buggy caller sees the error rather than silently never
+    deduping."""
+    monkeypatch.setattr(
+        "app.sqs_producer.publish_shorts_render_job",
+        MagicMock(),
+    )
+    service, _repo = _make_service()
+
+    with pytest.raises(ValueError, match=">= 0"):
+        await service.create_render_job(
+            org_id=uuid4(), user_id=uuid4(), payload=_make_payload(),
+            dedupe_within_seconds=-1,
+        )


### PR DESCRIPTION
## Summary

Stacked on top of #121 (Phase 4 PR #6). The wizard child runner's lease is 300s; if a replica crashes between `create_render_job` and `complete_tracking`, the lease expires before another replica re-claims and retries. The render service's existing 30s composition_hash dedupe window had already closed by then → duplicate render row + orphan S3 output.

Adds `dedupe_within_seconds: int | None = None` to `ShortsRenderService.create_render_job`. None preserves the 30s anti-double-click default that HTTP-initiated callers rely on. The runner passes `lease_seconds + 60` (= 360s by default).

## Commit

`b0f0295` feat(api,runner): widen render dedupe window for runner crash-retries

## Decoupling

- Service stays unaware of "who is calling" — accepts a window value
- Per-call override; HTTP callers (web client, highlight reel, v1 auto-shorts) unchanged
- No DB migration, no new column

## Out of scope (separate PR worth tracking)

The track-worker's `/internal/products/{id}/render` callback at `internal_router.py:704` has the same crash-retry shape (5 callers of `create_render_job` total; 2 affected by the lease-vs-dedupe mismatch). Scoped this PR to the runner-side; the worker-side widening is a tighter PR in its own right.

## Test plan

- [x] 4 new service-level tests (default 30s, explicit override, zero, negative validation)
- [x] Existing `test_shorts_render_hardening.py` 30s tests still pass — backward compatible
- [x] 75 tests cumulative in 0.62s
- [ ] Staging soak: monitor for `render_job_idempotent_replay` log lines from the runner path (Phase 7 ops follow-up)

Targets `feat/wizard-runner-real-swap` so the diff shows only this PR's delta. Auto-retargets to `main` once #121 merges.