### PR TITLE
feat(wizard): add product-select step between criteria and result (Phase B)

### DIFF
--- a/services/web/src/app/export/shorts/auto/wizard/[videoId]/select-product/page.tsx
+++ b/services/web/src/app/export/shorts/auto/wizard/[videoId]/select-product/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useParams } from "next/navigation";
+import { Suspense } from "react";
+
+const WizardStepSelectProduct = dynamic(
+  () =>
+    import(
+      "@/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct"
+    ).then((m) => m.WizardStepSelectProduct),
+  { ssr: false },
+);
+
+export default function WizardSelectProductRoute() {
+  const params = useParams<{ videoId: string }>();
+  const videoId = params?.videoId ?? "";
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-indigo-500" />
+        </div>
+      }
+    >
+      <WizardStepSelectProduct videoId={videoId} />
+    </Suspense>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepCriteria.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepCriteria.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import { WizardStepCriteria } from "../pages/WizardStepCriteria";
 
@@ -9,25 +9,9 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
 }));
 
-vi.mock("@/lib/auth", () => ({
-  useAuth: () => ({ getAccessToken: vi.fn(async () => "test-token") }),
-}));
-
-const createScanOrderMock = vi.fn();
-vi.mock("@/lib/api/shorts-auto-product-wizard", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/api/shorts-auto-product-wizard")
-  >("@/lib/api/shorts-auto-product-wizard");
-  return {
-    ...actual,
-    createScanOrder: (...args: unknown[]) => createScanOrderMock(...args),
-  };
-});
-
 describe("WizardStepCriteria", () => {
   beforeEach(() => {
     pushMock.mockReset();
-    createScanOrderMock.mockReset();
   });
 
   it("renders all five inputs with sensible defaults", () => {
@@ -64,11 +48,10 @@ describe("WizardStepCriteria", () => {
     expect(next.disabled).toBe(true);
   });
 
-  it("submits the scan order with the chosen criteria + routes to step 4", async () => {
-    createScanOrderMock.mockResolvedValueOnce({
-      parent_job_id: "00000000-0000-0000-0000-000000000123",
-      deduped: false,
-    });
+  it("navigates to /select-product with criteria as URL params", () => {
+    // Phase B: criteria step no longer calls createScanOrder. It just
+    // forwards the form values to the product-select step (which then
+    // submits with catalog_entry_id baked in).
     render(<WizardStepCriteria videoId="gd_test" />);
     fireEvent.click(screen.getByTestId("length-preset-30"));
     fireEvent.click(screen.getByTestId("count-preset-10"));
@@ -79,35 +62,30 @@ describe("WizardStepCriteria", () => {
 
     fireEvent.click(screen.getByTestId("wizard-next"));
 
-    await waitFor(() => expect(createScanOrderMock).toHaveBeenCalledTimes(1));
-    expect(createScanOrderMock.mock.calls[0][0]).toBe("gd_test");
-    const body = createScanOrderMock.mock.calls[0][1];
-    expect(body).toMatchObject({
-      length_seconds: 30,
-      requested_count: 10,
-      language: "en",
-      product_distribution: "single",
-      intent: "commit",
-      time_range_start_ms: 90_000, // 1:30 = 90s = 90000ms
-    });
-    await waitFor(() =>
-      expect(pushMock).toHaveBeenCalledWith(
-        "/export/shorts/auto/wizard/gd_test/result/00000000-0000-0000-0000-000000000123",
-      ),
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const target = pushMock.mock.calls[0][0] as string;
+    // Path is the new step under the same videoId.
+    expect(target).toMatch(
+      /^\/export\/shorts\/auto\/wizard\/gd_test\/select-product\?/,
     );
+    // Query params carry every field the next step needs.
+    const url = new URL(`http://x${target}`);
+    expect(url.searchParams.get("length")).toBe("30");
+    expect(url.searchParams.get("count")).toBe("10");
+    expect(url.searchParams.get("language")).toBe("en");
+    expect(url.searchParams.get("distribution")).toBe("single");
+    expect(url.searchParams.get("intent")).toBe("commit");
+    expect(url.searchParams.get("start")).toBe("90000"); // 1:30 → 90 000ms
+    // Empty range-end stays absent (vs serialized as empty string).
+    expect(url.searchParams.has("end")).toBe(false);
   });
 
-  it("surfaces the API's 422 detail message", async () => {
-    const { WizardValidationError } = await import(
-      "@/lib/api/shorts-auto-product-wizard"
-    );
-    createScanOrderMock.mockRejectedValueOnce(
-      new WizardValidationError("requested_count must be >= 1"),
-    );
+  it("omits start/end params when range fields are blank", () => {
     render(<WizardStepCriteria videoId="gd_test" />);
     fireEvent.click(screen.getByTestId("wizard-next"));
-    const error = await screen.findByTestId("error-message");
-    expect(error.textContent).toContain("requested_count must be >= 1");
-    expect(pushMock).not.toHaveBeenCalled();
+    const target = pushMock.mock.calls[0][0] as string;
+    const url = new URL(`http://x${target}`);
+    expect(url.searchParams.has("start")).toBe(false);
+    expect(url.searchParams.has("end")).toBe(false);
   });
 });

--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepSelectProduct.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepSelectProduct.test.tsx
@@ -166,15 +166,71 @@ describe("WizardStepSelectProduct", () => {
     expect(getProductCatalogMock).not.toHaveBeenCalled();
   });
 
-  it("shows the error state when triggerEnumeration rejects", async () => {
-    // Use mockRejectedValue (not …Once) because React 18+ strict-mode
-    // mounts the effect twice in dev/test; both runs must reject for
-    // the assertion to find the original error message.
-    triggerEnumerationMock.mockRejectedValue(new Error("network down"));
+  it("trigger failure does NOT block access to cached catalog entries", async () => {
+    // Codex P2 fix: a transient triggerEnumeration failure must not
+    // strand the user — if a prior wizard run already populated the
+    // catalog, those entries should still render. We swallow the
+    // trigger error and let the poll be the source of truth.
+    triggerEnumerationMock.mockRejectedValue(new Error("transient blip"));
+    getProductCatalogMock.mockResolvedValue({
+      video_id: "gd_test",
+      entries: [SAMPLE_ENTRY],
+    });
+
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+
+    const card = await screen.findByTestId("product-card");
+    expect(card.textContent).toContain("테스트 가방");
+    // The error UI does NOT take over.
+    expect(screen.queryByTestId("poll-error")).not.toBeInTheDocument();
+  });
+
+  it("shows the error state when the catalog poll itself fails", async () => {
+    // The poll endpoint failing IS a real error — no cached catalog
+    // means there's nothing the user can do but retry.
+    triggerEnumerationMock.mockResolvedValue({
+      job_id: "j1",
+      deduped: false,
+    });
+    getProductCatalogMock.mockRejectedValue(new Error("poll dead"));
 
     render(<WizardStepSelectProduct videoId="gd_test" />);
 
     const err = await screen.findByTestId("poll-error");
-    expect(err.textContent).toContain("network down");
+    expect(err.textContent).toContain("poll dead");
+  });
+
+  it("retry button restarts the polling effect", async () => {
+    // Codex P2 fix: clicking 다시 시도 must trigger fresh API calls.
+    // Pre-fix the button only reset local state — the useEffect's deps
+    // didn't change, so no new triggerEnumeration / getProductCatalog
+    // calls fired and the user was stuck on the loading state forever.
+    triggerEnumerationMock.mockResolvedValue({
+      job_id: "j1",
+      deduped: false,
+    });
+    // First two calls (StrictMode dev double-mount) reject; subsequent
+    // calls (after retry click) return entries.
+    getProductCatalogMock
+      .mockRejectedValueOnce(new Error("poll dead"))
+      .mockRejectedValueOnce(new Error("poll dead"))
+      .mockResolvedValue({ video_id: "gd_test", entries: [SAMPLE_ENTRY] });
+
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+
+    // Wait for the initial failure to surface.
+    const err = await screen.findByTestId("poll-error");
+    expect(err).toBeInTheDocument();
+    const callsBefore = getProductCatalogMock.mock.calls.length;
+
+    // Click retry — this must re-enter the effect and call the catalog
+    // endpoint again (NOT just call router.refresh()).
+    fireEvent.click(screen.getByText("다시 시도"));
+
+    const card = await screen.findByTestId("product-card");
+    expect(card).toBeInTheDocument();
+    expect(getProductCatalogMock.mock.calls.length).toBeGreaterThan(
+      callsBefore,
+    );
   });
 });

--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepSelectProduct.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepSelectProduct.test.tsx
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { WizardStepSelectProduct } from "../pages/WizardStepSelectProduct";
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+const refreshMock = vi.fn();
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ getAccessToken: vi.fn(async () => "test-token") }),
+}));
+
+const triggerEnumerationMock = vi.fn();
+const getProductCatalogMock = vi.fn();
+const createScanOrderMock = vi.fn();
+
+vi.mock("@/lib/api/shorts-auto-product-wizard", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/shorts-auto-product-wizard")
+  >("@/lib/api/shorts-auto-product-wizard");
+  return {
+    ...actual,
+    triggerEnumeration: (...args: unknown[]) =>
+      triggerEnumerationMock(...args),
+    getProductCatalog: (...args: unknown[]) => getProductCatalogMock(...args),
+    createScanOrder: (...args: unknown[]) => createScanOrderMock(...args),
+  };
+});
+
+const VALID_CRITERIA_PARAMS = new URLSearchParams({
+  length: "60",
+  count: "5",
+  distribution: "single",
+  language: "ko",
+  intent: "commit",
+});
+
+const SAMPLE_ENTRY = {
+  catalog_entry_id: "00000000-0000-0000-0000-000000000aaa",
+  label: "테스트 가방",
+  canonical_crop_url: "https://example/crop.jpg",
+  enumeration_confidence: 0.9,
+  prominence_score: 0.8,
+  appearance_count: null,
+};
+
+describe("WizardStepSelectProduct", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    refreshMock.mockReset();
+    triggerEnumerationMock.mockReset();
+    getProductCatalogMock.mockReset();
+    createScanOrderMock.mockReset();
+    mockSearchParams = VALID_CRITERIA_PARAMS;
+  });
+
+  it("kicks off enumeration on mount and renders the loading state", async () => {
+    triggerEnumerationMock.mockResolvedValue({
+      job_id: "j1",
+      deduped: false,
+    });
+    // Empty first poll → still loading.
+    getProductCatalogMock.mockResolvedValue({
+      video_id: "gd_test",
+      entries: [],
+    });
+
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+
+    expect(screen.getByTestId("enumeration-loading")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(triggerEnumerationMock).toHaveBeenCalledTimes(1),
+    );
+    expect(triggerEnumerationMock.mock.calls[0][0]).toBe("gd_test");
+    expect(triggerEnumerationMock.mock.calls[0][1]).toEqual({
+      duration_preset_sec: 60,
+    });
+  });
+
+  it("renders the product grid when polling returns entries", async () => {
+    triggerEnumerationMock.mockResolvedValue({
+      job_id: "j1",
+      deduped: true,
+    });
+    getProductCatalogMock.mockResolvedValue({
+      video_id: "gd_test",
+      entries: [SAMPLE_ENTRY],
+    });
+
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+
+    const card = await screen.findByTestId("product-card");
+    expect(card).toBeInTheDocument();
+    expect(card.textContent).toContain("테스트 가방");
+  });
+
+  it("submits createScanOrder with catalog_entry_id when Next clicked", async () => {
+    triggerEnumerationMock.mockResolvedValue({
+      job_id: "j1",
+      deduped: true,
+    });
+    getProductCatalogMock.mockResolvedValue({
+      video_id: "gd_test",
+      entries: [SAMPLE_ENTRY],
+    });
+    createScanOrderMock.mockResolvedValue({
+      parent_job_id: "00000000-0000-0000-0000-000000000123",
+      deduped: false,
+    });
+
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+
+    const card = await screen.findByTestId("product-card");
+    // Next is disabled until a card is selected.
+    const nextBefore = screen.getByTestId(
+      "wizard-next",
+    ) as HTMLButtonElement;
+    expect(nextBefore.disabled).toBe(true);
+
+    fireEvent.click(card);
+    const nextAfter = screen.getByTestId(
+      "wizard-next",
+    ) as HTMLButtonElement;
+    expect(nextAfter.disabled).toBe(false);
+
+    fireEvent.click(nextAfter);
+
+    await waitFor(() => expect(createScanOrderMock).toHaveBeenCalledTimes(1));
+    expect(createScanOrderMock.mock.calls[0][0]).toBe("gd_test");
+    expect(createScanOrderMock.mock.calls[0][1]).toMatchObject({
+      length_seconds: 60,
+      requested_count: 5,
+      product_distribution: "single",
+      language: "ko",
+      intent: "commit",
+      catalog_entry_id: SAMPLE_ENTRY.catalog_entry_id,
+    });
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith(
+        "/export/shorts/auto/wizard/gd_test/result/00000000-0000-0000-0000-000000000123",
+      ),
+    );
+  });
+
+  it("redirects to /criteria when URL params are missing", () => {
+    mockSearchParams = new URLSearchParams(); // no length / count / etc.
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/export/shorts/auto/wizard/gd_test/criteria",
+    );
+    // Critically: no API calls fire on the bad-params path.
+    expect(triggerEnumerationMock).not.toHaveBeenCalled();
+    expect(getProductCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the error state when triggerEnumeration rejects", async () => {
+    // Use mockRejectedValue (not …Once) because React 18+ strict-mode
+    // mounts the effect twice in dev/test; both runs must reject for
+    // the assertion to find the original error message.
+    triggerEnumerationMock.mockRejectedValue(new Error("network down"));
+
+    render(<WizardStepSelectProduct videoId="gd_test" />);
+
+    const err = await screen.findByTestId("poll-error");
+    expect(err.textContent).toContain("network down");
+  });
+});

--- a/services/web/src/features/shorts-auto-product-wizard/components/WizardLayout.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/components/WizardLayout.tsx
@@ -14,7 +14,7 @@ import type { ReactNode } from "react";
 const STEPS = [
   { idx: 1, label: "동영상 선택" },
   { idx: 2, label: "생성 기준 설정" },
-  { idx: 3, label: "쇼츠 가편집본" },
+  { idx: 3, label: "제품 선택" },
   { idx: 4, label: "쇼츠 자동 생성" },
 ] as const;
 

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepCriteria.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepCriteria.tsx
@@ -19,14 +19,6 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import { useAuth } from "@/lib/auth";
-import {
-  WizardBudgetExceededError,
-  WizardFeatureDisabledError,
-  WizardRateLimitError,
-  WizardValidationError,
-  createScanOrder,
-} from "@/lib/api/shorts-auto-product-wizard";
 import type {
   Language,
   ProductDistribution,
@@ -59,7 +51,6 @@ function parseMmSsToMs(raw: string): number | null {
 
 export function WizardStepCriteria({ videoId }: Props) {
   const router = useRouter();
-  const { getAccessToken } = useAuth();
 
   // Form state — defaults match the most-common preset choices.
   const [lengthSeconds, setLengthSeconds] = useState<number>(60);
@@ -70,62 +61,42 @@ export function WizardStepCriteria({ videoId }: Props) {
     useState<ProductDistribution>("single");
   const [language, setLanguage] = useState<Language>("ko");
 
-  // Submission state
-  const [submitting, setSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
   // Inline aggregate-cap warning (server enforces; this is an early hint).
   const aggregateSeconds = lengthSeconds * requestedCount;
   const exceedsAggregateCap = aggregateSeconds > 1800;
 
-  const handleSubmit = async () => {
-    setErrorMessage(null);
-    setSubmitting(true);
-    try {
-      const response = await createScanOrder(
-        videoId,
-        {
-          length_seconds: lengthSeconds,
-          requested_count: requestedCount,
-          time_range_start_ms: parseMmSsToMs(rangeStartRaw),
-          time_range_end_ms: parseMmSsToMs(rangeEndRaw),
-          product_distribution: distribution,
-          language,
-          intent: "commit", // Phase 4: skip preview, go straight to commit
-        },
-        getAccessToken,
-      );
-      router.push(
-        `/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/result/${encodeURIComponent(response.parent_job_id)}`,
-      );
-    } catch (err) {
-      if (err instanceof WizardValidationError) {
-        setErrorMessage(`입력 오류: ${err.message}`);
-      } else if (err instanceof WizardBudgetExceededError) {
-        setErrorMessage(`일일 비용 한도 초과: ${err.message}`);
-      } else if (err instanceof WizardRateLimitError) {
-        setErrorMessage(`동시 실행 한도 초과: ${err.message}`);
-      } else if (err instanceof WizardFeatureDisabledError) {
-        setErrorMessage("이 조직에는 마법사 기능이 활성화되지 않았습니다.");
-      } else {
-        setErrorMessage(
-          err instanceof Error ? err.message : "Unknown error",
-        );
-      }
-    } finally {
-      setSubmitting(false);
-    }
+  // Phase B: criteria step is no longer a submission point — it just
+  // collects inputs and forwards them to the product-select step via
+  // URL search params. The actual createScanOrder call happens AFTER
+  // the user picks a catalog entry on /select-product, so the body
+  // gets ``catalog_entry_id`` baked in. Validation errors (422 / 402 /
+  // 429 / 404) surface on the select-product step instead.
+  const handleNext = () => {
+    const startMs = parseMmSsToMs(rangeStartRaw);
+    const endMs = parseMmSsToMs(rangeEndRaw);
+    const params = new URLSearchParams({
+      length: String(lengthSeconds),
+      count: String(requestedCount),
+      distribution,
+      language,
+      intent: "commit",
+    });
+    if (startMs !== null) params.set("start", String(startMs));
+    if (endMs !== null) params.set("end", String(endMs));
+    router.push(
+      `/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/select-product?${params.toString()}`,
+    );
   };
 
-  const canSubmit = !submitting && !exceedsAggregateCap;
+  const canSubmit = !exceedsAggregateCap;
 
   return (
     <WizardLayout
       currentStep={2}
       heading="생성 기준을 선택하고, '다음'버튼을 클릭하세요"
       next={{
-        label: submitting ? "생성 중..." : "다음 >",
-        onClick: handleSubmit,
+        label: "다음 >",
+        onClick: handleNext,
         disabled: !canSubmit,
       }}
       backHref="/export/shorts/auto/wizard"
@@ -181,15 +152,6 @@ export function WizardStepCriteria({ videoId }: Props) {
             총 출력 길이 한도(30분) 초과: {requestedCount}개 ×{" "}
             {lengthSeconds}초 = {aggregateSeconds}초. 개수 또는 길이를
             줄여주세요.
-          </p>
-        ) : null}
-
-        {errorMessage ? (
-          <p
-            className="rounded-md bg-red-50 p-3 text-sm text-red-700"
-            data-testid="error-message"
-          >
-            {errorMessage}
           </p>
         ) : null}
       </div>

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct.tsx
@@ -1,0 +1,366 @@
+// ============================================================================
+// Step 3 — 제품 선택 (product select)
+//
+// On mount: kick off enumeration (idempotent — POST /products/{id}/scan
+// dedupes via the v1 service's in-flight check) and poll the catalog
+// every 5s until entries arrive or the timeout fires. User picks one
+// product card; "다음" submits the scan_order with catalog_entry_id baked
+// in. Worker filters its catalog fetch to that single entry (Phase A
+// backend in PR #134).
+//
+// Criteria values flow in via URL search params (Criteria → SelectProduct
+// is one-way; back-navigation loses the form — Phase D polish will add
+// URL-param prefill on the Criteria step). The values are passed through
+// to createScanOrder verbatim.
+// ============================================================================
+
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  WizardBudgetExceededError,
+  WizardFeatureDisabledError,
+  WizardRateLimitError,
+  WizardValidationError,
+  createScanOrder,
+  getProductCatalog,
+  triggerEnumeration,
+} from "@/lib/api/shorts-auto-product-wizard";
+import { useAuth } from "@/lib/auth";
+import type {
+  CatalogProductSummary,
+  Language,
+  ProductDistribution,
+  ScanIntent,
+} from "@/lib/types/shorts-auto-product-wizard";
+
+import { WizardLayout } from "../components/WizardLayout";
+
+interface Props {
+  videoId: string;
+}
+
+const POLL_INTERVAL_MS = 5_000;
+// Enumeration on a typical 5–10 min livecommerce VOD takes 30–90s on
+// the warm Aircloud container; 3 min ceiling covers cold-start +
+// HuggingFace download on a fresh container without waiting forever.
+const POLL_TIMEOUT_MS = 180_000;
+
+interface ParsedCriteria {
+  length_seconds: number;
+  requested_count: number;
+  time_range_start_ms: number | null;
+  time_range_end_ms: number | null;
+  product_distribution: ProductDistribution;
+  language: Language;
+  intent: ScanIntent;
+}
+
+/**
+ * Read URL search params into the criteria shape. Returns null when any
+ * required field is missing or out of range — caller redirects back to
+ * the criteria step. Values are clamped to the same bounds the backend
+ * validates so a malformed URL doesn't 422 us silently mid-submit.
+ */
+function parseCriteriaFromUrl(
+  params: URLSearchParams,
+): ParsedCriteria | null {
+  const length = Number(params.get("length"));
+  const count = Number(params.get("count"));
+  const dist = params.get("distribution");
+  const lang = params.get("language");
+  const intent = params.get("intent") ?? "commit";
+  if (!Number.isInteger(length) || length < 10 || length > 120) return null;
+  if (!Number.isInteger(count) || count < 1 || count > 50) return null;
+  if (dist !== "single" && dist !== "multi") return null;
+  if (lang !== "ko" && lang !== "en") return null;
+  if (intent !== "commit" && intent !== "preview") return null;
+  const startRaw = params.get("start");
+  const endRaw = params.get("end");
+  const start = startRaw && startRaw !== "" ? Number(startRaw) : null;
+  const end = endRaw && endRaw !== "" ? Number(endRaw) : null;
+  return {
+    length_seconds: length,
+    requested_count: count,
+    time_range_start_ms: start,
+    time_range_end_ms: end,
+    product_distribution: dist,
+    language: lang,
+    intent,
+  };
+}
+
+export function WizardStepSelectProduct({ videoId }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { getAccessToken } = useAuth();
+
+  // Criteria from URL — if missing/malformed, kick back to step 2.
+  // Convert Next's ReadonlyURLSearchParams → standard URLSearchParams
+  // so the pure helper has no Next.js coupling (and stays unit-testable).
+  const criteria = parseCriteriaFromUrl(
+    new URLSearchParams(searchParams?.toString() ?? ""),
+  );
+
+  const [entries, setEntries] = useState<CatalogProductSummary[]>([]);
+  const [pollState, setPollState] = useState<
+    "enumerating" | "ready" | "no_products" | "error"
+  >("enumerating");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  // Ref + state separation: state for re-render, ref for the polling
+  // closure to read latest selection without re-creating the interval.
+  const startedAtRef = useRef<number>(Date.now());
+
+  // Single effect handles both: trigger enumeration once, then poll
+  // catalog. Combining them avoids a flicker where the catalog endpoint
+  // 200s with empty entries before enumeration even fires.
+  useEffect(() => {
+    if (!criteria) {
+      router.replace(
+        `/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/criteria`,
+      );
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const resp = await getProductCatalog(videoId, getAccessToken);
+        if (cancelled) return;
+        if (resp.entries.length > 0) {
+          setEntries(resp.entries);
+          setPollState("ready");
+          return; // stop polling
+        }
+        if (Date.now() - startedAtRef.current >= POLL_TIMEOUT_MS) {
+          setPollState("no_products");
+          return;
+        }
+        timer = setTimeout(poll, POLL_INTERVAL_MS);
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMessage(
+          err instanceof Error ? err.message : "카탈로그 로드 실패",
+        );
+        setPollState("error");
+      }
+    };
+
+    const start = async () => {
+      try {
+        await triggerEnumeration(
+          videoId,
+          { duration_preset_sec: 60 },
+          getAccessToken,
+        );
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMessage(
+          err instanceof Error ? err.message : "제품 스캔 시작 실패",
+        );
+        setPollState("error");
+        return;
+      }
+      // Fire the first poll immediately — covers the common case where
+      // the catalog was already populated from a prior wizard run on
+      // the same video (deduped triggerEnumeration returns instantly).
+      void poll();
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+    // criteria reference changes on every render (parseCriteriaFromUrl
+    // returns a new object); we only care about videoId stability.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [videoId, getAccessToken, router]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!criteria || !selectedId) return;
+    setErrorMessage(null);
+    setSubmitting(true);
+    try {
+      const response = await createScanOrder(
+        videoId,
+        { ...criteria, catalog_entry_id: selectedId },
+        getAccessToken,
+      );
+      router.push(
+        `/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/result/${encodeURIComponent(response.parent_job_id)}`,
+      );
+    } catch (err) {
+      if (err instanceof WizardValidationError) {
+        setErrorMessage(`입력 오류: ${err.message}`);
+      } else if (err instanceof WizardBudgetExceededError) {
+        setErrorMessage(`일일 비용 한도 초과: ${err.message}`);
+      } else if (err instanceof WizardRateLimitError) {
+        setErrorMessage(`동시 실행 한도 초과: ${err.message}`);
+      } else if (err instanceof WizardFeatureDisabledError) {
+        setErrorMessage("이 조직에는 마법사 기능이 활성화되지 않았습니다.");
+      } else {
+        setErrorMessage(err instanceof Error ? err.message : "Unknown error");
+      }
+      setSubmitting(false);
+    }
+  }, [criteria, selectedId, videoId, getAccessToken, router]);
+
+  // Pass criteria back through to /criteria so the user can adjust
+  // without losing it. Same URL params shape this page reads on mount.
+  const backHref = criteria
+    ? `/export/shorts/auto/wizard/${encodeURIComponent(videoId)}/criteria`
+    : `/export/shorts/auto/wizard`;
+
+  return (
+    <WizardLayout
+      currentStep={3}
+      heading="쇼츠 주제로 사용할 제품을 선택하세요"
+      next={{
+        label: submitting ? "생성 중..." : "다음 >",
+        onClick: handleSubmit,
+        disabled: !selectedId || submitting || pollState !== "ready",
+      }}
+      backHref={backHref}
+    >
+      {pollState === "enumerating" ? (
+        <div
+          className="space-y-3 rounded-lg border border-gray-200 bg-white p-6 text-center"
+          data-testid="enumeration-loading"
+        >
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent" />
+          <p className="text-sm text-gray-700">
+            영상에서 제품을 찾고 있어요... (보통 30–90초 소요)
+          </p>
+          <p className="text-xs text-gray-500">
+            이미 스캔한 영상이라면 즉시 결과가 표시됩니다.
+          </p>
+        </div>
+      ) : null}
+
+      {pollState === "no_products" ? (
+        <div
+          className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-6"
+          data-testid="no-products"
+        >
+          <h2 className="text-lg font-semibold text-amber-900">
+            제품을 찾을 수 없어요
+          </h2>
+          <p className="text-sm text-amber-800">
+            이 영상에서 자동으로 인식할 수 있는 제품이 없습니다. 다른
+            영상을 선택하거나, 영상에 제품이 잘 보이는 시간 구간을
+            지정해 보세요.
+          </p>
+        </div>
+      ) : null}
+
+      {pollState === "error" ? (
+        <div
+          className="space-y-3 rounded-lg border border-red-200 bg-red-50 p-6"
+          data-testid="poll-error"
+        >
+          <h2 className="text-lg font-semibold text-red-900">
+            제품 스캔에 실패했어요
+          </h2>
+          <p className="text-sm text-red-800">
+            {errorMessage ?? "잠시 후 다시 시도해 주세요."}
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              startedAtRef.current = Date.now();
+              setEntries([]);
+              setSelectedId(null);
+              setErrorMessage(null);
+              setPollState("enumerating");
+              router.refresh();
+            }}
+            className="rounded-md bg-red-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+          >
+            다시 시도
+          </button>
+        </div>
+      ) : null}
+
+      {pollState === "ready" ? (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            아래 제품 중 하나를 클릭해 선택하세요.
+          </p>
+          <div
+            className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4"
+            data-testid="product-grid"
+          >
+            {entries.map((entry) => {
+              const isSelected = entry.catalog_entry_id === selectedId;
+              return (
+                <button
+                  key={entry.catalog_entry_id}
+                  type="button"
+                  onClick={() => setSelectedId(entry.catalog_entry_id)}
+                  className={[
+                    "group flex flex-col gap-2 rounded-lg border bg-white p-3 text-left transition",
+                    isSelected
+                      ? "border-indigo-500 ring-2 ring-indigo-200"
+                      : "border-gray-200 hover:border-indigo-300",
+                  ].join(" ")}
+                  data-testid="product-card"
+                  data-selected={isSelected}
+                >
+                  <div className="aspect-square overflow-hidden rounded bg-gray-100">
+                    {entry.canonical_crop_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={entry.canonical_crop_url}
+                        alt={entry.label}
+                        className="h-full w-full object-cover transition group-hover:scale-105"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="flex h-full items-center justify-center text-xs text-gray-400">
+                        이미지 없음
+                      </div>
+                    )}
+                  </div>
+                  <p
+                    className="line-clamp-2 text-sm font-medium text-gray-900"
+                    title={entry.label}
+                  >
+                    {entry.label}
+                  </p>
+                  <div className="flex items-center gap-2 text-xs text-gray-500">
+                    <span>인식 신뢰도</span>
+                    <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200">
+                      <div
+                        className="h-full bg-indigo-400"
+                        style={{
+                          width: `${Math.round(entry.enumeration_confidence * 100)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          {errorMessage ? (
+            <p
+              className="rounded-md bg-red-50 p-3 text-sm text-red-700"
+              data-testid="submit-error"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </WizardLayout>
+  );
+}

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct.tsx
@@ -111,11 +111,15 @@ export function WizardStepSelectProduct({ videoId }: Props) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // Bumped by the "다시 시도" button to re-enter the effect — without
+  // this, retry would only reset local state and the polling closure
+  // would never re-fire (codex P2, Phase B follow-up).
+  const [retryCount, setRetryCount] = useState(0);
   // Ref + state separation: state for re-render, ref for the polling
   // closure to read latest selection without re-creating the interval.
   const startedAtRef = useRef<number>(Date.now());
 
-  // Single effect handles both: trigger enumeration once, then poll
+  // Single effect handles both: trigger enumeration, then poll
   // catalog. Combining them avoids a flicker where the catalog endpoint
   // 200s with empty entries before enumeration even fires.
   useEffect(() => {
@@ -154,6 +158,12 @@ export function WizardStepSelectProduct({ videoId }: Props) {
     };
 
     const start = async () => {
+      // Trigger is best-effort: if it transiently fails (network blip,
+      // service hiccup) but the video already has a catalog from a
+      // prior wizard run, the user can still pick from the cached
+      // entries. Don't terminate on trigger failure — let the catalog
+      // poll be the source of truth. The poll's own error / timeout
+      // paths handle the "no cached catalog AND trigger failed" case.
       try {
         await triggerEnumeration(
           videoId,
@@ -162,11 +172,11 @@ export function WizardStepSelectProduct({ videoId }: Props) {
         );
       } catch (err) {
         if (cancelled) return;
-        setErrorMessage(
-          err instanceof Error ? err.message : "제품 스캔 시작 실패",
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[wizard] triggerEnumeration failed; will still poll catalog",
+          err,
         );
-        setPollState("error");
-        return;
       }
       // Fire the first poll immediately — covers the common case where
       // the catalog was already populated from a prior wizard run on
@@ -182,8 +192,11 @@ export function WizardStepSelectProduct({ videoId }: Props) {
     };
     // criteria reference changes on every render (parseCriteriaFromUrl
     // returns a new object); we only care about videoId stability.
+    // retryCount is in the deps so the "다시 시도" button can re-enter
+    // this effect (codex P2). router.refresh() alone is insufficient —
+    // it doesn't change deps, so the effect wouldn't re-fire.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [videoId, getAccessToken, router]);
+  }, [videoId, getAccessToken, router, retryCount]);
 
   const handleSubmit = useCallback(async () => {
     if (!criteria || !selectedId) return;
@@ -281,7 +294,11 @@ export function WizardStepSelectProduct({ videoId }: Props) {
               setSelectedId(null);
               setErrorMessage(null);
               setPollState("enumerating");
-              router.refresh();
+              // Bumps the effect's deps → re-fires triggerEnumeration +
+              // poll. router.refresh() would re-fetch the RSC tree but
+              // wouldn't re-key the client effect, leaving the user on
+              // the loading state with no new API calls.
+              setRetryCount((n) => n + 1);
             }}
             className="rounded-md bg-red-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-700"
           >

--- a/services/web/src/lib/api/shorts-auto-product-wizard.ts
+++ b/services/web/src/lib/api/shorts-auto-product-wizard.ts
@@ -11,6 +11,9 @@
 // ============================================================================
 
 import type {
+  ProductCatalogResponse,
+  ProductScanRequest,
+  ProductScanResponse,
   ScanOrderCreateRequest,
   ScanOrderResponse,
   ScanOrderStatusResponse,
@@ -164,4 +167,76 @@ export async function cancelScanOrder(
   if (!res.ok) {
     throw new Error(`cancelScanOrder failed: ${await detailMessage(res)}`);
   }
+}
+
+// ----------------------------------------------------------------------
+// POST /api/shorts/auto/products/{video_id}/scan
+//
+// V1 enumeration trigger — wizard's product-select step calls this on
+// mount. Idempotent: an in-flight enumeration returns the same job id
+// with deduped=true (no duplicate cost). Frontend ignores the job id
+// and just polls getProductCatalog for the resulting entries.
+// ----------------------------------------------------------------------
+
+export async function triggerEnumeration(
+  videoId: string,
+  body: ProductScanRequest,
+  tokenGetter: TokenGetter,
+): Promise<ProductScanResponse> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/shorts/auto/products/${encodeURIComponent(videoId)}/scan`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: await authHeader(tokenGetter),
+      body: JSON.stringify(body),
+    },
+  );
+  if (res.status === 404) {
+    throw new WizardFeatureDisabledError(
+      "Product mode v2 is not enabled for this org",
+    );
+  }
+  if (res.status === 402) {
+    throw new WizardBudgetExceededError(await detailMessage(res));
+  }
+  if (res.status === 429) {
+    throw new WizardRateLimitError(await detailMessage(res));
+  }
+  if (!res.ok) {
+    throw new Error(`triggerEnumeration failed: ${await detailMessage(res)}`);
+  }
+  return (await res.json()) as ProductScanResponse;
+}
+
+// ----------------------------------------------------------------------
+// GET /api/shorts/auto/products/{video_id}
+//
+// Polled every 5s by the product-select step. Returns the active
+// catalog (non-rejected entries). Empty entries[] means enumeration
+// is still in flight (or genuinely found no products — caller
+// distinguishes via a max-poll-duration timeout).
+// ----------------------------------------------------------------------
+
+export async function getProductCatalog(
+  videoId: string,
+  tokenGetter: TokenGetter,
+): Promise<ProductCatalogResponse> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/shorts/auto/products/${encodeURIComponent(videoId)}`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: await authHeader(tokenGetter),
+    },
+  );
+  if (res.status === 404) {
+    throw new WizardFeatureDisabledError(
+      "Product mode v2 is not enabled for this org",
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`getProductCatalog failed: ${await detailMessage(res)}`);
+  }
+  return (await res.json()) as ProductCatalogResponse;
 }

--- a/services/web/src/lib/types/shorts-auto-product-wizard.ts
+++ b/services/web/src/lib/types/shorts-auto-product-wizard.ts
@@ -53,6 +53,53 @@ export interface ScanOrderCreateRequest {
   product_distribution: ProductDistribution;
   language: Language;
   intent: ScanIntent;
+  // Optional pre-tracking pick from the wizard's product-select step.
+  // When set, the worker filters its catalog fetch to this single
+  // entry instead of looping over the whole active catalog. NULL =
+  // legacy whole-catalog round-robin.
+  catalog_entry_id?: string | null;
+}
+
+// ----------------------------------------------------------------------
+// V1 product catalog endpoints — used by the wizard's product-select
+// step to trigger enumeration and poll for the resulting catalog.
+// ----------------------------------------------------------------------
+
+/**
+ * Body for ``POST /api/shorts/auto/products/{video_id}/scan``.
+ * One field — kept compact since the wizard always uses 60s presets;
+ * the wizard's wizard-level length_seconds is captured separately on
+ * the scan_order.
+ */
+export interface ProductScanRequest {
+  duration_preset_sec: 30 | 60 | 90;
+}
+
+/** Response for ``POST /api/shorts/auto/products/{video_id}/scan``. */
+export interface ProductScanResponse {
+  job_id: string;
+  /**
+   * True when an in-flight enumerate job already covers this video —
+   * the same parent gets returned, no duplicate work / no extra cost.
+   */
+  deduped: boolean;
+}
+
+/** A single enumerated product in the catalog (gallery shape). */
+export interface CatalogProductSummary {
+  catalog_entry_id: string;
+  label: string;
+  canonical_crop_url: string | null;
+  enumeration_confidence: number;
+  prominence_score: number;
+  /** Populated only AFTER tracking — null during enumeration polling. */
+  appearance_count: number | null;
+}
+
+/** Response for ``GET /api/shorts/auto/products/{video_id}``. */
+export interface ProductCatalogResponse {
+  video_id: string;
+  entries: CatalogProductSummary[];
 }
 
 export interface ScanOrderResponse {


### PR DESCRIPTION
## Summary

Phase B of the wizard product-select feature. Wires the frontend to
[Phase A's backend (PR #134)](https://github.com/jlee-heimdex/heimdex-for-livecommerce-dev/pull/134)
so the wizard can:

1. Trigger enumeration on the picked video (`POST /products/{id}/scan`)
2. Poll the catalog every 5s until products appear
3. Render a grid of enumerated products with thumbnail + label + confidence bar
4. Submit the scan_order with the user's pick baked in (`POST /scan-orders/videos/{id}` with `catalog_entry_id`)

Replaces the Phase 6-stub PreviewStub at step 3 (label changes from "쇼츠 가편집본" to "제품 선택"). The criteria step's "다음" no longer calls `createScanOrder` — it just forwards the form values to `/select-product` as URL search params.

## ⚠️ Depends on PR #134

`ScanOrderCreateRequest` schema uses `extra="forbid"`, so the frontend submitting `catalog_entry_id` REQUIRES PR #134 to be deployed on the same staging environment. PR #134 is already merged and the GHCR image rebuilt.

## Surface area

| File | Change |
|---|---|
| `WizardStepSelectProduct.tsx` (new) | Full step component with loading / ready / no_products / error pollState machine. 5s poll interval, 3-min timeout. |
| `select-product/page.tsx` (new) | Next.js route, mirrors `/preview/page.tsx` pattern |
| `WizardLayout.tsx` | Step 3 label: "쇼츠 가편집본" → "제품 선택" |
| `WizardStepCriteria.tsx` | `handleSubmit` now navigates to `/select-product?length=…&count=…` instead of calling createScanOrder. Drops Wizard*Error imports + inline error state |
| `lib/api/shorts-auto-product-wizard.ts` | `triggerEnumeration` and `getProductCatalog` (mirrors existing client style) |
| `lib/types/shorts-auto-product-wizard.ts` | Optional `catalog_entry_id` on `ScanOrderCreateRequest`, plus `ProductScan*` and `CatalogProductSummary` / `ProductCatalogResponse` |

## Tests (vitest)

- `WizardStepCriteria.test.tsx` (rewritten) — 5 tests; submit-API tests gone (no longer applicable), replaced by navigation-with-URL-params tests
- `WizardStepSelectProduct.test.tsx` (new) — 5 tests covering happy path (enumerate → poll → grid → pick → submit → navigate), missing-criteria-params redirect, rejection, and "Next disabled until card selected"

**Total wizard suite: 21/21 vitest tests pass. `tsc --noEmit` clean.**

## Behavior notes

- **Enumeration trigger is idempotent** on the v1 service side — safe to fire on every mount; in-flight enumerate returns same job_id with `deduped=true`
- The 5s poll cadence is chosen over 3s (which `useScanOrder` uses for result-page polling) because enumeration's slow path doesn't have child stages that transition faster than 5s
- Going back from `/select-product` → `/criteria` currently loses the form (Criteria doesn't read URL params yet). Phase D polish will add prefill for symmetry
- The SAM2-free preview Phase 6 deliverable (the OLD step 3) is NOT deleted — `PreviewStub.tsx` and `/preview/page.tsx` remain orphaned; Phase 6 can wire them as a sub-step or replace differently

## What's deferred (Phase D)

- Loading skeleton for the product grid (currently a spinner)
- "Rescan" button on the catalog screen for staleness recovery
- URL-param prefill on Criteria (so back-navigation preserves form)
- i18n KR/EN strings (currently KR-only)
- Keyboard nav for the grid

## Test plan

- [x] All 21 wizard vitest tests pass
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] After merge: real wizard submission on staging end-to-end:
  1. Submit a fresh wizard with a video that has NO prior enumeration
  2. SelectProduct shows the loading spinner
  3. Enumeration completes → product grid renders
  4. Click a product → "다음" enables
  5. Click "다음" → scan order created with `catalog_entry_id`
  6. Result page shows the parent transitioning out of `queued` → `tracking` → `done`/`failed`