### PR TITLE
fix(compose): wire wizard publish flag through api service block

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,14 @@ services:
       - IMAGE_CAPTION_DAILY_BUDGET_USD=${IMAGE_CAPTION_DAILY_BUDGET_USD:-50.0}
       - IMAGE_CAPTION_ESTIMATED_COST_PER_CALL_USD=${IMAGE_CAPTION_ESTIMATED_COST_PER_CALL_USD:-0.012}
       - IMAGE_CAPTION_PROMPT_VERSION=${IMAGE_CAPTION_PROMPT_VERSION:-2026-04-13-v1}
+      # Auto-shorts product mode v2 (wizard) — pass-through to api so .env
+      # toggles propagate. Without this block the api silently uses
+      # config.py defaults (every flag false) regardless of host .env state.
+      # The same pattern of bug bit Phase 2 — the worker block had its own
+      # vars wired but the api block didn't, so the API never saw flag flips.
+      - AUTO_SHORTS_PRODUCT_V2_ENABLED=${AUTO_SHORTS_PRODUCT_V2_ENABLED:-false}
+      - AUTO_SHORTS_PRODUCT_V2_ROLLOUT_PCT=${AUTO_SHORTS_PRODUCT_V2_ROLLOUT_PCT:-0}
+      - AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED=${AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED:-false}
       # Auth0 configuration
       - AUTH0_ENABLED=${AUTH0_ENABLED:-false}
       - AUTH0_DOMAIN=${AUTH0_DOMAIN:-}


### PR DESCRIPTION
**Third hotfix in the staging-flip chain.** Caught while trying to flip \`AUTO_SHORTS_PRODUCT_V2_PUBLISH_SCAN_ORDER_ENABLED=true\` on staging.

## Root cause

The api service block in docker-compose.yml is allowlist-based — it only forwards env vars it explicitly lists. Setting an \`AUTO_SHORTS_PRODUCT_V2_*\` var in host .env was never reaching the api container; the api was using config.py defaults (every flag false) regardless.

Same gap that bit Phase 2 per memory \`project_shorts_auto_product_v2.md\` (SQS_PRODUCT_ENUMERATE_QUEUE_URL was added to worker but missing from api + drive-worker blocks).

## Fix

Three lines added to the api block forwarding the three wizard toggle vars. Other v2 settings (cost cap, concurrency, lease seconds) keep their config.py defaults — sane for staging + prod.

## After merge

1. Wait for staging deploy to finish
2. SSH to staging, append \`AUTO_SHORTS_PRODUCT_V2_ENABLED=true\` and \`AUTO_SHORTS_PRODUCT_V2_ROLLOUT_PCT=100\` to .env (the publish flag is already there)
3. \`docker compose up -d --force-recreate api\` to load new env
4. Verify the flags are live: \`docker compose exec api env | grep PRODUCT_V2\`