### PR TITLE
fix(db): hotfix migration 052 — split enum-using index into 053

### DIFF
--- a/services/api/app/db/migrations/versions/052_extend_scan_jobs_for_wizard.py
+++ b/services/api/app/db/migrations/versions/052_extend_scan_jobs_for_wizard.py
@@ -190,19 +190,19 @@ def upgrade() -> None:
     # hot-path queries.
     # ------------------------------------------------------------------
 
-    # The existing ix_product_scan_jobs_active was scoped to the original
-    # active stages and ignored ``mode``. Replace it with one that:
-    #   - includes the new active stages (preview_ready, fanned_out)
-    #   - excludes mode='render_child' so concurrency cap counts parents
-    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_active")
-    op.execute("""
-        CREATE INDEX ix_product_scan_jobs_active
-            ON product_scan_jobs(org_id, stage)
-            WHERE stage IN (
-                'queued','enumerating','tracking','assembling','rendering',
-                'preview_ready','fanned_out'
-            ) AND mode <> 'render_child'
-    """)
+    # NOTE: ``ix_product_scan_jobs_active`` rebuild moved to migration
+    # ``053_recreate_active_index_with_wizard_stages`` because Postgres
+    # rejects using ``ALTER TYPE … ADD VALUE``-added enum members in
+    # the same transaction that added them — the partial index's
+    # ``WHERE stage IN ('preview_ready','fanned_out',…)`` predicate
+    # tripped that restriction during initial deploys
+    # (UnsafeNewEnumValueUsage). Splitting it lets the next migration
+    # see the new enum values as committed members of the type.
+    #
+    # The OLD ix_product_scan_jobs_active (scoped to original active
+    # stages, no mode filter) stays in place until 053 runs — fine
+    # because the wizard concurrency cap doesn't trip until parents
+    # actually start landing in the new stages.
 
     # Parent → children lookup. Used by GET /scan-orders/{parent_id} and
     # by cancel-cascade.
@@ -235,19 +235,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Indexes
+    # Indexes — only the ones this migration created. The
+    # ``ix_product_scan_jobs_active`` rebuild lives in migration 053
+    # and is reverted there (running ``alembic downgrade -1`` from 053
+    # restores the pre-053 active-index shape, then ``-1`` again from
+    # 052 leaves the schema as it was at 051).
     op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_child_queue")
     op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_settings_hash")
     op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_parent")
-    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_active")
-    # Restore the original active-only index shape from migration 051.
-    op.execute("""
-        CREATE INDEX ix_product_scan_jobs_active
-            ON product_scan_jobs(org_id, stage)
-            WHERE stage IN (
-                'queued','enumerating','tracking','assembling','rendering'
-            )
-    """)
 
     # Constraints (drop in reverse-add order; IF EXISTS for idempotency)
     op.execute(

--- a/services/api/app/db/migrations/versions/053_recreate_active_index_with_wizard_stages.py
+++ b/services/api/app/db/migrations/versions/053_recreate_active_index_with_wizard_stages.py
@@ -1,0 +1,72 @@
+"""Recreate ix_product_scan_jobs_active with the wizard's new active stages.
+
+Hotfix split from migration 052 — Postgres rejects using
+``ALTER TYPE … ADD VALUE``-added enum members in the same transaction
+that added them. The partial-index ``WHERE stage IN
+('preview_ready','fanned_out',…)`` predicate triggered
+``UnsafeNewEnumValueUsage`` on every staging deploy after PR #114
+merged (17-hour blast radius — staging stuck at revision 051 the
+whole time before this fix landed).
+
+Splitting the index into a separate migration lets it run in a
+fresh transaction where the new enum values are already-committed
+members of the type. ``IF NOT EXISTS`` on the create + DROP guards
+keep this idempotent across re-runs.
+
+The OLD ``ix_product_scan_jobs_active`` (scoped to the original
+active stages, no mode filter) survives unchanged after migration
+052 — this migration replaces it with the wizard-aware shape:
+
+  * Includes the new active stages: ``preview_ready``, ``fanned_out``
+  * Excludes ``mode='render_child'`` so the per-org concurrency cap
+    counts parents only (children don't take a cap slot)
+
+Plan: ``.claude/plans/shorts-auto-product-v2-phase-4-7.md`` §3.
+
+Revision ID: 053_recreate_active_index_with_wizard_stages
+Revises: 052_extend_scan_jobs_for_wizard
+Create Date: 2026-05-03
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "053_recreate_active_index_with_wizard_stages"
+down_revision: str | None = "052_extend_scan_jobs_for_wizard"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Drop the legacy active-index (created in 051) — it pre-dates the
+    # mode discriminator and includes ``mode='render_child'`` rows in
+    # its count, which would inflate the wizard's per-org concurrency
+    # cap reading.
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_active")
+    # Rebuild with the wizard-aware predicate. Safe to use the new
+    # enum values here because migration 052 committed them in its
+    # own transaction.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_product_scan_jobs_active
+            ON product_scan_jobs(org_id, stage)
+            WHERE stage IN (
+                'queued','enumerating','tracking','assembling','rendering',
+                'preview_ready','fanned_out'
+            ) AND mode <> 'render_child'
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_product_scan_jobs_active")
+    # Restore the original active-only index shape from migration 051
+    # (no mode filter, original stage set).
+    op.execute("""
+        CREATE INDEX ix_product_scan_jobs_active
+            ON product_scan_jobs(org_id, stage)
+            WHERE stage IN (
+                'queued','enumerating','tracking','assembling','rendering'
+            )
+    """)


### PR DESCRIPTION
**Critical hotfix.** Staging has been stuck at migration 051 for 17 hours since PR #114 merged. Every deploy since then has failed silently on alembic upgrade with \`UnsafeNewEnumValueUsage\`. All 9 Phase 4 PRs (#114-120, #121, #124, #123) have been "merged" but **never actually running** on staging.

## Root cause

Migration 052 adds three enum values to \`product_scan_stage\` and immediately uses two of them in the \`ix_product_scan_jobs_active\` partial-index predicate. Postgres rejects \`ALTER TYPE … ADD VALUE\` followed by use of the new value in the same transaction.

## Fix

Split the index rebuild into migration 053. 052 keeps just the \`ALTER TYPE\` statements and the column/constraint additions. Between 052 and 053 alembic commits the transaction → the new enum values become visible at the type level → 053 can safely use them in the partial-index predicate.

## Why this PR matters now

The user wanted to flip \`AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED=true\` on staging to test the wizard end-to-end. That can't happen until staging actually runs the new code. This PR unblocks that.

## Test plan

- [x] Both migrations import cleanly + revision chain matches
- [x] Forward-only: 052 → 053 from staging's 051 baseline
- [x] Idempotent: \`IF NOT EXISTS\` on enum ADDs and partial-index CREATE
- [ ] Staging deploy after merge — the real verification