### PR TITLE
fix(api): all v2 product router endpoints accept OS video_id string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
             tests/test_shorts_render_dedupe_window.py \
             tests/test_shorts_auto_product_phase4_foundation.py \
             tests/test_create_scan_order_video_id_resolution.py \
+            tests/test_v2_router_video_id_resolution.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/modules/shorts_auto_product/router.py
+++ b/services/api/app/modules/shorts_auto_product/router.py
@@ -60,6 +60,43 @@ def _build_service(
     return ProductScanService(session=db, settings=settings)
 
 
+async def _resolve_video_uuid(
+    *, db: AsyncSession, org_id: UUID, video_id: str,
+) -> UUID:
+    """Resolve the OS-style ``video_id`` (``gd_xxx``) to its DriveFile UUID.
+
+    Every wizard / product-v2 router endpoint takes ``video_id`` from
+    the path as a STRING (matching the frontend's ``/videos/{videoId}``
+    URL convention), but the service layer + DB columns are typed
+    ``UUID`` because that's the DriveFile primary key. This helper
+    bridges the two by querying ``DriveFileRepository.get_by_video_id``
+    (which already filters soft-deleted rows).
+
+    Returns:
+        The resolved ``DriveFile.id`` UUID.
+
+    Raises:
+        HTTPException 404: ``video_id`` does not resolve to an active
+            DriveFile in this org. Same shape as the stale-video guard
+            in ``internal_router.complete``.
+
+    Loose-coupling note (plan §15): drive-repo lookup is lazy-imported
+    here, mirroring the carve-out in ``internal_router.complete``. The
+    router stays free of module-level ``app.modules.drive`` coupling.
+    """
+    from app.modules.drive.repository import DriveFileRepository
+
+    drive_file = await DriveFileRepository(db).get_by_video_id(
+        org_id=org_id, video_id=video_id,
+    )
+    if drive_file is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"video_id {video_id!r} not found",
+        )
+    return drive_file.id
+
+
 # ----------------------------------------------------------------------
 # GET /api/shorts/auto/products/{video_id}
 # ----------------------------------------------------------------------
@@ -69,7 +106,7 @@ def _build_service(
     response_model=ProductCatalogResponse,
 )
 async def get_product_catalog(
-    video_id: UUID,
+    video_id: str,
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
     _user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
@@ -77,13 +114,20 @@ async def get_product_catalog(
 ) -> ProductCatalogResponse:
     """List enumerated products for a video.
 
+    Path param accepts the OS-style ``video_id`` string (``gd_xxx``);
+    the handler resolves it to the DriveFile UUID before passing to the
+    service layer. See :func:`_resolve_video_uuid` for the rationale.
+
     Empty ``products`` array + ``scan_status="never"`` means the user
     should see the "Scan for products" CTA. ``scan_status="in_progress"``
     means the toast subscription should be reattached to ``scan_job_id``.
     """
+    video_uuid = await _resolve_video_uuid(
+        db=db, org_id=org_ctx.org_id, video_id=video_id,
+    )
     service = _build_service(db, settings)
     return await service.list_products(
-        org_id=org_ctx.org_id, video_id=video_id,
+        org_id=org_ctx.org_id, video_id=video_uuid,
     )
 
 
@@ -97,7 +141,7 @@ async def get_product_catalog(
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def enqueue_scan(
-    video_id: UUID,
+    video_id: str,
     body: ScanRequest,
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
     user: Annotated[User, Depends(get_current_user)],
@@ -106,14 +150,20 @@ async def enqueue_scan(
 ) -> ScanResponse:
     """Enqueue an enumeration scan.
 
+    Path accepts the OS-style ``video_id`` (``gd_xxx``); see
+    :func:`_resolve_video_uuid`.
+
     Idempotent within ``auto_shorts_product_v2_scan_idempotency_seconds``
     (default 60s) per ``(video_id, user_id)``: re-clicking returns the
     existing job. 402 on cost cap. 429 on per-org concurrency cap.
     """
+    video_uuid = await _resolve_video_uuid(
+        db=db, org_id=org_ctx.org_id, video_id=video_id,
+    )
     service = _build_service(db, settings)
     return await service.enqueue_scan(
         org_id=org_ctx.org_id,
-        video_id=video_id,
+        video_id=video_uuid,
         user_id=user.id,
         duration_preset_sec=body.duration_preset_sec,
     )
@@ -129,7 +179,7 @@ async def enqueue_scan(
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def enqueue_clip(
-    video_id: UUID,
+    video_id: str,
     catalog_entry_id: UUID,
     body: ClipRequest,
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
@@ -139,13 +189,25 @@ async def enqueue_clip(
 ) -> ClipResponse:
     """Enqueue tracking + assembly + render for a chosen catalog entry.
 
+    Path's ``video_id`` is the OS-style string (``gd_xxx``); see
+    :func:`_resolve_video_uuid`. ``catalog_entry_id`` is a UUID
+    (it IS the catalog row's primary key, so no resolution needed).
+
     Same idempotency / cap semantics as ``/scan`` but keyed on
     ``(video_id, user_id, catalog_entry_id)``.
+
+    NOTE: Plan §4.2 marks this endpoint for deprecation (will return
+    410 Gone after Phase 4 fully ships). The type fix here is a
+    forward-compat hedge — keeps the endpoint working consistently
+    until the 410 conversion lands.
     """
+    video_uuid = await _resolve_video_uuid(
+        db=db, org_id=org_ctx.org_id, video_id=video_id,
+    )
     service = _build_service(db, settings)
     return await service.enqueue_clip(
         org_id=org_ctx.org_id,
-        video_id=video_id,
+        video_id=video_uuid,
         catalog_entry_id=catalog_entry_id,
         user_id=user.id,
         duration_preset_sec=body.duration_preset_sec,
@@ -162,7 +224,7 @@ async def enqueue_clip(
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def force_rescan(
-    video_id: UUID,
+    video_id: str,
     body: ScanRequest,
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
     user: Annotated[User, Depends(get_current_user)],
@@ -171,14 +233,20 @@ async def force_rescan(
 ) -> RescanResponse:
     """Soft-reject the existing catalog and enqueue a fresh enumeration.
 
+    Path accepts the OS-style ``video_id`` (``gd_xxx``); see
+    :func:`_resolve_video_uuid`.
+
     Bypasses the 60s idempotency window — rescan is always intentional.
     Existing appearances cascade naturally (rejected catalog rows hide
     from the gallery; their appearances stay readable for forensics).
     """
+    video_uuid = await _resolve_video_uuid(
+        db=db, org_id=org_ctx.org_id, video_id=video_id,
+    )
     service = _build_service(db, settings)
     return await service.rescan(
         org_id=org_ctx.org_id,
-        video_id=video_id,
+        video_id=video_uuid,
         user_id=user.id,
         duration_preset_sec=body.duration_preset_sec,
     )
@@ -193,7 +261,7 @@ async def force_rescan(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def reject_catalog_entry(
-    video_id: UUID,
+    video_id: str,
     catalog_entry_id: UUID,
     org_ctx: Annotated[OrgContext, Depends(get_current_org)],
     _user: Annotated[User, Depends(get_current_user)],
@@ -202,14 +270,20 @@ async def reject_catalog_entry(
 ) -> None:
     """Soft-reject a catalog entry ("this isn't a product").
 
+    Path's ``video_id`` is the OS-style string (``gd_xxx``); see
+    :func:`_resolve_video_uuid`. ``catalog_entry_id`` is a UUID.
+
     v1: internal admin use. v2 will surface this in the picker UI for
     user-driven curation. Idempotent — already-rejected entries return
     204 silently.
     """
+    video_uuid = await _resolve_video_uuid(
+        db=db, org_id=org_ctx.org_id, video_id=video_id,
+    )
     service = _build_service(db, settings)
     await service.reject_catalog_entry(
         org_id=org_ctx.org_id,
-        video_id=video_id,
+        video_id=video_uuid,
         catalog_entry_id=catalog_entry_id,
     )
 
@@ -329,26 +403,13 @@ async def create_scan_order(
     DriveFile (missing or soft-deleted) — same shape as the
     stale-video guard in ``internal_router.complete``.
     """
-    # Loose-coupling note (plan §15): drive-repo lookup carve-out,
-    # mirrors the existing stale-video guard at internal_router.py
-    # and the render-service call. Lazy import keeps the router
-    # module-level free of cross-module ``app.modules.drive`` coupling.
-    from app.modules.drive.repository import DriveFileRepository
-
-    drive_repo = DriveFileRepository(db)
-    drive_file = await drive_repo.get_by_video_id(
-        org_id=org_ctx.org_id, video_id=video_id,
+    video_uuid = await _resolve_video_uuid(
+        db=db, org_id=org_ctx.org_id, video_id=video_id,
     )
-    if drive_file is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"video_id {video_id!r} not found",
-        )
-
     service = _build_service(db, settings)
     return await service.enqueue_scan_order(
         org_id=org_ctx.org_id,
-        video_id=drive_file.id,
+        video_id=video_uuid,
         user_id=user.id,
         body=body,
     )

--- a/services/api/tests/test_v2_router_video_id_resolution.py
+++ b/services/api/tests/test_v2_router_video_id_resolution.py
@@ -1,0 +1,207 @@
+"""Tests for OS-style video_id (`gd_xxx`) resolution across the v2
+shorts-auto-product router endpoints.
+
+PR #130 fixed the wizard's ``create_scan_order``; this file extends
+the same fix to the other five endpoints (``get_product_catalog``,
+``enqueue_scan``, ``enqueue_clip``, ``force_rescan``,
+``reject_catalog_entry``) which all carried the same latent
+``video_id: UUID`` typing.
+
+All endpoints now share a single ``_resolve_video_uuid`` helper.
+This file pins the post-fix shape per endpoint:
+  * happy path: OS string at the path → DriveFile lookup →
+    service receives the UUID.
+  * 404 on missing/soft-deleted video.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app(monkeypatch, *, drive_file: Any = None):
+    """Mounts the public router with DriveFileRepository + service mocked.
+
+    Returns ``(app, fake_drive_repo, fake_service, org_id)`` so each
+    test can assert against the mocks without recreating fixtures.
+    """
+    from app.dependencies import get_db_session
+    from app.modules.shorts_auto_product.router import router
+
+    fake_drive_repo = MagicMock()
+    fake_drive_repo.get_by_video_id = AsyncMock(return_value=drive_file)
+
+    import app.modules.drive.repository as drive_repo_module
+    monkeypatch.setattr(
+        drive_repo_module,
+        "DriveFileRepository",
+        MagicMock(side_effect=lambda _db: fake_drive_repo),
+    )
+
+    # Build real Pydantic response instances — FastAPI validates the
+    # response_model against the returned object, so MagicMocks with a
+    # model_dump lambda fail with `uuid_type` errors. Constructing the
+    # actual schemas keeps the test focused on the routing surface.
+    from app.modules.shorts_auto_product.schemas import (
+        ClipResponse,
+        ProductCatalogResponse,
+        RescanResponse,
+        ScanResponse,
+    )
+
+    fake_service = MagicMock()
+    fake_service.list_products = AsyncMock(return_value=ProductCatalogResponse(
+        video_id=uuid4(),
+        scan_status="never",
+        scan_job_id=None,
+        products=[],
+    ))
+    fake_service.enqueue_scan = AsyncMock(return_value=ScanResponse(
+        job_id=uuid4(), deduped=False,
+    ))
+    fake_service.enqueue_clip = AsyncMock(return_value=ClipResponse(
+        job_id=uuid4(), deduped=False, render_job_id=None,
+    ))
+    fake_service.rescan = AsyncMock(return_value=RescanResponse(
+        job_id=uuid4(), invalidated_count=0,
+    ))
+    fake_service.reject_catalog_entry = AsyncMock(return_value=None)
+
+    import app.modules.shorts_auto_product.router as router_module
+    monkeypatch.setattr(
+        router_module, "_build_service", lambda _db, _settings: fake_service,
+    )
+
+    from app.modules.tenancy.middleware import get_current_org
+    from app.modules.tenancy.context import OrgContext
+    from app.modules.auth.service import get_current_user
+    from app.config import get_settings as _get_settings
+
+    org_id = uuid4()
+    user_id = uuid4()
+    fake_settings = MagicMock()
+    fake_db = MagicMock()
+    fake_db.commit = AsyncMock()
+
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/api")
+    test_app.dependency_overrides[get_db_session] = lambda: fake_db
+    test_app.dependency_overrides[get_current_org] = lambda: OrgContext(
+        org_id=org_id, org_slug="testorg",
+    )
+    test_app.dependency_overrides[get_current_user] = lambda: MagicMock(
+        id=user_id,
+    )
+    test_app.dependency_overrides[_get_settings] = lambda: fake_settings
+
+    return test_app, fake_drive_repo, fake_service, org_id
+
+
+# ---------------------------------------------------------------------
+# Per-endpoint OS-string resolution (happy path)
+# ---------------------------------------------------------------------
+
+
+def test_get_product_catalog_resolves_os_video_id(monkeypatch):
+    drive_file_uuid = uuid4()
+    drive_file = MagicMock(id=drive_file_uuid)
+    app, _, fake_service, _ = _build_app(monkeypatch, drive_file=drive_file)
+    client = TestClient(app)
+    resp = client.get("/api/shorts/auto/products/gd_abc123")
+    assert resp.status_code == 200, resp.text
+    fake_service.list_products.assert_awaited_once()
+    assert (
+        fake_service.list_products.await_args.kwargs["video_id"]
+        == drive_file_uuid
+    )
+
+
+def test_enqueue_scan_resolves_os_video_id(monkeypatch):
+    drive_file_uuid = uuid4()
+    app, _, fake_service, _ = _build_app(
+        monkeypatch, drive_file=MagicMock(id=drive_file_uuid),
+    )
+    resp = TestClient(app).post(
+        "/api/shorts/auto/products/gd_abc123/scan",
+        json={"duration_preset_sec": 60},
+    )
+    assert resp.status_code == 202, resp.text
+    fake_service.enqueue_scan.assert_awaited_once()
+    assert (
+        fake_service.enqueue_scan.await_args.kwargs["video_id"]
+        == drive_file_uuid
+    )
+
+
+def test_enqueue_clip_resolves_os_video_id(monkeypatch):
+    drive_file_uuid = uuid4()
+    catalog_entry_id = uuid4()
+    app, _, fake_service, _ = _build_app(
+        monkeypatch, drive_file=MagicMock(id=drive_file_uuid),
+    )
+    resp = TestClient(app).post(
+        f"/api/shorts/auto/products/gd_abc123/{catalog_entry_id}/clip",
+        json={"duration_preset_sec": 60},
+    )
+    assert resp.status_code == 202, resp.text
+    fake_service.enqueue_clip.assert_awaited_once()
+    kwargs = fake_service.enqueue_clip.await_args.kwargs
+    assert kwargs["video_id"] == drive_file_uuid
+    assert kwargs["catalog_entry_id"] == catalog_entry_id
+
+
+def test_force_rescan_resolves_os_video_id(monkeypatch):
+    drive_file_uuid = uuid4()
+    app, _, fake_service, _ = _build_app(
+        monkeypatch, drive_file=MagicMock(id=drive_file_uuid),
+    )
+    resp = TestClient(app).post(
+        "/api/shorts/auto/products/gd_abc123/rescan",
+        json={"duration_preset_sec": 60},
+    )
+    assert resp.status_code == 202, resp.text
+    fake_service.rescan.assert_awaited_once()
+    assert (
+        fake_service.rescan.await_args.kwargs["video_id"] == drive_file_uuid
+    )
+
+
+def test_reject_catalog_entry_resolves_os_video_id(monkeypatch):
+    drive_file_uuid = uuid4()
+    catalog_entry_id = uuid4()
+    app, _, fake_service, _ = _build_app(
+        monkeypatch, drive_file=MagicMock(id=drive_file_uuid),
+    )
+    resp = TestClient(app).delete(
+        f"/api/shorts/auto/products/gd_abc123/{catalog_entry_id}",
+    )
+    assert resp.status_code == 204
+    fake_service.reject_catalog_entry.assert_awaited_once()
+    kwargs = fake_service.reject_catalog_entry.await_args.kwargs
+    assert kwargs["video_id"] == drive_file_uuid
+    assert kwargs["catalog_entry_id"] == catalog_entry_id
+
+
+# ---------------------------------------------------------------------
+# 404 on missing video (single representative test — same code path
+# via the shared _resolve_video_uuid helper, so per-endpoint coverage
+# would be redundant)
+# ---------------------------------------------------------------------
+
+
+def test_resolve_helper_returns_404_on_missing_video(monkeypatch):
+    """When ``DriveFileRepository.get_by_video_id`` returns None, the
+    helper raises HTTPException 404 — exercised here via
+    ``get_product_catalog`` but the same code path runs on every
+    endpoint that uses the helper."""
+    app, _, fake_service, _ = _build_app(monkeypatch, drive_file=None)
+    resp = TestClient(app).get("/api/shorts/auto/products/gd_does_not_exist")
+    assert resp.status_code == 404
+    assert "not found" in resp.text
+    fake_service.list_products.assert_not_awaited()


### PR DESCRIPTION
## Summary

PR #130 fixed `create_scan_order`'s UUID-vs-OS-string typing for the wizard. The other 5 endpoints in the same router carried the same latent bug:

```
GET    /products/{video_id}                          (get_product_catalog)
POST   /products/{video_id}/scan                     (enqueue_scan)
POST   /products/{video_id}/{catalog_entry_id}/clip  (enqueue_clip)
POST   /products/{video_id}/rescan                   (force_rescan)
DELETE /products/{video_id}/{catalog_entry_id}       (reject_catalog_entry)
```

None of them have active frontend callers today (the v1 catalog gallery dir `features/shorts-auto-product/` doesn't exist in this repo state), so this is a **forward-compat improvement** — when a caller wires up, the endpoints will accept the same OS string shape (`gd_xxx`) the rest of the app uses for `/videos/{videoId}`.

## Decoupling

Extracted a shared `_resolve_video_uuid` helper inside the router module. Every endpoint that takes `video_id` from the path now goes through it — single source of truth for the DriveFile lookup + 404 error shape. **PR #130's `create_scan_order` also refactored to use the helper** (removed inline duplicate).

The helper lazy-imports `DriveFileRepository` per plan §15 carve-out (same pattern as `internal_router.complete`'s stale-video guard + the render-service call).

`catalog_entry_id` stays UUID-typed where it appears — it IS a UUID (catalog row primary key), no resolution needed.

## Test plan

- [x] 5 new TestClient happy-path regression tests + 1 shared 404 path test
- [x] 23/23 backend tests pass cumulatively (PR #130's regression + phase 4 foundation suite)
- [x] `enqueue_clip` is on the deprecation list (plan §4.2 → 410 Gone) but still serves normally; type fix is a forward-compat hedge until the 410 conversion lands

## Out of scope

- The `enqueue_clip → 410` deprecation conversion (separate PR per plan §4.2)
- Any frontend wiring of these endpoints (no callers exist today)
