### PR TITLE
feat(web): wire video detail → wizard → title + subtitle edits

### DIFF
--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepResult.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepResult.test.tsx
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { WizardStepResult } from "../pages/WizardStepResult";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ getAccessToken: vi.fn(async () => "test-token") }),
+}));
+
+// Mock useScanOrder so we feed deterministic status into the page
+// without spinning up the real polling loop.
+const useScanOrderMock = vi.fn();
+vi.mock("../hooks/useScanOrder", () => ({
+  useScanOrder: (...args: unknown[]) => useScanOrderMock(...args),
+}));
+
+// Mock the shorts-render API so we can assert the right calls without
+// hitting the network. Title edit + composition fetch are the two
+// surfaces this PR adds.
+const updateRenderJobTitleMock = vi.fn();
+const getShortCompositionMock = vi.fn();
+vi.mock("@/lib/api/shorts-render", () => ({
+  updateRenderJobTitle: (...args: unknown[]) =>
+    updateRenderJobTitleMock(...args),
+  getShortComposition: (...args: unknown[]) =>
+    getShortCompositionMock(...args),
+}));
+
+const RENDER_ID = "00000000-0000-0000-0000-000000000aaa";
+
+function makeStatus(overrides?: { title?: string | null }) {
+  return {
+    parent: {
+      job_id: "parent-1",
+      kind: "scan_order",
+      stage: "fanned_out",
+      progress_pct: 100,
+      progress_label: null,
+      completed_at: null,
+      failed_at: null,
+      cancelled_at: null,
+      error_code: null,
+      error_message: null,
+      render_job_id: null,
+      parent_job_id: null,
+      shorts_index: null,
+      cost_usd_estimate: "0.00",
+    },
+    children: [
+      {
+        job_id: "child-1",
+        kind: "render_child",
+        stage: "done",
+        progress_pct: 100,
+        progress_label: null,
+        completed_at: "2026-05-03T12:00:00Z",
+        failed_at: null,
+        cancelled_at: null,
+        error_code: null,
+        error_message: null,
+        render_job_id: RENDER_ID,
+        parent_job_id: "parent-1",
+        shorts_index: 1,
+        cost_usd_estimate: "0.00",
+      },
+    ],
+    children_complete: 1,
+    children_failed: 0,
+    children_total: 1,
+    _titleHint: overrides?.title, // not consumed by component, just for clarity
+  };
+}
+
+describe("WizardStepResult — render actions", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    updateRenderJobTitleMock.mockReset();
+    getShortCompositionMock.mockReset();
+    useScanOrderMock.mockReset();
+    useScanOrderMock.mockReturnValue({
+      status: makeStatus(),
+      error: null,
+      isPolling: false,
+      cancel: vi.fn(),
+    });
+  });
+
+  it("renders the title-edit + editor + render-result affordances on completed children", () => {
+    render(<WizardStepResult videoId="gd_test" parentJobId="parent-1" />);
+    expect(
+      screen.getByTestId(`child-title-edit-${RENDER_ID}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`child-view-render-${RENDER_ID}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`child-open-editor-${RENDER_ID}`),
+    ).toBeInTheDocument();
+  });
+
+  it("inline title edit calls updateRenderJobTitle with the trimmed value", async () => {
+    updateRenderJobTitleMock.mockResolvedValueOnce({});
+    render(<WizardStepResult videoId="gd_test" parentJobId="parent-1" />);
+    fireEvent.click(screen.getByTestId(`child-title-edit-${RENDER_ID}`));
+    const input = screen.getByTestId(
+      `child-title-input-${RENDER_ID}`,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  My Cool Short  " } });
+    fireEvent.click(screen.getByTestId(`child-title-save-${RENDER_ID}`));
+
+    await waitFor(() =>
+      expect(updateRenderJobTitleMock).toHaveBeenCalledWith(
+        RENDER_ID,
+        "My Cool Short",
+        expect.any(Function),
+      ),
+    );
+    // After save, the display reflects the new title.
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(`child-title-display-${RENDER_ID}`).textContent,
+      ).toContain("My Cool Short"),
+    );
+  });
+
+  it("empty title submits null to clear (matches backend semantics)", async () => {
+    updateRenderJobTitleMock.mockResolvedValueOnce({});
+    render(<WizardStepResult videoId="gd_test" parentJobId="parent-1" />);
+    fireEvent.click(screen.getByTestId(`child-title-edit-${RENDER_ID}`));
+    fireEvent.change(screen.getByTestId(`child-title-input-${RENDER_ID}`), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByTestId(`child-title-save-${RENDER_ID}`));
+    await waitFor(() =>
+      expect(updateRenderJobTitleMock).toHaveBeenCalledWith(
+        RENDER_ID,
+        null,
+        expect.any(Function),
+      ),
+    );
+  });
+
+  it("rolls back the displayed title on save failure", async () => {
+    updateRenderJobTitleMock.mockRejectedValueOnce(
+      new Error("server says no"),
+    );
+    render(<WizardStepResult videoId="gd_test" parentJobId="parent-1" />);
+    fireEvent.click(screen.getByTestId(`child-title-edit-${RENDER_ID}`));
+    fireEvent.change(screen.getByTestId(`child-title-input-${RENDER_ID}`), {
+      target: { value: "Fragile Title" },
+    });
+    fireEvent.click(screen.getByTestId(`child-title-save-${RENDER_ID}`));
+    await waitFor(() => expect(updateRenderJobTitleMock).toHaveBeenCalled());
+    // Display rolled back to "(제목 없음)" placeholder; the input is closed.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId(`child-title-input-${RENDER_ID}`),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId(`child-title-display-${RENDER_ID}`).textContent,
+    ).toContain("(제목 없음)");
+  });
+
+  it("스크립트 편집 fetches composition + routes to /export/shorts/editor with sceneIds", async () => {
+    getShortCompositionMock.mockResolvedValueOnce({
+      composition: {
+        scene_clips: [
+          { scene_id: "gd_test_scene_001" },
+          { scene_id: "gd_test_scene_007" },
+        ],
+      },
+      source: "render_job",
+    });
+    render(<WizardStepResult videoId="gd_test" parentJobId="parent-1" />);
+    fireEvent.click(screen.getByTestId(`child-open-editor-${RENDER_ID}`));
+    await waitFor(() =>
+      expect(getShortCompositionMock).toHaveBeenCalledWith(
+        RENDER_ID,
+        expect.any(Function),
+      ),
+    );
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith(
+        "/export/shorts/editor?videoId=gd_test&sceneIds=gd_test_scene_001%2Cgd_test_scene_007",
+      ),
+    );
+  });
+
+  it("surfaces a friendly error if the composition has no scene_clips", async () => {
+    getShortCompositionMock.mockResolvedValueOnce({
+      composition: { scene_clips: [] },
+      source: "render_job",
+    });
+    render(<WizardStepResult videoId="gd_test" parentJobId="parent-1" />);
+    fireEvent.click(screen.getByTestId(`child-open-editor-${RENDER_ID}`));
+    await waitFor(() => expect(getShortCompositionMock).toHaveBeenCalled());
+    expect(
+      await screen.findByText(/편집할 장면이 없습니다/),
+    ).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepResult.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepResult.tsx
@@ -15,7 +15,13 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
+import {
+  getShortComposition,
+  updateRenderJobTitle,
+} from "@/lib/api/shorts-render";
 import { useAuth } from "@/lib/auth";
 import type { JobStatusResponse } from "@/lib/types/shorts-auto-product-wizard";
 
@@ -62,7 +68,7 @@ export function WizardStepResult({ videoId, parentJobId }: Props) {
               isPolling={isPolling}
               onCancel={cancel}
             />
-            <ChildList children={status.children} />
+            <ChildList children={status.children} videoId={videoId} />
           </>
         )}
       </div>
@@ -139,9 +145,10 @@ function ParentProgress({
 
 interface ChildListProps {
   children: JobStatusResponse[];
+  videoId: string;
 }
 
-function ChildList({ children }: ChildListProps) {
+function ChildList({ children, videoId }: ChildListProps) {
   if (children.length === 0) {
     return (
       <div className="rounded-md border border-gray-200 bg-white p-4 text-sm text-gray-500">
@@ -156,15 +163,22 @@ function ChildList({ children }: ChildListProps) {
   return (
     <div className="grid gap-3 sm:grid-cols-2">
       {sorted.map((child) => (
-        <ChildCard key={child.job_id} child={child} />
+        <ChildCard key={child.job_id} child={child} videoId={videoId} />
       ))}
     </div>
   );
 }
 
-function ChildCard({ child }: { child: JobStatusResponse }) {
+function ChildCard({
+  child,
+  videoId,
+}: {
+  child: JobStatusResponse;
+  videoId: string;
+}) {
   const isDone = child.stage === "done" || child.stage === "committed";
   const isFailed = child.stage === "failed";
+  const hasRender = child.render_job_id !== null && isDone;
   return (
     <div
       className={`rounded-md border p-4 ${
@@ -183,17 +197,219 @@ function ChildCard({ child }: { child: JobStatusResponse }) {
         <span className="text-xs text-gray-500">{child.stage}</span>
       </div>
       <p className="text-xs text-gray-600">진행률 {child.progress_pct}%</p>
-      {child.render_job_id ? (
-        <Link
-          href={`/export/shorts/render/${child.render_job_id}`}
-          className="mt-2 inline-block text-xs text-indigo-600 hover:underline"
-        >
-          렌더 결과 보기 &rarr;
-        </Link>
+      {hasRender && child.render_job_id ? (
+        <ChildRenderActions
+          renderJobId={child.render_job_id}
+          videoId={videoId}
+        />
       ) : null}
       {isFailed && child.error_message ? (
         <p className="mt-1 text-xs text-red-700">{child.error_message}</p>
       ) : null}
     </div>
   );
+}
+
+/**
+ * Per-card actions surfaced once the child reaches a terminal-with-render
+ * state. Three affordances:
+ *
+ *   1. **Title edit** (inline): pencil → input → save; uses
+ *      ``updateRenderJobTitle``. Optimistic-update with rollback on error
+ *      so the user sees their edit immediately. Empty trimmed input
+ *      submits ``null`` to clear the title (matches backend semantics).
+ *   2. **렌더 결과 보기**: link to the existing render-result route
+ *      that lives in the shorts-render feature. We do NOT cross-import
+ *      from features/shorts-render — just route via Next href.
+ *   3. **스크립트 편집**: fetch the render job's composition spec on
+ *      click → derive scene_ids → route to the existing /export/shorts/editor
+ *      with ?videoId=...&sceneIds=... — same query-param contract the
+ *      v1 auto-shorts dashboard already uses.
+ *
+ * Loose-coupling: this component imports from ``@/lib/api/shorts-render``
+ * (allowed — it's the public surface) but NOT from ``@/features/shorts-render``
+ * or ``@/features/shorts-editor``. Routes carry the contract.
+ */
+function ChildRenderActions({
+  renderJobId,
+  videoId,
+}: {
+  renderJobId: string;
+  videoId: string;
+}) {
+  const router = useRouter();
+  const { getAccessToken } = useAuth();
+
+  // Title edit local state. ``displayedTitle`` is what the card shows;
+  // it stays in sync with the server after a successful save and rolls
+  // back on error. ``draftTitle`` is the input's edited value while the
+  // user is typing.
+  const [displayedTitle, setDisplayedTitle] = useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [titleError, setTitleError] = useState<string | null>(null);
+
+  // 편집 (open editor) state — single in-flight fetch lock + error.
+  const [isOpeningEditor, setIsOpeningEditor] = useState(false);
+  const [editorError, setEditorError] = useState<string | null>(null);
+
+  const handleEditClick = () => {
+    setDraftTitle(displayedTitle ?? "");
+    setIsEditing(true);
+    setTitleError(null);
+  };
+
+  const handleSave = async () => {
+    const trimmed = draftTitle.trim();
+    const next = trimmed.length === 0 ? null : trimmed;
+    const previous = displayedTitle;
+    // Optimistic update — close the editor + reflect the new title
+    // before the server confirms. Rollback on failure.
+    setDisplayedTitle(next);
+    setIsEditing(false);
+    setIsSaving(true);
+    setTitleError(null);
+    try {
+      await updateRenderJobTitle(renderJobId, next, getAccessToken);
+    } catch (err) {
+      setDisplayedTitle(previous);
+      setTitleError(err instanceof Error ? err.message : "저장 실패");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleOpenEditor = async () => {
+    setEditorError(null);
+    setIsOpeningEditor(true);
+    try {
+      const response = await getShortComposition(renderJobId, getAccessToken);
+      const sceneIds = extractSceneIds(response.composition);
+      if (sceneIds.length === 0) {
+        setEditorError("이 쇼츠에는 편집할 장면이 없습니다.");
+        return;
+      }
+      const params = new URLSearchParams({
+        videoId,
+        sceneIds: sceneIds.join(","),
+      });
+      router.push(`/export/shorts/editor?${params.toString()}`);
+    } catch (err) {
+      setEditorError(
+        err instanceof Error ? err.message : "에디터 열기 실패",
+      );
+    } finally {
+      setIsOpeningEditor(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-gray-500">제목:</span>
+        {isEditing ? (
+          <>
+            <input
+              type="text"
+              value={draftTitle}
+              onChange={(e) => setDraftTitle(e.target.value)}
+              placeholder="(제목 없음)"
+              className="flex-1 rounded-md border border-gray-300 px-2 py-1 text-xs"
+              data-testid={`child-title-input-${renderJobId}`}
+              autoFocus
+            />
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={isSaving}
+              className="rounded-md bg-indigo-500 px-2 py-1 text-xs text-white hover:bg-indigo-600 disabled:bg-gray-300"
+              data-testid={`child-title-save-${renderJobId}`}
+            >
+              저장
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsEditing(false);
+                setTitleError(null);
+              }}
+              disabled={isSaving}
+              className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+              data-testid={`child-title-cancel-${renderJobId}`}
+            >
+              취소
+            </button>
+          </>
+        ) : (
+          <>
+            <span
+              className="flex-1 truncate text-gray-800"
+              data-testid={`child-title-display-${renderJobId}`}
+            >
+              {displayedTitle ?? <span className="text-gray-400">(제목 없음)</span>}
+            </span>
+            <button
+              type="button"
+              onClick={handleEditClick}
+              className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+              data-testid={`child-title-edit-${renderJobId}`}
+            >
+              제목 편집
+            </button>
+          </>
+        )}
+      </div>
+      {titleError ? (
+        <p className="text-xs text-red-700">{titleError}</p>
+      ) : null}
+      <div className="flex gap-2 text-xs">
+        <Link
+          href={`/export/shorts/render/${renderJobId}`}
+          className="text-indigo-600 hover:underline"
+          data-testid={`child-view-render-${renderJobId}`}
+        >
+          렌더 결과 보기
+        </Link>
+        <button
+          type="button"
+          onClick={() => void handleOpenEditor()}
+          disabled={isOpeningEditor}
+          className="text-indigo-600 hover:underline disabled:text-gray-400"
+          data-testid={`child-open-editor-${renderJobId}`}
+        >
+          {isOpeningEditor ? "여는 중..." : "스크립트 편집"}
+        </button>
+      </div>
+      {editorError ? (
+        <p className="text-xs text-red-700">{editorError}</p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Pull scene_ids out of the loosely-typed CompositionResponse.composition
+ * field. Defensive: backend's ``CompositionResponse.composition`` is
+ * ``Record<string, unknown>`` because the same shape is used by both
+ * the rendered job's persisted spec AND a generated draft, so the FE
+ * type doesn't pin scene_clips. Cast carefully here and fall back to
+ * an empty list if the shape isn't what we expect — caller surfaces
+ * a friendly error.
+ */
+function extractSceneIds(composition: Record<string, unknown>): string[] {
+  const clips = composition.scene_clips;
+  if (!Array.isArray(clips)) return [];
+  const ids: string[] = [];
+  for (const clip of clips) {
+    if (
+      clip &&
+      typeof clip === "object" &&
+      "scene_id" in clip &&
+      typeof (clip as { scene_id: unknown }).scene_id === "string"
+    ) {
+      ids.push((clip as { scene_id: string }).scene_id);
+    }
+  }
+  return ids;
 }

--- a/services/web/src/features/shorts-auto/components/AutoShortsCTA.tsx
+++ b/services/web/src/features/shorts-auto/components/AutoShortsCTA.tsx
@@ -31,16 +31,21 @@ function CTAInner({
   if (availability === "disabled") return null;
   if (isLoading && !renderWhileProbing) return null;
 
+  // Routes to the 4-step wizard at step 2 (criteria) — videoId is
+  // already known from the video detail page so step 1's videoId
+  // input is bypassed entirely. The legacy v1 mode-tabs dashboard
+  // (/export/shorts/auto?videoId=…) stays accessible by direct URL
+  // for diagnostics, but isn't featured anywhere from this CTA.
   return (
     <Link
-      href={`/export/shorts/auto?videoId=${encodeURIComponent(videoId)}`}
+      href={`/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/criteria`}
       className={cn(
         "inline-flex items-center gap-2 rounded-lg border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700 transition-colors hover:bg-indigo-100",
         className,
       )}
     >
       <MagicWandIcon className="h-4 w-4" />
-      자동으로 쇼츠 만들기
+      AI 쇼츠 생성
     </Link>
   );
 }


### PR DESCRIPTION
## Summary

Wires the **intended user path** the wizard was missing: video detail → wizard → generation with title + subtitle edits. Three small changes, no new routes.

PR #128 shipped the wizard functional but orphaned — users couldn't reach it from the video detail page, and the result step had no editing affordances. This PR closes that gap.

## Changes

### A. AutoShortsCTA retargets to the wizard

`features/shorts-auto/components/AutoShortsCTA.tsx` — link target swapped from `/export/shorts/auto?videoId=…` (v1 mode-tabs) to `/export/shorts/auto/wizard/{videoId}/criteria` (wizard step 2). Step 1 video-input is bypassed entirely since videoId is already known. Label updated to "AI 쇼츠 생성".

The v1 mode-tabs page stays at `/export/shorts/auto` for direct-URL access but isn't featured anywhere in the navigation surface.

### B. Inline title edit on each child card (step 4)

Per-card pencil → input → save flow using the existing `updateRenderJobTitle` API. Optimistic update with rollback on error so the user sees their edit immediately. Empty trimmed input submits `null` to clear the title (matches backend semantics).

### C. "스크립트 편집" link on completed cards

Per-card link that fetches the render job's composition spec via `getShortComposition`, derives `scene_ids` from the persisted `scene_clips`, routes to the existing `/export/shorts/editor` with `?videoId=…&sceneIds=…`. **Same query-param contract the v1 auto-shorts dashboard already uses** — no new editor code.

## Decoupling

- **No cross-imports** from `features/shorts-render` or `features/shorts-editor`. The wizard's result step talks to those features ONLY via:
  1. Public API surfaces in `lib/api/shorts-render.ts` (the typed contract)
  2. Next href routing with shared query-param contract (`?videoId=…&sceneIds=…`)
- **Title-edit logic lives in a dedicated `ChildRenderActions` subcomponent** — keeps the `ChildCard` thin; future card-level affordances slot in there without bloating the parent.
- **Defensive scene_ids extraction** — `CompositionResponse.composition` is typed `Record<string, unknown>` on the backend (same shape used by both persisted and generated specs), so the FE casts carefully + falls back to a friendly "no scenes to edit" error if the shape isn't what we expect.

## Tests

- `WizardStepResult.test.tsx` — 6 new tests:
  - Affordances render on completed children
  - Inline title edit calls API with trimmed value
  - Empty title submits `null` to clear
  - Save failure rolls back the displayed title
  - 스크립트 편집 fetches composition + routes with `sceneIds=` joined
  - Missing scene_clips surfaces a friendly error instead of empty redirect

16/16 wizard suite green. tsc --noEmit clean.

## Test plan

- [x] Wizard suite vitest 16/16
- [x] Full repo tsc --noEmit clean
- [ ] Visual smoke after staging deploy: video detail page → CTA goes to wizard, criteria submits, child cards show edit affordances on completion
- [ ] Manual title edit + 편집 link integration on staging

## Routes

No new routes. Reuses:
- `/export/shorts/auto/wizard/{videoId}/criteria` (existing)
- `/export/shorts/auto/wizard/{videoId}/result/{parentJobId}` (existing)
- `/export/shorts/editor?videoId=…&sceneIds=…` (existing)
