### PR TITLE
fix(db): transaction_per_migration in alembic env.py (unblocks staging)

### DIFF
--- a/services/api/app/db/migrations/env.py
+++ b/services/api/app/db/migrations/env.py
@@ -34,6 +34,15 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        # ``transaction_per_migration=True``: each revision runs in its
+        # own transaction (committed between revisions) instead of one
+        # mega-transaction wrapping everything. Required for migrations
+        # that ``ALTER TYPE … ADD VALUE`` and downstream migrations
+        # that USE the new value — Postgres rejects same-transaction
+        # use of newly-added enum values (UnsafeNewEnumValueUsage).
+        # The previous staging outage (PRs #114-123 stuck on rev 051
+        # for 17h) was caused by this default. See migrations 052/053.
+        transaction_per_migration=True,
     )
 
     with context.begin_transaction():
@@ -50,7 +59,13 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata, version_num_width=128)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_num_width=128,
+            # See offline path for the rationale on transaction_per_migration.
+            transaction_per_migration=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()


### PR DESCRIPTION
**Critical staging hotfix #2.** PR #125 split migration 052 to escape the Postgres ADD-VALUE-then-USE restriction. Staging deploy still failed with the same error because alembic's default config wraps ALL pending migrations in ONE outer transaction — so the ALTER TYPE statements in 052 didn't commit between 052 and 053.

## Fix

Set \`transaction_per_migration=True\` in alembic env.py's \`context.configure(...)\`. Each revision now runs in its own transaction with a commit between. The ALTER TYPE statements are durable + visible by the time the next migration runs.

## Why two PRs?

#125 was necessary but not sufficient. The split between 052 (ALTER TYPE) and 053 (CREATE INDEX) only matters if alembic actually commits between them, which the default config doesn't do. Both fixes are needed.

## Test plan

- [x] env.py imports clean
- [ ] Staging deploy after merge — the real verification

If this also fails, the next-level fallback is \`alembic upgrade 052\` then \`alembic upgrade head\` as two separate invocations (the deploy script would need updating).