### PR TITLE
fix(wizard): align ProductCatalogResponse type with the actual API shape

### DIFF
--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepSelectProduct.test.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/WizardStepSelectProduct.test.tsx
@@ -53,7 +53,9 @@ const SAMPLE_ENTRY = {
   canonical_crop_url: "https://example/crop.jpg",
   enumeration_confidence: 0.9,
   prominence_score: 0.8,
+  has_track_data: false,
   appearance_count: null,
+  total_appearance_seconds: null,
 };
 
 describe("WizardStepSelectProduct", () => {
@@ -75,7 +77,7 @@ describe("WizardStepSelectProduct", () => {
     // Empty first poll → still loading.
     getProductCatalogMock.mockResolvedValue({
       video_id: "gd_test",
-      entries: [],
+      products: [],
     });
 
     render(<WizardStepSelectProduct videoId="gd_test" />);
@@ -97,7 +99,7 @@ describe("WizardStepSelectProduct", () => {
     });
     getProductCatalogMock.mockResolvedValue({
       video_id: "gd_test",
-      entries: [SAMPLE_ENTRY],
+      products: [SAMPLE_ENTRY],
     });
 
     render(<WizardStepSelectProduct videoId="gd_test" />);
@@ -114,7 +116,7 @@ describe("WizardStepSelectProduct", () => {
     });
     getProductCatalogMock.mockResolvedValue({
       video_id: "gd_test",
-      entries: [SAMPLE_ENTRY],
+      products: [SAMPLE_ENTRY],
     });
     createScanOrderMock.mockResolvedValue({
       parent_job_id: "00000000-0000-0000-0000-000000000123",
@@ -174,7 +176,7 @@ describe("WizardStepSelectProduct", () => {
     triggerEnumerationMock.mockRejectedValue(new Error("transient blip"));
     getProductCatalogMock.mockResolvedValue({
       video_id: "gd_test",
-      entries: [SAMPLE_ENTRY],
+      products: [SAMPLE_ENTRY],
     });
 
     render(<WizardStepSelectProduct videoId="gd_test" />);
@@ -214,7 +216,7 @@ describe("WizardStepSelectProduct", () => {
     getProductCatalogMock
       .mockRejectedValueOnce(new Error("poll dead"))
       .mockRejectedValueOnce(new Error("poll dead"))
-      .mockResolvedValue({ video_id: "gd_test", entries: [SAMPLE_ENTRY] });
+      .mockResolvedValue({ video_id: "gd_test", products: [SAMPLE_ENTRY] });
 
     render(<WizardStepSelectProduct videoId="gd_test" />);
 

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepSelectProduct.tsx
@@ -138,10 +138,25 @@ export function WizardStepSelectProduct({ videoId }: Props) {
       try {
         const resp = await getProductCatalog(videoId, getAccessToken);
         if (cancelled) return;
-        if (resp.entries.length > 0) {
-          setEntries(resp.entries);
+        if (resp.products.length > 0) {
+          setEntries(resp.products);
           setPollState("ready");
           return; // stop polling
+        }
+        // scan_status drives the empty-products decisions:
+        //   * failed   → terminal error (don't wait for the 3-min timeout)
+        //   * complete → enumeration ran and found nothing — terminal
+        //   * never / in_progress → keep polling until the timeout
+        if (resp.scan_status === "failed") {
+          setErrorMessage(
+            "이전 스캔이 실패했어요. 다시 시도해 주세요.",
+          );
+          setPollState("error");
+          return;
+        }
+        if (resp.scan_status === "complete") {
+          setPollState("no_products");
+          return;
         }
         if (Date.now() - startedAtRef.current >= POLL_TIMEOUT_MS) {
           setPollState("no_products");

--- a/services/web/src/lib/types/shorts-auto-product-wizard.ts
+++ b/services/web/src/lib/types/shorts-auto-product-wizard.ts
@@ -89,17 +89,36 @@ export interface ProductScanResponse {
 export interface CatalogProductSummary {
   catalog_entry_id: string;
   label: string;
-  canonical_crop_url: string | null;
+  // Required by the API (Field(..., min_length=1)); it's the product
+  // thumbnail the wizard renders. NEVER null in practice.
+  canonical_crop_url: string;
   enumeration_confidence: number;
   prominence_score: number;
+  /** True after the user picked this product and tracking ran. */
+  has_track_data: boolean;
   /** Populated only AFTER tracking — null during enumeration polling. */
   appearance_count: number | null;
+  total_appearance_seconds: number | null;
 }
+
+/**
+ * Lifecycle of the catalog from the user's POV — drives the wizard's
+ * polling decisions much more cleanly than guessing from
+ * ``products.length``: an empty list with ``scan_status='never'`` means
+ * "trigger me", with ``in_progress`` means "still scanning", with
+ * ``complete`` means "scan ran but found nothing", with ``failed``
+ * means "show the user the failure".
+ */
+export type ScanStatus = "never" | "in_progress" | "complete" | "failed";
 
 /** Response for ``GET /api/shorts/auto/products/{video_id}``. */
 export interface ProductCatalogResponse {
   video_id: string;
-  entries: CatalogProductSummary[];
+  scan_status: ScanStatus;
+  scan_job_id: string | null;
+  enumeration_version: string | null;
+  enumeration_prompt_version: string | null;
+  products: CatalogProductSummary[];
 }
 
 export interface ScanOrderResponse {


### PR DESCRIPTION
## Summary

User-reported error on staging:
```
Cannot read properties of undefined (reading 'length')
```
when visiting the new wizard product-select step
([Phase B / PR #135](https://github.com/jlee-heimdex/heimdex-for-livecommerce-dev/pull/135)).

**Root cause**: my Phase B `ProductCatalogResponse` type guessed the
catalog field name as `entries`, but the actual API
([schemas.py:97](https://github.com/jlee-heimdex/heimdex-for-livecommerce-dev/blob/main/services/api/app/modules/shorts_auto_product/schemas.py#L97))
returns `products`. The polling code did `resp.entries.length > 0` —
`resp.entries` was undefined → crash. Frontend tests were shape-blind
(they passed because the mock matched the wrong type), so the contract
gap surfaced only on the first real-server request.

## Type fixes

`ProductCatalogResponse`:
- `entries` → `products` (the real field name)
- Added `scan_status: ScanStatus` (drives polling decisions —
  `failed` / `complete` / `in_progress` / `never`)
- Added the auxiliary metadata the API returns: `scan_job_id`,
  `enumeration_version`, `enumeration_prompt_version`

`CatalogProductSummary`:
- `canonical_crop_url` is now `string` (not `string | null`) — backend
  declares `Field(..., min_length=1)`, never null
- Added `has_track_data: boolean` and
  `total_appearance_seconds: number | null` — present on every
  response, just unused by the wizard today

Added `ScanStatus` literal type (mirrors backend Literal exactly).

## Free behavior tightening

Now that the polling loop has `scan_status`, it terminates early on:
- `scan_status === "failed"` — no more 3-min timeout for known-failed scans
- `scan_status === "complete"` with empty products — no more 3-min wait
  for "this video has no products" (the backend already knows)

Otherwise the loop falls through to the prior timeout logic.

## Tests

`WizardStepSelectProduct.test.tsx`:
- `SAMPLE_ENTRY` shape updated to match the corrected `CatalogProductSummary`
- All 5 mock responses use `products:` (was `entries:`)
- Existing 7 tests still pass — they were behaviorally correct, just shape-blind

23/23 wizard vitest pass; `tsc --noEmit` clean.

## Test plan

- [x] All 23 wizard tests pass
- [x] tsc clean
- [ ] CI green
- [ ] After merge + staging deploy: re-attempt the wizard at
  `https://devorg.app.heimdexdemo.dev/export/shorts/auto/wizard/gd_d2e6142de1e19704/criteria`
  → submit criteria → SelectProduct step renders without the crash