### PR TITLE
feat(web): Phase 4 PR #7 — wizard skeleton

### DIFF
--- a/services/web/src/app/export/shorts/auto/wizard/[videoId]/criteria/page.tsx
+++ b/services/web/src/app/export/shorts/auto/wizard/[videoId]/criteria/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useParams } from "next/navigation";
+import { Suspense } from "react";
+
+const WizardStepCriteria = dynamic(
+  () =>
+    import("@/features/shorts-auto-product-wizard/pages/WizardStepCriteria").then(
+      (m) => m.WizardStepCriteria,
+    ),
+  { ssr: false },
+);
+
+export default function WizardCriteriaRoute() {
+  const params = useParams<{ videoId: string }>();
+  const videoId = params?.videoId ?? "";
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-indigo-500" />
+        </div>
+      }
+    >
+      <WizardStepCriteria videoId={videoId} />
+    </Suspense>
+  );
+}

--- a/services/web/src/app/export/shorts/auto/wizard/[videoId]/preview/page.tsx
+++ b/services/web/src/app/export/shorts/auto/wizard/[videoId]/preview/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useParams } from "next/navigation";
+import { Suspense } from "react";
+
+const WizardStepPreviewStub = dynamic(
+  () =>
+    import(
+      "@/features/shorts-auto-product-wizard/pages/WizardStepPreviewStub"
+    ).then((m) => m.WizardStepPreviewStub),
+  { ssr: false },
+);
+
+export default function WizardPreviewRoute() {
+  const params = useParams<{ videoId: string }>();
+  const videoId = params?.videoId ?? "";
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-indigo-500" />
+        </div>
+      }
+    >
+      <WizardStepPreviewStub videoId={videoId} />
+    </Suspense>
+  );
+}

--- a/services/web/src/app/export/shorts/auto/wizard/[videoId]/result/[parentJobId]/page.tsx
+++ b/services/web/src/app/export/shorts/auto/wizard/[videoId]/result/[parentJobId]/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useParams } from "next/navigation";
+import { Suspense } from "react";
+
+const WizardStepResult = dynamic(
+  () =>
+    import("@/features/shorts-auto-product-wizard/pages/WizardStepResult").then(
+      (m) => m.WizardStepResult,
+    ),
+  { ssr: false },
+);
+
+export default function WizardResultRoute() {
+  const params = useParams<{ videoId: string; parentJobId: string }>();
+  const videoId = params?.videoId ?? "";
+  const parentJobId = params?.parentJobId ?? "";
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-indigo-500" />
+        </div>
+      }
+    >
+      <WizardStepResult videoId={videoId} parentJobId={parentJobId} />
+    </Suspense>
+  );
+}

--- a/services/web/src/app/export/shorts/auto/wizard/page.tsx
+++ b/services/web/src/app/export/shorts/auto/wizard/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Suspense } from "react";
+
+const WizardStepVideoSelect = dynamic(
+  () =>
+    import("@/features/shorts-auto-product-wizard/pages/WizardStepVideoSelect").then(
+      (m) => m.WizardStepVideoSelect,
+    ),
+  { ssr: false },
+);
+
+export default function WizardEntryRoute() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-indigo-500" />
+        </div>
+      }
+    >
+      <WizardStepVideoSelect />
+    </Suspense>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/LengthSelector.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/LengthSelector.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { LengthSelector } from "../components/LengthSelector";
+
+describe("LengthSelector", () => {
+  it("renders all five presets", () => {
+    render(<LengthSelector value={60} onChange={vi.fn()} />);
+    [15, 30, 60, 90, 120].forEach((preset) => {
+      expect(screen.getByTestId(`length-preset-${preset}`)).toBeInTheDocument();
+    });
+  });
+
+  it("highlights the active preset", () => {
+    render(<LengthSelector value={30} onChange={vi.fn()} />);
+    const active = screen.getByTestId("length-preset-30");
+    expect(active.className).toMatch(/bg-indigo-500/);
+    const inactive = screen.getByTestId("length-preset-60");
+    expect(inactive.className).not.toMatch(/bg-indigo-500/);
+  });
+
+  it("fires onChange with the chosen preset", () => {
+    const onChange = vi.fn();
+    render(<LengthSelector value={60} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("length-preset-90"));
+    expect(onChange).toHaveBeenCalledWith(90);
+  });
+
+  it("clamps custom input to 10..120", () => {
+    const onChange = vi.fn();
+    render(<LengthSelector value={60} onChange={onChange} />);
+    const input = screen.getByTestId("length-custom-input");
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(onChange).toHaveBeenLastCalledWith(10);
+    fireEvent.change(input, { target: { value: "999" } });
+    expect(onChange).toHaveBeenLastCalledWith(120);
+    fireEvent.change(input, { target: { value: "75" } });
+    expect(onChange).toHaveBeenLastCalledWith(75);
+  });
+
+  it("ignores non-numeric input gracefully", () => {
+    const onChange = vi.fn();
+    render(<LengthSelector value={60} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId("length-custom-input"), {
+      target: { value: "abc" },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepCriteria.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepCriteria.test.tsx
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { WizardStepCriteria } from "../pages/WizardStepCriteria";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ getAccessToken: vi.fn(async () => "test-token") }),
+}));
+
+const createScanOrderMock = vi.fn();
+vi.mock("@/lib/api/shorts-auto-product-wizard", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/shorts-auto-product-wizard")
+  >("@/lib/api/shorts-auto-product-wizard");
+  return {
+    ...actual,
+    createScanOrder: (...args: unknown[]) => createScanOrderMock(...args),
+  };
+});
+
+describe("WizardStepCriteria", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    createScanOrderMock.mockReset();
+  });
+
+  it("renders all five inputs with sensible defaults", () => {
+    render(<WizardStepCriteria videoId="gd_test" />);
+    expect(screen.getByTestId("length-preset-60")).toBeInTheDocument();
+    expect(screen.getByTestId("count-preset-5")).toBeInTheDocument();
+    expect(screen.getByTestId("range-start-input")).toBeInTheDocument();
+    expect(screen.getByTestId("range-end-input")).toBeInTheDocument();
+    expect(screen.getByTestId("distribution-single")).toBeInTheDocument();
+    expect(screen.getByTestId("language-ko")).toBeInTheDocument();
+  });
+
+  it("shows the aggregate-cap warning when count × length > 1800s", () => {
+    render(<WizardStepCriteria videoId="gd_test" />);
+    // default 60s × 5 = 300s — no warning yet
+    expect(
+      screen.queryByTestId("aggregate-cap-warning"),
+    ).not.toBeInTheDocument();
+    // bump count → 60s × 20 = 1200 (still ok)
+    fireEvent.click(screen.getByTestId("count-preset-20"));
+    expect(
+      screen.queryByTestId("aggregate-cap-warning"),
+    ).not.toBeInTheDocument();
+    // bump length to 120 → 120 × 20 = 2400, over cap
+    fireEvent.click(screen.getByTestId("length-preset-120"));
+    expect(screen.getByTestId("aggregate-cap-warning")).toBeInTheDocument();
+  });
+
+  it("disables Next when over the aggregate cap", () => {
+    render(<WizardStepCriteria videoId="gd_test" />);
+    fireEvent.click(screen.getByTestId("count-preset-20"));
+    fireEvent.click(screen.getByTestId("length-preset-120"));
+    const next = screen.getByTestId("wizard-next") as HTMLButtonElement;
+    expect(next.disabled).toBe(true);
+  });
+
+  it("submits the scan order with the chosen criteria + routes to step 4", async () => {
+    createScanOrderMock.mockResolvedValueOnce({
+      parent_job_id: "00000000-0000-0000-0000-000000000123",
+      deduped: false,
+    });
+    render(<WizardStepCriteria videoId="gd_test" />);
+    fireEvent.click(screen.getByTestId("length-preset-30"));
+    fireEvent.click(screen.getByTestId("count-preset-10"));
+    fireEvent.click(screen.getByTestId("language-en"));
+    fireEvent.change(screen.getByTestId("range-start-input"), {
+      target: { value: "1:30" },
+    });
+
+    fireEvent.click(screen.getByTestId("wizard-next"));
+
+    await waitFor(() => expect(createScanOrderMock).toHaveBeenCalledTimes(1));
+    expect(createScanOrderMock.mock.calls[0][0]).toBe("gd_test");
+    const body = createScanOrderMock.mock.calls[0][1];
+    expect(body).toMatchObject({
+      length_seconds: 30,
+      requested_count: 10,
+      language: "en",
+      product_distribution: "single",
+      intent: "commit",
+      time_range_start_ms: 90_000, // 1:30 = 90s = 90000ms
+    });
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith(
+        "/export/shorts/auto/wizard/gd_test/result/00000000-0000-0000-0000-000000000123",
+      ),
+    );
+  });
+
+  it("surfaces the API's 422 detail message", async () => {
+    const { WizardValidationError } = await import(
+      "@/lib/api/shorts-auto-product-wizard"
+    );
+    createScanOrderMock.mockRejectedValueOnce(
+      new WizardValidationError("requested_count must be >= 1"),
+    );
+    render(<WizardStepCriteria videoId="gd_test" />);
+    fireEvent.click(screen.getByTestId("wizard-next"));
+    const error = await screen.findByTestId("error-message");
+    expect(error.textContent).toContain("requested_count must be >= 1");
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/web/src/features/shorts-auto-product-wizard/components/CountSelector.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/components/CountSelector.tsx
@@ -1,0 +1,76 @@
+// ============================================================================
+// 생성할 쇼츠 개수 (5/10/15/20 + 직접입력)
+//
+// Bound range: 1..50 (matches backend's ``requested_count: int = Field(...,
+// ge=1, le=50)``). Aggregate output cap (count × length ≤ 1800s) is enforced
+// server-side at submit; the criteria page surfaces it as a 422 message.
+// ============================================================================
+
+"use client";
+
+import { useState } from "react";
+
+const PRESETS = [5, 10, 15, 20] as const;
+const MIN = 1;
+const MAX = 50;
+
+interface Props {
+  value: number;
+  onChange: (next: number) => void;
+}
+
+export function CountSelector({ value, onChange }: Props) {
+  const [customDraft, setCustomDraft] = useState<string>("");
+  const isPresetActive = (PRESETS as readonly number[]).includes(value);
+
+  const handlePresetClick = (preset: number) => {
+    onChange(preset);
+    setCustomDraft("");
+  };
+
+  const handleCustomChange = (raw: string) => {
+    setCustomDraft(raw);
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = Math.max(MIN, Math.min(MAX, parsed));
+    onChange(clamped);
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700">
+        생성할 쇼츠 개수
+      </label>
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => handlePresetClick(preset)}
+            className={`rounded-md border px-3 py-1.5 text-sm transition ${
+              isPresetActive && value === preset
+                ? "border-indigo-500 bg-indigo-500 text-white"
+                : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+            }`}
+            data-testid={`count-preset-${preset}`}
+          >
+            {preset}개
+          </button>
+        ))}
+        <input
+          type="number"
+          min={MIN}
+          max={MAX}
+          placeholder="직접입력"
+          value={customDraft || (isPresetActive ? "" : String(value))}
+          onChange={(e) => handleCustomChange(e.target.value)}
+          className="w-24 rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+          data-testid="count-custom-input"
+        />
+      </div>
+      <p className="text-xs text-gray-500">
+        {MIN}개 이상 {MAX}개 이하 (현재 {value}개)
+      </p>
+    </div>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/components/LanguageToggle.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/components/LanguageToggle.tsx
@@ -1,0 +1,49 @@
+// ============================================================================
+// 언어 — 한국어 / 영어
+//
+// Phase 4 ships ``ko`` end-to-end. ``en`` is the Phase 7 deliverable
+// (alignment tokenizer split for English narration + EN-only LLM picker
+// prompt). Until then selecting ``en`` is accepted at the API level
+// (backend stores it on the parent row) but downstream alignment defaults
+// to the Korean tokenizer rules — minor false-negative rate on narration
+// matching, no hard failure.
+// ============================================================================
+
+"use client";
+
+import type { Language } from "@/lib/types/shorts-auto-product-wizard";
+
+interface Props {
+  value: Language;
+  onChange: (next: Language) => void;
+}
+
+const OPTIONS: Array<{ value: Language; label: string }> = [
+  { value: "ko", label: "한국어" },
+  { value: "en", label: "영어" },
+];
+
+export function LanguageToggle({ value, onChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700">언어</label>
+      <div className="flex gap-2">
+        {OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={`rounded-md border px-3 py-1.5 text-sm transition ${
+              value === opt.value
+                ? "border-indigo-500 bg-indigo-500 text-white"
+                : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+            }`}
+            data-testid={`language-${opt.value}`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/components/LengthSelector.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/components/LengthSelector.tsx
@@ -1,0 +1,76 @@
+// ============================================================================
+// 쇼츠 길이 선택 (15/30/60/90/120 + 직접입력)
+//
+// Bound range: 10..120 seconds (matches backend ScanOrderCreateRequest's
+// ``length_seconds: int = Field(..., ge=10, le=120)``). The custom input
+// clamps locally so the user sees the rejection before submit.
+// ============================================================================
+
+"use client";
+
+import { useState } from "react";
+
+const PRESETS = [15, 30, 60, 90, 120] as const;
+const MIN = 10;
+const MAX = 120;
+
+interface Props {
+  value: number;
+  onChange: (next: number) => void;
+}
+
+export function LengthSelector({ value, onChange }: Props) {
+  const [customDraft, setCustomDraft] = useState<string>("");
+  const isPresetActive = (PRESETS as readonly number[]).includes(value);
+
+  const handlePresetClick = (preset: number) => {
+    onChange(preset);
+    setCustomDraft("");
+  };
+
+  const handleCustomChange = (raw: string) => {
+    setCustomDraft(raw);
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = Math.max(MIN, Math.min(MAX, parsed));
+    onChange(clamped);
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700">
+        쇼츠 길이
+      </label>
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => handlePresetClick(preset)}
+            className={`rounded-md border px-3 py-1.5 text-sm transition ${
+              isPresetActive && value === preset
+                ? "border-indigo-500 bg-indigo-500 text-white"
+                : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+            }`}
+            data-testid={`length-preset-${preset}`}
+          >
+            {preset}초
+          </button>
+        ))}
+        <input
+          type="number"
+          min={MIN}
+          max={MAX}
+          placeholder="직접입력"
+          value={customDraft || (isPresetActive ? "" : String(value))}
+          onChange={(e) => handleCustomChange(e.target.value)}
+          className="w-24 rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+          data-testid="length-custom-input"
+        />
+      </div>
+      <p className="text-xs text-gray-500">
+        {MIN}초 이상 {MAX}초 이하 (현재 {value}초)
+      </p>
+    </div>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/components/ProductDistributionToggle.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/components/ProductDistributionToggle.tsx
@@ -1,0 +1,79 @@
+// ============================================================================
+// 상품 구분 여부 — 개별 상품 / 여러 상품
+//
+// Per the wizard mockup:
+//   * 개별 상품 (single): each generated short is dedicated to one product.
+//   * 여러 상품 (multi): each generated short can mix multiple products.
+//
+// In Phase 4 only ``single`` is implemented end-to-end (the runner +
+// SingleProductSubsetPicker round-robin distribution). ``multi`` is the
+// Phase 5 deliverable — until ``MULTI_PRODUCT_PICKER_ENABLED=true`` flips
+// on the backend, selecting it returns a 422 at submit time, which the
+// criteria page surfaces verbatim. We keep the toggle visible so the
+// product surface area is complete.
+// ============================================================================
+
+"use client";
+
+import type { ProductDistribution } from "@/lib/types/shorts-auto-product-wizard";
+
+interface Props {
+  value: ProductDistribution;
+  onChange: (next: ProductDistribution) => void;
+}
+
+const OPTIONS: Array<{
+  value: ProductDistribution;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "single",
+    label: "개별 상품",
+    description: "각 제품별로 구분해서 쇼츠를 제작해요",
+  },
+  {
+    value: "multi",
+    label: "여러 상품",
+    description: "여러 상품을 하나의 쇼츠에 보여줘도 돼요",
+  },
+];
+
+export function ProductDistributionToggle({ value, onChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700">
+        상품 구분 여부
+      </label>
+      <div className="space-y-2">
+        {OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 transition ${
+              value === opt.value
+                ? "border-indigo-500 bg-indigo-50"
+                : "border-gray-300 bg-white hover:bg-gray-50"
+            }`}
+            data-testid={`distribution-${opt.value}`}
+          >
+            <input
+              type="radio"
+              name="product-distribution"
+              checked={value === opt.value}
+              onChange={() => onChange(opt.value)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block text-sm font-medium text-gray-800">
+                {opt.label}
+              </span>
+              <span className="block text-xs text-gray-500">
+                {opt.description}
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/components/WizardLayout.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/components/WizardLayout.tsx
@@ -1,0 +1,83 @@
+// ============================================================================
+// Wizard chrome — header breadcrumb + Next/Prev buttons.
+//
+// Minimal stepper (no UI lib dependency). Each step page passes its index
+// (1-4) and renders its own content as children. The layout owns the
+// breadcrumb visualization + the consistent "다음 >" / "< 뒤로" affordances.
+// ============================================================================
+
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+const STEPS = [
+  { idx: 1, label: "동영상 선택" },
+  { idx: 2, label: "생성 기준 설정" },
+  { idx: 3, label: "쇼츠 가편집본" },
+  { idx: 4, label: "쇼츠 자동 생성" },
+] as const;
+
+interface Props {
+  currentStep: 1 | 2 | 3 | 4;
+  /** Visible header instruction text (right side). */
+  heading: string;
+  /** Optional Next button — pass null to omit (e.g., terminal step). */
+  next?: { label: string; onClick: () => void; disabled?: boolean } | null;
+  /** Optional Back href. Defaults to ``/export/shorts/auto`` from step 1. */
+  backHref?: string;
+  children: ReactNode;
+}
+
+export function WizardLayout({
+  currentStep,
+  heading,
+  next,
+  backHref = "/export/shorts/auto",
+  children,
+}: Props) {
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="space-y-3">
+        <div className="flex items-center justify-between gap-4">
+          <Link
+            href={backHref}
+            className="text-sm text-gray-600 hover:underline"
+          >
+            &lt; 뒤로
+          </Link>
+          <nav className="flex items-center gap-2 text-sm text-gray-700">
+            {STEPS.map((step) => (
+              <span
+                key={step.idx}
+                className={
+                  step.idx === currentStep
+                    ? "font-semibold text-indigo-600"
+                    : "text-gray-500"
+                }
+              >
+                {step.idx}.{step.label}
+                {step.idx < STEPS.length ? " >" : ""}
+              </span>
+            ))}
+          </nav>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-gray-700">{heading}</p>
+          {next ? (
+            <button
+              type="button"
+              onClick={next.onClick}
+              disabled={next.disabled}
+              className="rounded-md bg-indigo-500 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-600 disabled:bg-gray-300 disabled:text-gray-500"
+              data-testid="wizard-next"
+            >
+              {next.label}
+            </button>
+          ) : null}
+        </div>
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/hooks/useScanOrder.ts
+++ b/services/web/src/features/shorts-auto-product-wizard/hooks/useScanOrder.ts
@@ -1,0 +1,131 @@
+// ============================================================================
+// Scan-order lifecycle hook for the wizard.
+//
+// One responsibility: take a created parent_job_id, poll its aggregate
+// status every 3s, expose the current snapshot + a stop signal. The
+// criteria step uses ``createScanOrder`` directly (one-shot mutation);
+// this hook subscribes to the resulting parent.
+//
+// Polling cadence is 3s (locked in plan §4.4 — codex pushback against
+// the original 10s throttle for the rendering stage; child stages can
+// transition queued→assembling→done faster than 10s).
+// ============================================================================
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  cancelScanOrder,
+  getScanOrderStatus,
+} from "@/lib/api/shorts-auto-product-wizard";
+import type { ScanOrderStatusResponse } from "@/lib/types/shorts-auto-product-wizard";
+import { isTerminalStage } from "@/lib/types/shorts-auto-product-wizard";
+
+type TokenGetter = () => Promise<string | null>;
+
+const POLL_INTERVAL_MS = 3000;
+
+export interface UseScanOrderState {
+  status: ScanOrderStatusResponse | null;
+  error: Error | null;
+  isPolling: boolean;
+}
+
+export interface UseScanOrderResult extends UseScanOrderState {
+  cancel: () => Promise<void>;
+}
+
+/**
+ * Subscribe to a scan order's aggregate status.
+ *
+ * Polls every 3s until ALL of:
+ *   - parent stage is terminal (done / committed / failed / cancelled)
+ *   - every child stage is terminal
+ *
+ * Tests can override the interval by passing ``pollIntervalMs``.
+ */
+export function useScanOrder(
+  parentJobId: string | null,
+  tokenGetter: TokenGetter,
+  options?: { pollIntervalMs?: number },
+): UseScanOrderResult {
+  const interval = options?.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const [state, setState] = useState<UseScanOrderState>({
+    status: null,
+    error: null,
+    isPolling: false,
+  });
+  // Use a ref to track latest state in the polling closure without
+  // re-creating the interval on each render.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // Determine whether polling should continue based on the latest
+  // status. Pure function — no side effects.
+  const shouldKeepPolling = useCallback(
+    (status: ScanOrderStatusResponse): boolean => {
+      if (!isTerminalStage(status.parent.stage)) return true;
+      // Parent terminal but children still active → keep polling so
+      // the UI sees their final stages.
+      return status.children.some((c) => !isTerminalStage(c.stage));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!parentJobId) {
+      setState({ status: null, error: null, isPolling: false });
+      return;
+    }
+
+    let cancelled = false;
+    setState((prev) => ({ ...prev, isPolling: true, error: null }));
+
+    const poll = async () => {
+      try {
+        const next = await getScanOrderStatus(parentJobId, tokenGetter);
+        if (cancelled) return;
+        const keepGoing = shouldKeepPolling(next);
+        setState({
+          status: next,
+          error: null,
+          isPolling: keepGoing,
+        });
+        if (keepGoing) {
+          timerHandle = window.setTimeout(poll, interval);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err : new Error(String(err)),
+          isPolling: false,
+        }));
+      }
+    };
+
+    let timerHandle: number | undefined;
+    void poll();
+
+    return () => {
+      cancelled = true;
+      if (timerHandle !== undefined) {
+        window.clearTimeout(timerHandle);
+      }
+    };
+  }, [parentJobId, tokenGetter, interval, shouldKeepPolling]);
+
+  const cancel = useCallback(async () => {
+    if (!parentJobId) return;
+    await cancelScanOrder(parentJobId, tokenGetter);
+    // Trigger a fresh status read so the UI updates fast (rather
+    // than waiting for the next 3s tick).
+    try {
+      const refreshed = await getScanOrderStatus(parentJobId, tokenGetter);
+      setState({ status: refreshed, error: null, isPolling: false });
+    } catch {
+      // Ignore — the next poll cycle will surface any error.
+    }
+  }, [parentJobId, tokenGetter]);
+
+  return { ...state, cancel };
+}

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepCriteria.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepCriteria.tsx
@@ -1,0 +1,198 @@
+// ============================================================================
+// Step 2 — 생성 기준 설정 (criteria form)
+//
+// The headline screen from the wizard mockup. Five inputs:
+//   * length_seconds (LengthSelector — 15/30/60/90/120 + custom)
+//   * time_range_start_ms / time_range_end_ms (mm:ss text inputs;
+//     drag-handle slider deferred to follow-up PR per plan §8.3)
+//   * requested_count (CountSelector — 5/10/15/20 + custom)
+//   * product_distribution (개별 / 여러)
+//   * language (한국어 / 영어)
+//
+// On submit: POST /api/shorts/auto/scan-orders/videos/{videoId} → on success
+// route to step 4 with the parent_job_id; on 422 surface the message;
+// on 402 / 429 surface friendly copy.
+// ============================================================================
+
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { useAuth } from "@/lib/auth";
+import {
+  WizardBudgetExceededError,
+  WizardFeatureDisabledError,
+  WizardRateLimitError,
+  WizardValidationError,
+  createScanOrder,
+} from "@/lib/api/shorts-auto-product-wizard";
+import type {
+  Language,
+  ProductDistribution,
+} from "@/lib/types/shorts-auto-product-wizard";
+
+import { CountSelector } from "../components/CountSelector";
+import { LanguageToggle } from "../components/LanguageToggle";
+import { LengthSelector } from "../components/LengthSelector";
+import { ProductDistributionToggle } from "../components/ProductDistributionToggle";
+import { WizardLayout } from "../components/WizardLayout";
+
+interface Props {
+  videoId: string;
+}
+
+/**
+ * Convert "mm:ss" or "" to milliseconds (or null when blank).
+ * Tolerant — bad input parses to null and the field shows raw text.
+ */
+function parseMmSsToMs(raw: string): number | null {
+  if (!raw.trim()) return null;
+  const match = raw.match(/^(\d+):(\d{1,2})$/);
+  if (!match) return null;
+  const minutes = Number.parseInt(match[1] || "0", 10);
+  const seconds = Number.parseInt(match[2] || "0", 10);
+  if (Number.isNaN(minutes) || Number.isNaN(seconds)) return null;
+  if (seconds > 59) return null;
+  return (minutes * 60 + seconds) * 1000;
+}
+
+export function WizardStepCriteria({ videoId }: Props) {
+  const router = useRouter();
+  const { getAccessToken } = useAuth();
+
+  // Form state — defaults match the most-common preset choices.
+  const [lengthSeconds, setLengthSeconds] = useState<number>(60);
+  const [requestedCount, setRequestedCount] = useState<number>(5);
+  const [rangeStartRaw, setRangeStartRaw] = useState<string>("");
+  const [rangeEndRaw, setRangeEndRaw] = useState<string>("");
+  const [distribution, setDistribution] =
+    useState<ProductDistribution>("single");
+  const [language, setLanguage] = useState<Language>("ko");
+
+  // Submission state
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Inline aggregate-cap warning (server enforces; this is an early hint).
+  const aggregateSeconds = lengthSeconds * requestedCount;
+  const exceedsAggregateCap = aggregateSeconds > 1800;
+
+  const handleSubmit = async () => {
+    setErrorMessage(null);
+    setSubmitting(true);
+    try {
+      const response = await createScanOrder(
+        videoId,
+        {
+          length_seconds: lengthSeconds,
+          requested_count: requestedCount,
+          time_range_start_ms: parseMmSsToMs(rangeStartRaw),
+          time_range_end_ms: parseMmSsToMs(rangeEndRaw),
+          product_distribution: distribution,
+          language,
+          intent: "commit", // Phase 4: skip preview, go straight to commit
+        },
+        getAccessToken,
+      );
+      router.push(
+        `/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/result/${encodeURIComponent(response.parent_job_id)}`,
+      );
+    } catch (err) {
+      if (err instanceof WizardValidationError) {
+        setErrorMessage(`입력 오류: ${err.message}`);
+      } else if (err instanceof WizardBudgetExceededError) {
+        setErrorMessage(`일일 비용 한도 초과: ${err.message}`);
+      } else if (err instanceof WizardRateLimitError) {
+        setErrorMessage(`동시 실행 한도 초과: ${err.message}`);
+      } else if (err instanceof WizardFeatureDisabledError) {
+        setErrorMessage("이 조직에는 마법사 기능이 활성화되지 않았습니다.");
+      } else {
+        setErrorMessage(
+          err instanceof Error ? err.message : "Unknown error",
+        );
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSubmit = !submitting && !exceedsAggregateCap;
+
+  return (
+    <WizardLayout
+      currentStep={2}
+      heading="생성 기준을 선택하고, '다음'버튼을 클릭하세요"
+      next={{
+        label: submitting ? "생성 중..." : "다음 >",
+        onClick: handleSubmit,
+        disabled: !canSubmit,
+      }}
+      backHref="/export/shorts/auto/wizard"
+    >
+      <div className="space-y-6 rounded-lg border border-gray-200 bg-white p-6">
+        <LengthSelector value={lengthSeconds} onChange={setLengthSeconds} />
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">
+            주로 처리할 동영상 구간
+          </label>
+          <div className="flex items-center gap-2 text-sm">
+            <input
+              type="text"
+              placeholder="00:00"
+              value={rangeStartRaw}
+              onChange={(e) => setRangeStartRaw(e.target.value)}
+              className="w-24 rounded-md border border-gray-300 px-2 py-1.5"
+              data-testid="range-start-input"
+            />
+            <span className="text-gray-500">~</span>
+            <input
+              type="text"
+              placeholder="mm:ss"
+              value={rangeEndRaw}
+              onChange={(e) => setRangeEndRaw(e.target.value)}
+              className="w-24 rounded-md border border-gray-300 px-2 py-1.5"
+              data-testid="range-end-input"
+            />
+            <span className="text-xs text-gray-500">
+              비워두면 동영상 전체에서 선택
+            </span>
+          </div>
+          <p className="text-xs text-gray-500">
+            드래그 가능한 슬라이더는 다음 PR에서 추가됩니다.
+          </p>
+        </div>
+
+        <CountSelector value={requestedCount} onChange={setRequestedCount} />
+
+        <ProductDistributionToggle
+          value={distribution}
+          onChange={setDistribution}
+        />
+
+        <LanguageToggle value={language} onChange={setLanguage} />
+
+        {exceedsAggregateCap ? (
+          <p
+            className="rounded-md bg-amber-50 p-3 text-sm text-amber-800"
+            data-testid="aggregate-cap-warning"
+          >
+            총 출력 길이 한도(30분) 초과: {requestedCount}개 ×{" "}
+            {lengthSeconds}초 = {aggregateSeconds}초. 개수 또는 길이를
+            줄여주세요.
+          </p>
+        ) : null}
+
+        {errorMessage ? (
+          <p
+            className="rounded-md bg-red-50 p-3 text-sm text-red-700"
+            data-testid="error-message"
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+      </div>
+    </WizardLayout>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepPreviewStub.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepPreviewStub.tsx
@@ -1,0 +1,43 @@
+// ============================================================================
+// Step 3 — 쇼츠 가편집본 (preview stub)
+//
+// **Phase 6 deliverable.** The preview step runs a SigLIP2-only retrieval
+// pass (no SAM2) so the user can iterate on criteria without burning GPU.
+// Phase 4 ships the wizard with a stub here — the criteria step submits
+// with ``intent='commit'`` and skips this screen entirely. This page is
+// a placeholder so the route shape is locked even though the surface
+// isn't functional yet.
+//
+// Backend has the matching shape: ``POST /scan-orders/{id}/commit``
+// returns 501 today (plan §11.1).
+// ============================================================================
+
+"use client";
+
+import { WizardLayout } from "../components/WizardLayout";
+
+interface Props {
+  videoId: string;
+}
+
+export function WizardStepPreviewStub({ videoId }: Props) {
+  return (
+    <WizardLayout
+      currentStep={3}
+      heading="쇼츠 가편집본 미리보기 (Phase 6에서 구현)"
+      next={null}
+      backHref={`/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/criteria`}
+    >
+      <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-6">
+        <h2 className="text-lg font-semibold text-amber-900">
+          가편집본 미리보기는 곧 출시됩니다
+        </h2>
+        <p className="text-sm text-amber-800">
+          Phase 6에서 SigLIP2 기반 가편집 미리보기를 추가할 예정입니다.
+          그 전까지는 2단계의 '다음 &gt;' 버튼을 누르면 4단계로 바로
+          이동합니다.
+        </p>
+      </div>
+    </WizardLayout>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepResult.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepResult.tsx
@@ -1,0 +1,199 @@
+// ============================================================================
+// Step 4 — 쇼츠 자동 생성 (results)
+//
+// Subscribes to the parent job's aggregate status via useScanOrder
+// (3s polling). Renders parent progress + a list of N child status cards
+// keyed on ``shorts_index``. When a child reaches ``done`` with
+// ``render_job_id`` set, the card surfaces a download/preview link routed
+// through the existing shorts-render endpoints.
+//
+// Loose-coupling: this page does NOT import from features/shorts-render
+// or features/shorts-editor. It links to those routes via Next ``href``
+// strings only.
+// ============================================================================
+
+"use client";
+
+import Link from "next/link";
+
+import { useAuth } from "@/lib/auth";
+import type { JobStatusResponse } from "@/lib/types/shorts-auto-product-wizard";
+
+import { WizardLayout } from "../components/WizardLayout";
+import { useScanOrder } from "../hooks/useScanOrder";
+
+interface Props {
+  videoId: string;
+  parentJobId: string;
+}
+
+export function WizardStepResult({ videoId, parentJobId }: Props) {
+  const { getAccessToken } = useAuth();
+  const { status, error, isPolling, cancel } = useScanOrder(
+    parentJobId,
+    getAccessToken,
+  );
+
+  return (
+    <WizardLayout
+      currentStep={4}
+      heading="쇼츠 자동 생성"
+      next={null}
+      backHref={`/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/criteria`}
+    >
+      <div className="space-y-4">
+        {error ? (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            상태 조회 실패: {error.message}
+          </div>
+        ) : null}
+
+        {!status ? (
+          <div className="rounded-md border border-gray-200 bg-white p-6 text-sm text-gray-600">
+            상태를 불러오는 중...
+          </div>
+        ) : (
+          <>
+            <ParentProgress
+              parent={status.parent}
+              childrenComplete={status.children_complete}
+              childrenFailed={status.children_failed}
+              childrenTotal={status.children_total}
+              isPolling={isPolling}
+              onCancel={cancel}
+            />
+            <ChildList children={status.children} />
+          </>
+        )}
+      </div>
+    </WizardLayout>
+  );
+}
+
+interface ParentProgressProps {
+  parent: JobStatusResponse;
+  childrenComplete: number;
+  childrenFailed: number;
+  childrenTotal: number;
+  isPolling: boolean;
+  onCancel: () => Promise<void>;
+}
+
+function ParentProgress({
+  parent,
+  childrenComplete,
+  childrenFailed,
+  childrenTotal,
+  isPolling,
+  onCancel,
+}: ParentProgressProps) {
+  const showCancel =
+    parent.stage !== "done" &&
+    parent.stage !== "committed" &&
+    parent.stage !== "failed" &&
+    parent.stage !== "cancelled";
+
+  return (
+    <div className="space-y-2 rounded-lg border border-gray-200 bg-white p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-800">
+            전체 진행률
+          </h2>
+          <p className="text-xs text-gray-500">
+            {isPolling ? "3초마다 갱신" : "완료"}
+          </p>
+        </div>
+        {showCancel ? (
+          <button
+            type="button"
+            onClick={() => void onCancel()}
+            className="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-700 hover:bg-red-50"
+            data-testid="cancel-scan-order"
+          >
+            전체 취소
+          </button>
+        ) : null}
+      </div>
+      <div className="text-sm text-gray-700">
+        단계: <span className="font-medium">{parent.stage}</span> ·{" "}
+        진행률: {parent.progress_pct}%
+        {parent.progress_label ? ` · ${parent.progress_label}` : null}
+      </div>
+      <div className="text-sm text-gray-700">
+        쇼츠 진행: {childrenComplete} 완료 · {childrenFailed} 실패 ·{" "}
+        총 {childrenTotal}개
+      </div>
+      {parent.error_code ? (
+        <p
+          className="rounded-md bg-red-50 p-2 text-xs text-red-700"
+          data-testid="parent-error"
+        >
+          오류: {parent.error_code}
+          {parent.error_message ? ` — ${parent.error_message}` : ""}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface ChildListProps {
+  children: JobStatusResponse[];
+}
+
+function ChildList({ children }: ChildListProps) {
+  if (children.length === 0) {
+    return (
+      <div className="rounded-md border border-gray-200 bg-white p-4 text-sm text-gray-500">
+        아직 생성된 쇼츠가 없습니다.
+      </div>
+    );
+  }
+  // Sort by shorts_index so the visual order matches "쇼츠 1, 2, 3, ..."
+  const sorted = [...children].sort(
+    (a, b) => (a.shorts_index ?? 0) - (b.shorts_index ?? 0),
+  );
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {sorted.map((child) => (
+        <ChildCard key={child.job_id} child={child} />
+      ))}
+    </div>
+  );
+}
+
+function ChildCard({ child }: { child: JobStatusResponse }) {
+  const isDone = child.stage === "done" || child.stage === "committed";
+  const isFailed = child.stage === "failed";
+  return (
+    <div
+      className={`rounded-md border p-4 ${
+        isFailed
+          ? "border-red-200 bg-red-50"
+          : isDone
+            ? "border-green-200 bg-green-50"
+            : "border-gray-200 bg-white"
+      }`}
+      data-testid={`child-card-${child.shorts_index ?? "unknown"}`}
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-800">
+          쇼츠 {child.shorts_index ?? "?"}
+        </h3>
+        <span className="text-xs text-gray-500">{child.stage}</span>
+      </div>
+      <p className="text-xs text-gray-600">진행률 {child.progress_pct}%</p>
+      {child.render_job_id ? (
+        <Link
+          href={`/export/shorts/render/${child.render_job_id}`}
+          className="mt-2 inline-block text-xs text-indigo-600 hover:underline"
+        >
+          렌더 결과 보기 &rarr;
+        </Link>
+      ) : null}
+      {isFailed && child.error_message ? (
+        <p className="mt-1 text-xs text-red-700">{child.error_message}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepVideoSelect.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepVideoSelect.tsx
@@ -1,0 +1,57 @@
+// ============================================================================
+// Step 1 — 동영상 선택
+//
+// **Skeleton scope (PR #7):** a minimal text input for the user to paste
+// or type a video ID, then advance to step 2. The full video-library
+// search/list UI is a follow-up — wraps the existing video search
+// pattern via lib/api/search, but threading that through is its own
+// PR's worth of UX.
+// ============================================================================
+
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { WizardLayout } from "../components/WizardLayout";
+
+export function WizardStepVideoSelect() {
+  const router = useRouter();
+  const [videoId, setVideoId] = useState("");
+
+  const trimmed = videoId.trim();
+  const canProceed = trimmed.length > 0;
+
+  const handleNext = () => {
+    if (!canProceed) return;
+    router.push(
+      `/export/shorts/auto/wizard/${encodeURIComponent(trimmed)}/criteria`,
+    );
+  };
+
+  return (
+    <WizardLayout
+      currentStep={1}
+      heading="동영상을 선택하고 '다음'버튼을 클릭하세요"
+      next={{ label: "다음 >", onClick: handleNext, disabled: !canProceed }}
+      backHref="/export/shorts/auto"
+    >
+      <div className="space-y-3 rounded-lg border border-gray-200 bg-white p-6">
+        <p className="text-sm text-gray-600">
+          쇼츠를 만들 동영상의 ID를 입력하세요. 예: <code>gd_abc123</code>
+        </p>
+        <input
+          type="text"
+          value={videoId}
+          onChange={(e) => setVideoId(e.target.value)}
+          placeholder="gd_..."
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          data-testid="video-id-input"
+        />
+        <p className="text-xs text-gray-500">
+          향후 PR에서 동영상 라이브러리 검색 UI로 대체됩니다.
+        </p>
+      </div>
+    </WizardLayout>
+  );
+}

--- a/services/web/src/lib/api/shorts-auto-product-wizard.ts
+++ b/services/web/src/lib/api/shorts-auto-product-wizard.ts
@@ -1,0 +1,167 @@
+// ============================================================================
+// Shorts auto product wizard API client.
+//
+// Mirrors lib/api/shorts-auto.ts style: plain fetch + getApiBaseUrl, Bearer
+// token via TokenGetter, custom error subclasses so the UI can branch on
+// `err.isRateLimit` / `err.isFeatureDisabled` / `err.isValidation` without
+// parsing strings.
+//
+// NEVER import from features/*. This module is the one-way public surface
+// the wizard feature dir consumes.
+// ============================================================================
+
+import type {
+  ScanOrderCreateRequest,
+  ScanOrderResponse,
+  ScanOrderStatusResponse,
+} from "../types/shorts-auto-product-wizard";
+import { getApiBaseUrl } from "./utils";
+
+type TokenGetter = () => Promise<string | null>;
+
+// Error subclasses follow the shorts-auto.ts convention so the wizard's
+// error-handling code can mirror existing patterns.
+
+export class WizardRateLimitError extends Error {
+  readonly isRateLimit = true;
+  constructor(message: string) {
+    super(message);
+    this.name = "WizardRateLimitError";
+  }
+}
+
+export class WizardFeatureDisabledError extends Error {
+  readonly isFeatureDisabled = true;
+  constructor(message: string) {
+    super(message);
+    this.name = "WizardFeatureDisabledError";
+  }
+}
+
+export class WizardBudgetExceededError extends Error {
+  readonly isBudgetExceeded = true;
+  constructor(message: string) {
+    super(message);
+    this.name = "WizardBudgetExceededError";
+  }
+}
+
+export class WizardValidationError extends Error {
+  readonly isValidation = true;
+  constructor(message: string) {
+    super(message);
+    this.name = "WizardValidationError";
+  }
+}
+
+async function authHeader(tokenGetter: TokenGetter): Promise<HeadersInit> {
+  const token = await tokenGetter();
+  return token
+    ? { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+    : { "Content-Type": "application/json" };
+}
+
+/**
+ * Read the API's `detail` field from a 422 (validation) response. Backend
+ * already writes user-appropriate copy (e.g., "requested_count *
+ * length_seconds must be <= 1800s"), so the UI surfaces it verbatim.
+ */
+async function detailMessage(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { detail?: unknown };
+    if (typeof body.detail === "string") return body.detail;
+    return JSON.stringify(body.detail ?? body);
+  } catch {
+    return res.statusText || `HTTP ${res.status}`;
+  }
+}
+
+// ----------------------------------------------------------------------
+// POST /api/shorts/auto/scan-orders/videos/{video_id}
+// ----------------------------------------------------------------------
+
+export async function createScanOrder(
+  videoId: string,
+  body: ScanOrderCreateRequest,
+  tokenGetter: TokenGetter,
+): Promise<ScanOrderResponse> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/shorts/auto/scan-orders/videos/${encodeURIComponent(videoId)}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: await authHeader(tokenGetter),
+      body: JSON.stringify(body),
+    },
+  );
+  if (res.status === 404) {
+    throw new WizardFeatureDisabledError(
+      "Wizard is not enabled for this org",
+    );
+  }
+  if (res.status === 402) {
+    throw new WizardBudgetExceededError(await detailMessage(res));
+  }
+  if (res.status === 422) {
+    throw new WizardValidationError(await detailMessage(res));
+  }
+  if (res.status === 429) {
+    throw new WizardRateLimitError(await detailMessage(res));
+  }
+  if (!res.ok) {
+    throw new Error(`createScanOrder failed: ${await detailMessage(res)}`);
+  }
+  return (await res.json()) as ScanOrderResponse;
+}
+
+// ----------------------------------------------------------------------
+// GET /api/shorts/auto/scan-orders/{parent_job_id}
+// ----------------------------------------------------------------------
+
+export async function getScanOrderStatus(
+  parentJobId: string,
+  tokenGetter: TokenGetter,
+): Promise<ScanOrderStatusResponse> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/shorts/auto/scan-orders/${encodeURIComponent(parentJobId)}`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: await authHeader(tokenGetter),
+    },
+  );
+  if (res.status === 404) {
+    throw new WizardFeatureDisabledError(
+      "Scan order not found or wizard disabled",
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`getScanOrderStatus failed: ${await detailMessage(res)}`);
+  }
+  return (await res.json()) as ScanOrderStatusResponse;
+}
+
+// ----------------------------------------------------------------------
+// POST /api/shorts/auto/scan-orders/{parent_job_id}/cancel
+// ----------------------------------------------------------------------
+
+export async function cancelScanOrder(
+  parentJobId: string,
+  tokenGetter: TokenGetter,
+): Promise<void> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/shorts/auto/scan-orders/${encodeURIComponent(parentJobId)}/cancel`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: await authHeader(tokenGetter),
+    },
+  );
+  if (res.status === 404) {
+    // Already terminal or missing — treat as success (no info leak).
+    return;
+  }
+  if (!res.ok) {
+    throw new Error(`cancelScanOrder failed: ${await detailMessage(res)}`);
+  }
+}

--- a/services/web/src/lib/types/shorts-auto-product-wizard.ts
+++ b/services/web/src/lib/types/shorts-auto-product-wizard.ts
@@ -1,0 +1,120 @@
+// ============================================================================
+// Shorts auto product mode — wizard request/response types.
+//
+// Mirrors services/api/app/modules/shorts_auto_product/schemas.py exactly.
+// Single source of truth for the wizard feature dir; no other types are
+// duplicated locally inside features/shorts-auto-product-wizard/.
+//
+// NEVER import from features/*. This module is consumed by:
+//   - lib/api/shorts-auto-product-wizard.ts (client)
+//   - features/shorts-auto-product-wizard/ (consumers)
+// ============================================================================
+
+export type ProductDistribution = "single" | "multi";
+export type Language = "ko" | "en";
+export type ScanIntent = "preview" | "commit";
+
+export type JobKind =
+  | "enumeration"
+  | "tracking"
+  | "scan_order"
+  | "render_child";
+
+export type ScanStage =
+  | "queued"
+  | "enumerating"
+  | "enumeration_done"
+  | "tracking"
+  | "assembling"
+  | "rendering"
+  | "preview_ready"
+  | "fanned_out"
+  | "committed"
+  | "done"
+  | "failed"
+  | "cancelled";
+
+export type ScanErrorCode =
+  | "internal_error"
+  | "tracker_low_confidence_global"
+  | "no_products_detected"
+  | "render_enqueue_failed"
+  | "video_no_longer_available";
+
+// ----------------------------------------------------------------------
+// POST /api/shorts/auto/scan-orders/videos/{video_id}
+// ----------------------------------------------------------------------
+
+export interface ScanOrderCreateRequest {
+  length_seconds: number; // 10..120
+  requested_count: number; // 1..50
+  time_range_start_ms: number | null;
+  time_range_end_ms: number | null;
+  product_distribution: ProductDistribution;
+  language: Language;
+  intent: ScanIntent;
+}
+
+export interface ScanOrderResponse {
+  parent_job_id: string;
+  deduped: boolean;
+}
+
+// ----------------------------------------------------------------------
+// GET /api/shorts/auto/scan-orders/{parent_job_id}
+// ----------------------------------------------------------------------
+
+export interface JobStatusResponse {
+  job_id: string;
+  kind: JobKind;
+  stage: ScanStage;
+  progress_pct: number;
+  progress_label: string | null;
+  completed_at: string | null;
+  failed_at: string | null;
+  cancelled_at: string | null;
+  error_code: ScanErrorCode | null;
+  error_message: string | null;
+  render_job_id: string | null;
+  parent_job_id: string | null;
+  shorts_index: number | null;
+  cost_usd_estimate: string;
+}
+
+export interface ScanOrderStatusResponse {
+  parent: JobStatusResponse;
+  children: JobStatusResponse[];
+  children_complete: number;
+  children_failed: number;
+  children_total: number;
+}
+
+// ----------------------------------------------------------------------
+// Stage classification helpers (pure functions — no side effects).
+// ----------------------------------------------------------------------
+
+const ACTIVE_STAGES: ReadonlySet<ScanStage> = new Set<ScanStage>([
+  "queued",
+  "enumerating",
+  "enumeration_done",
+  "tracking",
+  "assembling",
+  "rendering",
+  "preview_ready",
+  "fanned_out",
+]);
+
+const TERMINAL_STAGES: ReadonlySet<ScanStage> = new Set<ScanStage>([
+  "committed",
+  "done",
+  "failed",
+  "cancelled",
+]);
+
+export function isActiveStage(stage: ScanStage): boolean {
+  return ACTIVE_STAGES.has(stage);
+}
+
+export function isTerminalStage(stage: ScanStage): boolean {
+  return TERMINAL_STAGES.has(stage);
+}


### PR DESCRIPTION
## Summary

Skeleton implementation of the 4-step product-shorts wizard from the mockup. Closed-boundary feature dir at `services/web/src/features/shorts-auto-product-wizard/`; routes wired under `app/export/shorts/auto/wizard/...`.

The criteria step (the headline screen from the mockup) is fully built; steps 1 (video select) and 3 (preview) are deliberate MVP stubs that follow-up PRs flesh out.

## Files

- 4 new Next routes (page.tsx wrappers — minimal Suspense + dynamic-import)
- 1 closed-boundary feature dir with 5 components + 4 step pages + 1 hook + 2 test files
- 1 new API client at `lib/api/shorts-auto-product-wizard.ts` (mirrors `shorts-auto.ts` conventions)
- 1 new types module at `lib/types/shorts-auto-product-wizard.ts` (mirrors `schemas.py`)

## Decoupling

- Closed-boundary rule: feature dir doesn't cross-import from any other `features/*` directory
- API client + types are the single one-way surface the feature consumes
- 3s polling cadence (codex-locked in plan §4.4); single endpoint covers parent + N children — no N+1
- Custom error subclasses (`WizardRateLimitError` / `WizardFeatureDisabledError` / `WizardBudgetExceededError` / `WizardValidationError`) so the UI branches on `err.isXxx` without parsing strings

## Deferred to follow-ups

- Time-range drag-handle slider (wraps `lib/timeline/TimelineRuler`)
- Full video-library search UI for step 1
- Phase 6 step 3 preview semantics (server-side endpoint also returns 501 today)
- Entry-point link from `/export/shorts/auto` main page

## Test plan

- [x] `npx tsc --noEmit` clean across services/web
- [x] `npx vitest run` 791 tests pass (10 new in this PR's 2 files)
- [ ] Visual smoke after staging deploy — verify routes render + the form submits to the live wizard endpoints
- [ ] End-to-end: wizard submission produces a parent_job_id, the worker fans out, children land with `render_job_id`

## Routes

- `/export/shorts/auto/wizard` — step 1 (video select)
- `/export/shorts/auto/wizard/{videoId}/criteria` — step 2
- `/export/shorts/auto/wizard/{videoId}/preview` — step 3 stub
- `/export/shorts/auto/wizard/{videoId}/result/{parentJobId}` — step 4 (polling)
