### PR TITLE
fix(product-track-worker): remove redundant claim in _handle_scan_order_parent

### DIFF
--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -1155,31 +1155,18 @@ def _handle_scan_order_parent(
     Time-range pre-filter (codex Q3) and per-length min-window
     threshold (plan §7.3) apply at the scenes/config layer before
     the per-product loop kicks off.
+
+    Precondition: ``handle_track_job`` already issued the ``api.claim``
+    call at the entrypoint. Re-claiming here would 409 (parent already
+    in ``tracking``), then this function returned early, dispatch
+    returned normally, the SDK ack-deleted the message — and the job
+    never progressed past claim. Bug shipped 2026-05-03 with the
+    wizard scan_order flow.
     """
     cost_accumulator = Decimal("0")
     length_seconds = decoded.length_seconds or 60
 
-    # ── 1. claim ──────────────────────────────────────────────
-    try:
-        api.claim(
-            job_id=decoded.job_id,
-            claimed_by=settings.worker_id,
-            next_stage="tracking",
-            lease_seconds=settings.worker_lease_seconds,
-        )
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 409:
-            logger.info(
-                "scan_order_claim_conflict_acking_message",
-                extra={
-                    "job_id": str(decoded.job_id),
-                    "claimed_by": settings.worker_id,
-                },
-            )
-            return
-        raise
-
-    # ── 2. heartbeat: resolving ───────────────────────────────
+    # ── 1. heartbeat: resolving ───────────────────────────────
     api.heartbeat(
         job_id=decoded.job_id,
         claimed_by=settings.worker_id,
@@ -1190,7 +1177,7 @@ def _handle_scan_order_parent(
         lease_seconds=settings.worker_lease_seconds,
     )
 
-    # ── 3. fetch active catalog ───────────────────────────────
+    # ── 2. fetch active catalog ───────────────────────────────
     catalog_entries = api.fetch_catalog_entries_for_video(
         video_id=decoded.video_id, org_id=decoded.org_id,
     )
@@ -1207,7 +1194,7 @@ def _handle_scan_order_parent(
         )
         return
 
-    # ── 4. fetch scenes-with-keyframes (ONCE for the video) ──
+    # ── 3. fetch scenes-with-keyframes (ONCE for the video) ──
     api.heartbeat(
         job_id=decoded.job_id,
         claimed_by=settings.worker_id,
@@ -1238,7 +1225,7 @@ def _handle_scan_order_parent(
     scenes = scenes_resp.get("scenes", [])
     os_video_id = scenes_resp.get("video_id", "")
 
-    # ── 4.5 time-range pre-filter (codex Q3) ──────────────────
+    # ── 3.5 time-range pre-filter (codex Q3) ──────────────────
     scene_id_to_kf = _filter_scenes_by_time_range(
         scenes,
         range_start_ms=decoded.time_range_start_ms,
@@ -1258,7 +1245,7 @@ def _handle_scan_order_parent(
         )
         return
 
-    # ── 5. per-product loop ───────────────────────────────────
+    # ── 4. per-product loop ───────────────────────────────────
     cfg = _make_config(settings)
     # Per-length threshold override (plan §7.3 — codex Q4).
     cfg.min_window_duration_ms = _min_window_ms_for_length(length_seconds)
@@ -1320,7 +1307,7 @@ def _handle_scan_order_parent(
             products_f4_failed += 1
             continue
 
-    # ── 6. /complete or /fail ─────────────────────────────────
+    # ── 5. /complete or /fail ─────────────────────────────────
     if not aggregated_appearances:
         # Distinguish "all products F4-failed" (stage-wide regression)
         # from "all products produced no qualifying windows" (correct

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -347,3 +347,76 @@ def test_render_enqueue_passes_os_video_id_not_drivefile_uuid():
     # Composition's per-clip video_id must also be the OS string.
     composition = enqueue_kwargs["composition"]
     assert all(c["video_id"] == "gd_test" for c in composition["scene_clips"])
+
+
+# =====================================================================
+# scan_order parent flow: claim is owned by handle_track_job, NOT by
+# _handle_scan_order_parent (regression for 2026-05-03 prod incident)
+# =====================================================================
+
+
+def _scan_order_body() -> dict:
+    """Wizard parent message — mode='scan_order', no catalog_entry_id."""
+    return {
+        "type": "product.track_job",
+        "job_id": str(uuid4()),
+        "org_id": str(uuid4()),
+        "video_id": str(uuid4()),
+        "requested_by_user_id": str(uuid4()),
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+        "mode": "scan_order",
+        "length_seconds": 30,
+        "requested_count": 5,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+    }
+
+
+def test_scan_order_parent_calls_claim_exactly_once():
+    """Regression: ``_handle_scan_order_parent`` previously issued a
+    SECOND ``api.claim`` call after ``handle_track_job`` had already
+    claimed the job. The second call always 409'd (parent in
+    ``tracking``), the function returned early, dispatch returned
+    normally, the SDK ack-deleted the message — and the job stuck at
+    ``stage=tracking`` forever with no heartbeat/fail/complete.
+    Symptom on staging 2026-05-03: 3 successive scan orders all
+    silently stalled after the api transitioned to ``tracking``.
+
+    Pin: claim is called EXACTLY ONCE per dispatch, by
+    ``handle_track_job``. ``_handle_scan_order_parent`` MUST NOT
+    re-claim — its first call should be the resolving heartbeat.
+    """
+    api = MagicMock()
+    # Empty catalog → fast termination via the no_products_detected
+    # fail path. Lets the test prove "we got past the redundant claim
+    # block" without standing up the full SAM2/picker mock pipeline.
+    api.fetch_catalog_entries_for_video.return_value = []
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    handle_track_job(
+        message=_scan_order_body(),
+        settings=_settings(),
+        api_client=api,
+        embedder=embedder,
+        tracker=tracker,
+        picker=picker,
+        s3_client=s3,
+    )
+
+    # The fix: claim called once, by handle_track_job. Pre-fix this
+    # was 2 (handle_track_job + _handle_scan_order_parent).
+    assert api.claim.call_count == 1, (
+        f"expected exactly one claim call, got {api.claim.call_count} "
+        f"(double-claim bug regression: 2026-05-03)"
+    )
+    # Heartbeat fires only AFTER the redundant claim block was removed —
+    # if the bug returns, this would be 0.
+    assert api.heartbeat.call_count >= 1, (
+        "heartbeat never fired — the dispatcher likely hit the early "
+        "return on a redundant claim 409"
+    )
+    # Sanity: the empty-catalog path's terminal /fail call landed.
+    api.fail.assert_called_once()
+    assert api.fail.call_args.kwargs["error_code"] == "no_products_detected"


### PR DESCRIPTION
## Summary

`handle_track_job` already issues `api.claim` at line 328. The Phase
4 wizard sub-handler `_handle_scan_order_parent` was issuing a
**second** claim on entry, which always 409'd (parent already in
`tracking`), the function returned early, dispatch returned normally,
and the SDK ack-deleted the SQS message. Net effect: every wizard
scan order silently stuck at `stage=tracking` with NO heartbeat /
fail / complete callback.

## Symptom on staging (2026-05-03)

Three successive wizard scan orders all reproduced the exact same
pattern within 60 seconds of submit:

```
POST /internal/products/{id}/claim 200 OK         ← handle_track_job claim (good)
POST /internal/products/{id}/claim 409 Conflict   ← _handle_scan_order_parent claim (bug)
(zero further calls — no heartbeat, no fail, no complete)
```

Container shows running, queue drains to 0 (SDK ack-deleted),
parent stays at `tracking` forever (until DB lease expires 30 min
later). The previous-handoff "wizard fully shipped" status was a
false positive — the runner real-flow code was correct, but the
sub-handler was a copy of the legacy single-product flow that
hadn't been adapted for being called as a sub-step.

## Fix

Remove the claim block from `_handle_scan_order_parent` (~18 lines).
The first call in the function is now the resolving heartbeat. Add
a docstring precondition stating that `handle_track_job` owns the
claim. Renumber the subsequent section comments (1-6 → 1-5).

After the fix, only one `api.claim(` call remains in the entire
file (line 328 in `handle_track_job`) — claim happens exactly once
per dispatch regardless of mode.

## Tests

`test_scan_order_parent_calls_claim_exactly_once` — calls
`handle_track_job` with `mode='scan_order'`, mocks
`fetch_catalog_entries_for_video` to return empty (fast termination
via the `no_products_detected` fail path), and asserts:
- `api.claim.call_count == 1` (was 2 pre-fix)
- `api.heartbeat.call_count >= 1` (proves we got past the
  redundant claim block — was 0 pre-fix)
- The terminal `/fail` reached the `no_products_detected` branch

Worker tests are NOT in the api CI allowlist — `heimdex_media_pipelines`
isn't on PyPI so this file can't import in the github-hosted runner.
The test does run for anyone executing the worker suite directly
or in the GPU image build pipeline.

## Test plan

- [x] Source-level: only one `api.claim(` call site remains in `tasks/track.py`
- [x] Syntax: both files parse via `ast.parse`
- [x] Regression test added with explicit failure modes
- [ ] CI green (compose / type-check / no worker tests in scope)
- [ ] Post-merge: `gh workflow run build-gpu-images.yml -f workers=product-track`
- [ ] Post-build: stop+start container `d809c6e8` in Aircloud SaaS to pull `:latest`
- [ ] Post-deploy: re-trigger a wizard scan order, watch parent transition
      `tracking → assembling → done` with children + render_job_ids

## Why I'm confident

The diagnosis is direct: the api access logs show exactly two claim
calls per submission with the signature `200 → 409`, and the only
function in the codebase that matches that two-call shape is the
overlap of `handle_track_job` + `_handle_scan_order_parent`. After
removing the second claim, the symptom signature should change to a
single `200`, then heartbeats, then either `complete` or `fail`.

If staging *still* gets stuck post-fix, the next likely culprits
are SAM2 OOM on RTX 4070 Super (would log a CUDA error in container
stdout) or the orchestrator's idle-stop killing the worker before
SAM2 finishes (separate worker-sdk issue worth filing).