### PR TITLE
feat(shorts-auto-product): plumb optional catalog_entry_id through scan_order (Phase A)

### DIFF
--- a/services/api/app/modules/shorts_auto_product/repositories/job.py
+++ b/services/api/app/modules/shorts_auto_product/repositories/job.py
@@ -480,20 +480,27 @@ class ProductScanJobRepository:
         language: str,
         intent: str,
         settings_hash: str,
+        catalog_entry_id: UUID | None = None,
     ) -> ProductScanJob:
         """Insert a wizard parent row.
 
         ``mode='scan_order'`` + every wizard input from the body. The
         DB-level CHECKs (``ck_psj_parent_required_fields``,
         ``ck_psj_aggregate_output``, etc.) catch any service-side
-        validation gap. ``catalog_entry_id`` is NULL — parents process
-        the whole catalog.
+        validation gap.
+
+        ``catalog_entry_id`` is NULL by default — parent processes the
+        whole active catalog (legacy round-robin via the picker). When
+        the wizard's product-select step returns a chosen entry, the
+        service layer plumbs it through and the worker filters its
+        catalog fetch to that single entry. The ``ck_psj_parent_*``
+        constraints don't gate this column for scan_order parents.
         """
         job = ProductScanJob(
             org_id=org_id,
             video_id=video_id,
             requested_by_user_id=user_id,
-            catalog_entry_id=None,
+            catalog_entry_id=catalog_entry_id,
             duration_preset_sec=length_seconds,  # legacy column carries the same number
             mode=SCAN_MODE_SCAN_ORDER,
             length_seconds=length_seconds,

--- a/services/api/app/modules/shorts_auto_product/schemas.py
+++ b/services/api/app/modules/shorts_auto_product/schemas.py
@@ -254,6 +254,15 @@ class ScanOrderCreateRequest(BaseModel):
     product_distribution: ProductDistribution
     language: Language
     intent: ScanIntent = "commit"
+    # Optional pre-tracking product pick. When set, the scan_order is
+    # bound to a single catalog entry (the wizard's product-select
+    # step's output) and the worker filters its catalog fetch to just
+    # this id instead of looping over the whole active catalog. When
+    # NULL, legacy whole-catalog round-robin behavior is preserved.
+    # Service-level validation enforces the entry exists, belongs to
+    # (org, video), and isn't soft-rejected — same pattern as the
+    # legacy ``enqueue_clip`` 404 path.
+    catalog_entry_id: UUID | None = None
 
 
 class ScanOrderResponse(BaseModel):

--- a/services/api/app/modules/shorts_auto_product/service.py
+++ b/services/api/app/modules/shorts_auto_product/service.py
@@ -603,6 +603,26 @@ class ProductScanService:
         # better error messages for the frontend.
         _validate_scan_order_inputs(body=body)
 
+        # If the wizard's product-select step picked a specific entry,
+        # validate it BEFORE allocating a concurrency slot — same shape
+        # as the legacy ``enqueue_clip`` 404 (no-info-leak: cross-org,
+        # missing, and rejected all return the same status). The check
+        # also doubles as a defense against stale catalog ids that
+        # survived a rescan invalidation.
+        if body.catalog_entry_id is not None:
+            entry = await self.catalog_repo.get(
+                org_id=org_id, entry_id=body.catalog_entry_id,
+            )
+            if (
+                entry is None
+                or entry.video_id != video_id
+                or entry.rejected_at is not None
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="catalog entry not found",
+                )
+
         # Active catalog set drives idempotency invalidation: a rescan
         # that produces new entries naturally invalidates the dedupe
         # key without needing an explicit catalog version column.
@@ -625,6 +645,11 @@ class ProductScanService:
             tracker_version=self.settings.auto_shorts_product_v2_tracker_version,
             enumeration_prompt_version=(
                 self.settings.auto_shorts_product_v2_enumeration_prompt_version
+            ),
+            selected_catalog_entry_id=(
+                str(body.catalog_entry_id)
+                if body.catalog_entry_id is not None
+                else None
             ),
         )
 
@@ -655,6 +680,7 @@ class ProductScanService:
             language=body.language,
             intent=body.intent,
             settings_hash=settings_hash,
+            catalog_entry_id=body.catalog_entry_id,
         )
         await self.session.flush()
 
@@ -692,9 +718,13 @@ class ProductScanService:
                     product_distribution=body.product_distribution,
                     language=body.language,
                     intent=body.intent,
-                    # Legacy fields intentionally omitted — workers on
-                    # v0.14.0+ use ``length_seconds`` and dispatch on
-                    # ``mode='scan_order'`` (not ``catalog_entry_id``).
+                    # Optional pre-tracking pick. None = whole-catalog
+                    # round-robin (legacy scan_order behavior). Set =
+                    # worker filters its catalog fetch to this single
+                    # entry. ``duration_preset_sec`` stays omitted —
+                    # scan_order uses ``length_seconds`` not the legacy
+                    # preset.
+                    catalog_entry_id=body.catalog_entry_id,
                 )
             except Exception:
                 logger.exception(
@@ -838,6 +868,7 @@ def compute_settings_hash(
     active_catalog_entry_ids: list[str],
     tracker_version: str,
     enumeration_prompt_version: str,
+    selected_catalog_entry_id: str | None = None,
 ) -> str:
     """Canonical-JSON SHA256 of every wizard input that should
     discriminate "same intent" from "different intent" for the 60s
@@ -880,6 +911,13 @@ def compute_settings_hash(
         "tracker_version": tracker_version,
         "enumeration_prompt_version": enumeration_prompt_version,
     }
+    # Only include the user's pick when set, so the no-pick path
+    # preserves the original hash composition. Different picks for the
+    # same video naturally get different hashes; flipping from no-pick
+    # to a specific pick also re-hashes (intentional — semantically
+    # different jobs).
+    if selected_catalog_entry_id is not None:
+        payload["selected_catalog_entry_id"] = selected_catalog_entry_id
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 

--- a/services/api/tests/test_shorts_auto_product_scan_order.py
+++ b/services/api/tests/test_shorts_auto_product_scan_order.py
@@ -214,6 +214,54 @@ def test_settings_hash_canonical_json_is_key_order_insensitive():
     assert h1 == h2
 
 
+def test_settings_hash_omits_selected_entry_when_none():
+    """Backward compat: scan orders submitted before the product-select
+    step shipped (or with the field absent) must hash IDENTICALLY to
+    the same call without the parameter, so live idempotency keys
+    don't churn during deploy."""
+    base = {
+        "video_id": uuid4(),
+        "user_id": uuid4(),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+        "active_catalog_entry_ids": ["aaa"],
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+    h_no_kwarg = compute_settings_hash(**base)
+    h_explicit_none = compute_settings_hash(selected_catalog_entry_id=None, **base)
+    assert h_no_kwarg == h_explicit_none
+
+
+def test_settings_hash_changes_when_user_picks_a_product():
+    """Picking a product semantically narrows the job — must produce a
+    distinct dedupe key from the same wizard inputs without a pick."""
+    base = {
+        "video_id": uuid4(),
+        "user_id": uuid4(),
+        "length_seconds": 60,
+        "requested_count": 5,
+        "time_range_start_ms": None,
+        "time_range_end_ms": None,
+        "product_distribution": "single",
+        "language": "ko",
+        "intent": "commit",
+        "active_catalog_entry_ids": ["aaa", "bbb"],
+        "tracker_version": "v1.0",
+        "enumeration_prompt_version": "v1.0",
+    }
+    h_unpicked = compute_settings_hash(**base)
+    h_picked_a = compute_settings_hash(selected_catalog_entry_id="aaa", **base)
+    h_picked_b = compute_settings_hash(selected_catalog_entry_id="bbb", **base)
+    # Three distinct intents → three distinct hashes.
+    assert len({h_unpicked, h_picked_a, h_picked_b}) == 3
+
+
 # ======================================================================
 # _validate_scan_order_inputs — codex Q5 aggregate cap + time range
 # ======================================================================

--- a/services/api/tests/test_shorts_auto_product_schemas.py
+++ b/services/api/tests/test_shorts_auto_product_schemas.py
@@ -23,6 +23,7 @@ from app.modules.shorts_auto_product.schemas import (
     ProductCatalogResponse,
     ProductV2AvailabilityFragment,
     RescanResponse,
+    ScanOrderCreateRequest,
     ScanRequest,
     ScanResponse,
 )
@@ -216,3 +217,34 @@ class TestRescanResponse:
         # First-ever rescan on a video with no catalog → 0 invalidated.
         r = RescanResponse(job_id=uuid4(), invalidated_count=0)
         assert r.invalidated_count == 0
+
+
+class TestScanOrderCreateRequest:
+    """Wizard parent body — Phase 4 + product-select extension."""
+
+    _BASE = {
+        "length_seconds": 60,
+        "requested_count": 5,
+        "product_distribution": "single",
+        "language": "ko",
+    }
+
+    def test_catalog_entry_id_is_optional(self):
+        # Backward compat: existing wizard submissions don't carry the
+        # field; default to None (whole-catalog round-robin).
+        body = ScanOrderCreateRequest(**self._BASE)
+        assert body.catalog_entry_id is None
+
+    def test_catalog_entry_id_accepts_uuid(self):
+        # Product-select step output: a UUID narrows the worker's
+        # catalog fetch to that single entry.
+        eid = uuid4()
+        body = ScanOrderCreateRequest(catalog_entry_id=eid, **self._BASE)
+        assert body.catalog_entry_id == eid
+
+    def test_catalog_entry_id_rejects_non_uuid_string(self):
+        # Pydantic enforces UUID shape; a stringly-typed sentinel
+        # would otherwise silently slip through to the SQS body and
+        # fail at the worker.
+        with pytest.raises(ValidationError):
+            ScanOrderCreateRequest(catalog_entry_id="not-a-uuid", **self._BASE)

--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -1178,9 +1178,39 @@ def _handle_scan_order_parent(
     )
 
     # ── 2. fetch active catalog ───────────────────────────────
-    catalog_entries = api.fetch_catalog_entries_for_video(
-        video_id=decoded.video_id, org_id=decoded.org_id,
-    )
+    # When the wizard's product-select step picked a single entry,
+    # narrow the fetch to that one (Pattern B endpoint
+    # /internal/products/catalog/{id}). The per-product loop below
+    # takes a uniform ``[entry, ...]`` shape, so wrapping in a
+    # one-element list lets the rest of the function ignore the
+    # distinction. service.enqueue_scan_order already validated, but
+    # treat 404 here as the entry was rejected between submit and
+    # worker pickup.
+    if decoded.catalog_entry_id is not None:
+        try:
+            single = api.fetch_catalog_entry(
+                catalog_entry_id=decoded.catalog_entry_id,
+                org_id=decoded.org_id,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                api.fail(
+                    job_id=decoded.job_id,
+                    claimed_by=settings.worker_id,
+                    cost_delta_usd=cost_accumulator,
+                    error_code="no_products_detected",
+                    error_message=(
+                        f"catalog entry {decoded.catalog_entry_id} "
+                        f"not found or rejected since submit"
+                    ),
+                )
+                return
+            raise
+        catalog_entries = [single]
+    else:
+        catalog_entries = api.fetch_catalog_entries_for_video(
+            video_id=decoded.video_id, org_id=decoded.org_id,
+        )
     if not catalog_entries:
         api.fail(
             job_id=decoded.job_id,

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -420,3 +420,94 @@ def test_scan_order_parent_calls_claim_exactly_once():
     # Sanity: the empty-catalog path's terminal /fail call landed.
     api.fail.assert_called_once()
     assert api.fail.call_args.kwargs["error_code"] == "no_products_detected"
+
+
+# =====================================================================
+# scan_order parent flow: catalog_entry_id narrows the catalog fetch
+# (wizard product-select step output)
+# =====================================================================
+
+
+def test_scan_order_with_catalog_entry_id_uses_single_entry_fetch():
+    """When the wizard's product-select step picked a catalog entry,
+    the worker MUST call fetch_catalog_entry(id) — NOT
+    fetch_catalog_entries_for_video — and proceed to track ONLY that
+    product. Pre-feature: the field was unused, the worker always
+    fanned across the whole active catalog (round-robin via picker).
+
+    Test uses an empty scenes-with-keyframes response to terminate the
+    per-product loop quickly via the no-qualifying-windows path —
+    avoids standing up the full SAM2 + picker mock pipeline. The
+    assertion is on which fetch path the worker took, not on output.
+    """
+    catalog_entry_id = uuid4()
+    api = MagicMock()
+    # The single-entry fetch returns the same shape as the per-video
+    # list endpoint (per fetch_catalog_entry's docstring contract).
+    api.fetch_catalog_entry.return_value = {
+        "catalog_entry_id": str(catalog_entry_id),
+        "org_id": str(uuid4()),
+        "video_id": "gd_test",
+        "canonical_crop_s3_key": "k.jpg",
+        "canonical_bbox": {"x": 0, "y": 0, "w": 10, "h": 10},
+        "llm_label": "테스트 제품",
+    }
+    # No scenes → per-product loop produces no qualifying windows →
+    # parent /fails as tracker_low_confidence_global. Skips SAM2.
+    api.fetch_scenes_with_keyframes.return_value = {"video_id": "gd_test", "scenes": []}
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    body = _scan_order_body()
+    body["catalog_entry_id"] = str(catalog_entry_id)
+
+    handle_track_job(
+        message=body,
+        settings=_settings(),
+        api_client=api,
+        embedder=embedder,
+        tracker=tracker,
+        picker=picker,
+        s3_client=s3,
+    )
+
+    # The point of this test: single-entry fetch is the chosen path.
+    api.fetch_catalog_entry.assert_called_once()
+    fetch_kwargs = api.fetch_catalog_entry.call_args.kwargs
+    assert fetch_kwargs["catalog_entry_id"] == catalog_entry_id
+    # And the bulk fetch was NOT used.
+    api.fetch_catalog_entries_for_video.assert_not_called()
+
+
+def test_scan_order_catalog_entry_404_fails_cleanly():
+    """If the picked entry was rejected between submit and worker
+    pickup, fetch_catalog_entry 404s. Worker MUST translate that to
+    a no_products_detected /fail (not bubble the HTTPStatusError to
+    SDK as a redelivery candidate — the entry won't un-reject)."""
+    import httpx
+
+    catalog_entry_id = uuid4()
+    api = MagicMock()
+    # Build a real httpx 404 to mirror what the api_client raises.
+    fake_resp = MagicMock(spec=httpx.Response)
+    fake_resp.status_code = 404
+    api.fetch_catalog_entry.side_effect = httpx.HTTPStatusError(
+        "404", request=MagicMock(spec=httpx.Request), response=fake_resp,
+    )
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    body = _scan_order_body()
+    body["catalog_entry_id"] = str(catalog_entry_id)
+
+    handle_track_job(
+        message=body,
+        settings=_settings(),
+        api_client=api,
+        embedder=embedder,
+        tracker=tracker,
+        picker=picker,
+        s3_client=s3,
+    )
+
+    api.fetch_catalog_entry.assert_called_once()
+    api.fail.assert_called_once()
+    assert api.fail.call_args.kwargs["error_code"] == "no_products_detected"


### PR DESCRIPTION
## Summary

Phase A of the wizard product-select feature ([plan thread](#)). Adds an
**optional** `catalog_entry_id` field on `ScanOrderCreateRequest` that
binds the wizard's scan_order parent to a single previously-enumerated
product. The worker filters its catalog fetch to that one entry instead
of running the per-product loop across the whole active catalog.

**Backward-compat**: when the field is None (current frontend behavior),
the legacy whole-catalog round-robin path is preserved bit-for-bit —
including the settings_hash composition (the hash key is omitted when
None, so existing in-flight idempotency keys don't churn).

## Why now

Currently the wizard's track stage hard-fails with `no_products_detected`
on any video that hasn't been previously enumerated via the v1 product
gallery flow. There's no UI in the wizard to enumerate products first,
let the user pick one, and then track only that product. This PR is the
backend plumbing so Phase B (the new wizard step) has a place to send
the user's pick.

## Surface area

| Layer | Change |
|---|---|
| Schema | Optional `UUID` field on `ScanOrderCreateRequest` |
| Service `enqueue_scan_order` | Validates entry exists + belongs to (org, video) + not soft-rejected. Same 404 shape as legacy `enqueue_clip` |
| Service `compute_settings_hash` | Optional `selected_catalog_entry_id` kwarg; hash composition unchanged when None |
| Repository `create_scan_order_parent` | Accepts + persists `catalog_entry_id` (column already nullable; no migration needed) |
| Worker `_handle_scan_order_parent` | When set, calls `fetch_catalog_entry(id)` (single) instead of `fetch_catalog_entries_for_video` (bulk). 404 → `no_products_detected` /fail (rejected-since-submit edge) |

No DB migration. No contract bump (`publish_product_track_job` already
accepts `catalog_entry_id` for the legacy `enqueue_clip` flow; the SQS
body for no-pick scan_orders is byte-identical to before).

## Tests

5 new tests, all pass locally (~50 + 34 in surrounding suites unchanged):

- `test_shorts_auto_product_schemas.py::TestScanOrderCreateRequest` (3)
- `test_settings_hash_omits_selected_entry_when_none` — backward compat
- `test_settings_hash_changes_when_user_picks_a_product` — 3 distinct
  intents (no-pick / pick A / pick B) → 3 distinct hashes
- `test_scan_order_with_catalog_entry_id_uses_single_entry_fetch` —
  worker takes the single-entry path
- `test_scan_order_catalog_entry_404_fails_cleanly` — rejected-since-submit
  edge translates to structured /fail (not redelivery)

## Not in this PR (deferred)

- **Phase B**: `WizardStepProductSelect.tsx` frontend component
- **Phase C**: wizard state + API client wiring (pass selected ID into
  `createScanOrder` body)
- **Phase D**: polish (loading skeleton, retry, i18n)
- Multi-product selection (would need `MultiProductSubsetPicker` + UI)

## Test plan

- [x] All 5 new tests pass locally
- [x] CI-allowlist scan_order tests still pass (34/34)
- [x] Schema regression tests still pass (50/50)
- [x] Both edited Python files parse via `ast.parse`
- [ ] CI green (no behavior change for existing no-pick path)
- [ ] After merge: GHCR rebuild for product-track image (worker code changed)
- [ ] After GHCR rebuild: stop+start container `d809c6e8` to pick up new image
- [ ] Phase B will exercise this end-to-end via real frontend submission

## Related

- Builds on PR #133 (the double-claim fix that finally got the wizard
  reaching `_handle_scan_order_parent`'s catalog fetch)
- Resolves the `no_products_detected` symptom we observed on parent
  `91d60256` — that video had no enumerated catalog AND no way for the
  user to enumerate from the wizard. Phase A removes the second blocker
  conditionally; Phase B will solve the first by triggering enumeration
  from the new step.