### PR TITLE
fix(api): wizard create_scan_order accepts OS video_id string (gd_xxx)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
             tests/test_shorts_auto_product_child_runner.py \
             tests/test_shorts_render_dedupe_window.py \
             tests/test_shorts_auto_product_phase4_foundation.py \
+            tests/test_create_scan_order_video_id_resolution.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/modules/shorts_auto_product/router.py
+++ b/services/api/app/modules/shorts_auto_product/router.py
@@ -16,7 +16,7 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import Settings, get_settings
@@ -297,7 +297,7 @@ async def get_product_v2_availability(
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def create_scan_order(
-    video_id: UUID,
+    video_id: str,
     body: ScanOrderCreateRequest,
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
     user: Annotated[User, Depends(get_current_user)],
@@ -305,6 +305,14 @@ async def create_scan_order(
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> ScanOrderResponse:
     """Submit the 4-step wizard.
+
+    Path param accepts the OpenSearch-style ``video_id`` string
+    (``gd_{sha256(org_id:google_file_id)[:16]}`` per
+    ``DriveFile.video_id``). The frontend's ``/videos/{videoId}``
+    URL pattern uses this shape, and the wizard CTA threads it
+    through unchanged. The handler resolves the DriveFile to its
+    UUID before passing to the service layer (which persists
+    ``ProductScanJob.video_id`` as a UUID FK).
 
     Body captures every wizard input. Idempotent within
     ``auto_shorts_product_v2_scan_order_idempotency_seconds``
@@ -317,16 +325,30 @@ async def create_scan_order(
     * If time-range provided: end > start AND
       ``(end - start) / count >= length_seconds * 1000``
 
-    Mounted under ``/videos/{video_id}`` so the path naturally scopes
-    to the video the user picked in step 1 of the wizard. The
-    counterpart ``GET /scan-orders/{parent_job_id}`` does NOT carry
-    ``video_id`` in the path — once a parent exists, the wizard
-    polls by parent id directly.
+    Returns 404 when the video_id doesn't resolve to an active
+    DriveFile (missing or soft-deleted) — same shape as the
+    stale-video guard in ``internal_router.complete``.
     """
+    # Loose-coupling note (plan §15): drive-repo lookup carve-out,
+    # mirrors the existing stale-video guard at internal_router.py
+    # and the render-service call. Lazy import keeps the router
+    # module-level free of cross-module ``app.modules.drive`` coupling.
+    from app.modules.drive.repository import DriveFileRepository
+
+    drive_repo = DriveFileRepository(db)
+    drive_file = await drive_repo.get_by_video_id(
+        org_id=org_ctx.org_id, video_id=video_id,
+    )
+    if drive_file is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"video_id {video_id!r} not found",
+        )
+
     service = _build_service(db, settings)
     return await service.enqueue_scan_order(
         org_id=org_ctx.org_id,
-        video_id=video_id,
+        video_id=drive_file.id,
         user_id=user.id,
         body=body,
     )

--- a/services/api/tests/test_create_scan_order_video_id_resolution.py
+++ b/services/api/tests/test_create_scan_order_video_id_resolution.py
@@ -1,0 +1,135 @@
+"""Tests for the wizard's create_scan_order video_id resolution.
+
+Pre-fix the router accepted ``video_id: UUID`` at the path. The
+frontend's ``/videos/{videoId}`` URL pattern uses the OS-style
+``gd_xxx`` string, so every wizard submission from the video detail
+page returned 422 ``uuid_parsing`` from FastAPI's path validator
+before the handler ever ran.
+
+This file pins the post-fix behavior:
+  * OS string at the path resolves to the DriveFile, the service
+    layer receives the UUID.
+  * Missing / soft-deleted video → 404 (not 422), so the wizard
+    can render a friendly message.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app(monkeypatch, *, drive_file=None):
+    """Build a minimal FastAPI app with the public router mounted +
+    DriveFileRepository + ProductScanService mocked."""
+    from app.dependencies import get_db_session
+    from app.modules.shorts_auto_product.router import router
+
+    fake_drive_repo = MagicMock()
+    fake_drive_repo.get_by_video_id = AsyncMock(return_value=drive_file)
+
+    import app.modules.drive.repository as drive_repo_module
+    monkeypatch.setattr(
+        drive_repo_module,
+        "DriveFileRepository",
+        MagicMock(side_effect=lambda _db: fake_drive_repo),
+    )
+
+    fake_service = MagicMock()
+    fake_service.enqueue_scan_order = AsyncMock(
+        return_value=MagicMock(
+            parent_job_id=uuid4(),
+            deduped=False,
+            model_dump=lambda: {
+                "parent_job_id": str(uuid4()),
+                "deduped": False,
+            },
+        ),
+    )
+    import app.modules.shorts_auto_product.router as router_module
+    monkeypatch.setattr(
+        router_module, "_build_service", lambda _db, _settings: fake_service,
+    )
+
+    # Stub out auth + tenancy + settings so the router's deps resolve
+    # without standing up real Auth0 + middleware.
+    from app.modules.tenancy.middleware import get_current_org
+    from app.modules.tenancy.context import OrgContext
+    from app.modules.auth.service import get_current_user
+    from app.config import get_settings as _get_settings
+
+    org_id = uuid4()
+    user_id = uuid4()
+    fake_settings = MagicMock()
+    fake_db = MagicMock()
+    fake_db.commit = AsyncMock()
+
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/api")
+    test_app.dependency_overrides[get_db_session] = lambda: fake_db
+    test_app.dependency_overrides[get_current_org] = lambda: OrgContext(
+        org_id=org_id, org_slug="testorg",
+    )
+    test_app.dependency_overrides[get_current_user] = lambda: MagicMock(
+        id=user_id,
+    )
+    test_app.dependency_overrides[_get_settings] = lambda: fake_settings
+
+    return test_app, fake_drive_repo, fake_service, org_id
+
+
+def _valid_body() -> dict:
+    return {
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+    }
+
+
+def test_create_scan_order_resolves_os_video_id_to_drive_file_uuid(
+    monkeypatch,
+):
+    """**The 2026-05-03 staging-bug regression test.** OS-style
+    video_id at the path must NOT 422 — the handler should look up
+    the DriveFile and pass its UUID to the service."""
+    drive_file_uuid = uuid4()
+    drive_file = MagicMock(id=drive_file_uuid)
+    app, fake_drive_repo, fake_service, org_id = _build_app(
+        monkeypatch, drive_file=drive_file,
+    )
+    client = TestClient(app)
+    resp = client.post(
+        "/api/shorts/auto/scan-orders/videos/gd_d2e6142de1e19704",
+        json=_valid_body(),
+    )
+    assert resp.status_code == 202, resp.text
+    fake_drive_repo.get_by_video_id.assert_awaited_once_with(
+        org_id=org_id, video_id="gd_d2e6142de1e19704",
+    )
+    # Service got the resolved UUID, not the OS string.
+    fake_service.enqueue_scan_order.assert_awaited_once()
+    call_kwargs = fake_service.enqueue_scan_order.await_args.kwargs
+    assert call_kwargs["video_id"] == drive_file_uuid
+
+
+def test_create_scan_order_returns_404_on_missing_video(monkeypatch):
+    """Missing / soft-deleted DriveFile → 404 (not 422). Wizard
+    surfaces this as a friendly message."""
+    app, _, fake_service, _ = _build_app(monkeypatch, drive_file=None)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/shorts/auto/scan-orders/videos/gd_does_not_exist",
+        json=_valid_body(),
+    )
+    assert resp.status_code == 404, resp.text
+    assert "not found" in resp.text
+    # Service was never reached.
+    fake_service.enqueue_scan_order.assert_not_awaited()


### PR DESCRIPTION
**Staging hotfix.** User clicked the wizard CTA on a video detail page and got a 422 `uuid_parsing` from FastAPI's path validator before the handler ever ran.

## Root cause

`POST /api/shorts/auto/scan-orders/videos/{video_id}` typed `video_id: UUID`, but the frontend's `/videos/{videoId}` URL pattern (and the convention across the rest of the app — search, v1 auto-shorts, etc.) uses the OS-style string `gd_{sha256(org_id:google_file_id)[:16]}`.

## Fix

Path param becomes `str`. Handler looks up DriveFile via existing `DriveFileRepository.get_by_video_id(org_id, video_id)` and passes the UUID to the service (which keeps its UUID-typed signature — the DB stores UUID).

Missing/soft-deleted video → 404 (not 422). Same shape as the stale-video guard in `internal_router.complete`.

## Test plan

- [x] 2 new TestClient regression tests (resolution + 404)
- [x] 17/17 backend tests pass (includes existing phase 4 foundation suite)
- [ ] Staging smoke after merge: click CTA on a real video detail page, complete the wizard end-to-end

## Out of scope

The other v2 router endpoints (catalog, scan, clip, rescan, reject) have the same latent UUID typing. Out of scope until/unless they're reached from the frontend.