### PR TITLE
fix(api): use extra={} for stdlib logger calls in shorts_auto_product internal_router

### DIFF
--- a/services/api/app/modules/shorts_auto_product/internal_router.py
+++ b/services/api/app/modules/shorts_auto_product/internal_router.py
@@ -432,10 +432,12 @@ async def complete(
             if drive_file is None:
                 logger.info(
                     "product_v2_scan_order_video_no_longer_available",
-                    parent_job_id=str(job_id),
-                    video_id=str(job.video_id),
-                    org_id=str(job.org_id),
-                    persisted_appearances=persisted_appearances,
+                    extra={
+                        "parent_job_id": str(job_id),
+                        "video_id": str(job.video_id),
+                        "org_id": str(job.org_id),
+                        "persisted_appearances": persisted_appearances,
+                    },
                 )
                 # ``persisted_appearances`` upstream stays — the GPU
                 # work is preserved against the catalog, so a future
@@ -488,9 +490,11 @@ async def complete(
             )
             logger.info(
                 "product_v2_scan_order_fanned_out",
-                parent_job_id=str(job_id),
-                children_inserted=len(children),
-                requested_count=transitioned.requested_count,
+                extra={
+                    "parent_job_id": str(job_id),
+                    "children_inserted": len(children),
+                    "requested_count": transitioned.requested_count,
+                },
             )
         else:
             await job_repo.complete_tracking(
@@ -508,11 +512,13 @@ async def complete(
     await db.commit()
     logger.info(
         "product_v2_job_completed",
-        job_id=str(job_id),
-        kind=kind,
-        persisted_catalog=persisted_catalog,
-        persisted_appearances=persisted_appearances,
-        cost_delta_usd=str(body.cost_delta_usd),
+        extra={
+            "job_id": str(job_id),
+            "kind": kind,
+            "persisted_catalog": persisted_catalog,
+            "persisted_appearances": persisted_appearances,
+            "cost_delta_usd": str(body.cost_delta_usd),
+        },
     )
     return _CompleteResponse(
         persisted_catalog_entries=persisted_catalog,
@@ -568,9 +574,11 @@ async def fail(
     await db.commit()
     logger.warning(
         "product_v2_job_failed",
-        job_id=str(job_id),
-        error_code=body.error_code,
-        error_message=body.error_message[:120],
+        extra={
+            "job_id": str(job_id),
+            "error_code": body.error_code,
+            "error_message": body.error_message[:120],
+        },
     )
 
 


### PR DESCRIPTION
## Symptom

Worker → `/internal/products/{id}/fail` → **500** with traceback:

```
File "/app/app/modules/shorts_auto_product/internal_router.py", line 569, in fail
    logger.warning(
TypeError: Logger._log() got an unexpected keyword argument 'job_id'
```

Four logger calls in this file passed structlog-style kwargs
(`job_id=…`, `error_code=…`, etc.) directly to a stdlib
`logging.Logger`. stdlib `_log` only accepts `exc_info` / `extra` /
`stack_info` / `stacklevel`. Any other kwarg → TypeError → 500.

## Why tests didn't catch it

In pytest, the test runner installs structlog as the LoggerClass
**before** module import, so `getLogger(__name__)` returns a
structlog `BoundLogger` that accepts arbitrary kwargs.

On the staging API process, the FastAPI router module imports
**before** main.py's startup hook can swap the LoggerClass — so the
bound logger at module-load time is plain stdlib Logger.

15 existing phase4_foundation tests still pass post-fix.

## Fix

Wrap all 4 call sites in `extra={...}` — works for both stdlib and
structlog.

| Line (post-fix) | Event |
|---|---|
| 433 | `product_v2_scan_order_video_no_longer_available` |
| 491 | `product_v2_scan_order_fanned_out` |
| 513 | `product_v2_job_completed` |
| 575 | `product_v2_job_failed` |

## Net effect on staging

Pre-fix the worker saw 500 → retried → got 409 (the row IS at
`stage=failed` because the DB transaction commits BEFORE the broken
logger.warning call). Two extra round-trips and noisy logs per
failed job. Successful `/complete` calls would have hit the same
bug at line 513 — but nothing on staging reached that path yet (the
wizard didn't get past enumeration).

Post-fix: `/fail` returns 204 cleanly, `/complete` returns 200 cleanly.

## Test plan

- [x] All 4 logger calls now use `extra={…}`
- [x] AST parses
- [x] 15/15 phase4_foundation tests pass
- [ ] CI green
- [ ] After merge + staging deploy: re-trigger wizard → enumerate
  fail returns 204 (no 500), worker doesn't retry-with-409