### PR TITLE
fix(product-track-worker): use dataclasses.replace for TrackingConfig override (frozen dataclass)

### DIFF
--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import io
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -1276,9 +1276,15 @@ def _handle_scan_order_parent(
         return
 
     # ── 4. per-product loop ───────────────────────────────────
-    cfg = _make_config(settings)
     # Per-length threshold override (plan §7.3 — codex Q4).
-    cfg.min_window_duration_ms = _min_window_ms_for_length(length_seconds)
+    # ``TrackingConfig`` is a frozen dataclass — direct attribute
+    # assignment raises ``FrozenInstanceError`` ("cannot assign to
+    # field"). Use ``replace()`` to produce a new instance with the
+    # one field overridden.
+    cfg = replace(
+        _make_config(settings),
+        min_window_duration_ms=_min_window_ms_for_length(length_seconds),
+    )
 
     progress_per_entry = 80.0 / max(len(catalog_entries), 1)
     aggregated_appearances: list[dict[str, Any]] = []

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -511,3 +511,33 @@ def test_scan_order_catalog_entry_404_fails_cleanly():
     api.fetch_catalog_entry.assert_called_once()
     api.fail.assert_called_once()
     assert api.fail.call_args.kwargs["error_code"] == "no_products_detected"
+
+
+# =====================================================================
+# scan_order parent flow: TrackingConfig override uses dataclass.replace
+# (regression for 2026-05-04 staging incident)
+# =====================================================================
+
+
+def test_scan_order_cfg_override_uses_dataclass_replace():
+    """Regression: ``TrackingConfig`` is a frozen dataclass — direct
+    attribute assignment raises ``FrozenInstanceError`` ("cannot
+    assign to field 'min_window_duration_ms'"). Pre-fix code did
+    ``cfg.min_window_duration_ms = …`` and the parent failed with
+    ``error_code='internal_error'`` after a clean claim + 2
+    heartbeats. Post-fix uses ``dataclasses.replace()``.
+
+    Pure unit test — no SAM2 / picker mock needed; just exercise the
+    same import + config-construction path the dispatch uses.
+    """
+    from dataclasses import replace
+
+    from src.tasks.track import _make_config
+
+    cfg = _make_config(_settings())
+    # Shouldn't raise FrozenInstanceError.
+    new_cfg = replace(cfg, min_window_duration_ms=999)
+    assert new_cfg.min_window_duration_ms == 999
+    # Original instance is immutable — the override returns a new
+    # value, doesn't mutate in place.
+    assert cfg.min_window_duration_ms != 999


### PR DESCRIPTION
## Symptom on staging

Track worker → dispatch → `/fail` → 204:
```
error_code: internal_error
error_message: cannot assign to field 'min_window_duration_ms'
```

## Root cause

`_handle_scan_order_parent` did direct attribute assignment on
`TrackingConfig`:

```python
cfg = _make_config(settings)
cfg.min_window_duration_ms = _min_window_ms_for_length(length_seconds)
```

But `TrackingConfig` (in `heimdex_media_pipelines.product_track.config`)
is `@dataclass(frozen=True)`. Attribute write on a frozen dataclass
raises `FrozenInstanceError` ("cannot assign to field …"). The
dispatch's outer try/except caught it, called `api.fail` with
`internal_error`, returned cleanly.

## Fix

Replace direct assignment with `dataclasses.replace()` — returns a
new instance with the one field overridden, the contract the frozen-
dataclass design intended:

```python
cfg = replace(
    _make_config(settings),
    min_window_duration_ms=_min_window_ms_for_length(length_seconds),
)
```

## Why now

This is the **fourth bug** uncovered in sequence on staging while
validating the wizard end-to-end. Each fix unblocked the next
failure mode:

1. MinIO endpoint pointing at localhost on Aircloud — config gap fixed
2. `/fail` 500'ing on logger TypeError (PR #137) — fixed
3. Strict enumeration prompt → 0 LLM clusters (contracts PR #3) — fixed
4. **THIS** — frozen dataclass attribute assignment

This bug only surfaced on the FIRST successful walk through the
scan_order path past the catalog-fetch step. Earlier failures
short-circuited before the `cfg.min_window_duration_ms` line.

## Tests

`test_scan_order_cfg_override_uses_dataclass_replace` — pure unit
test, no SAM2 / picker mock. Calls `_make_config(_settings())` then
`replace(cfg, min_window_duration_ms=999)` and asserts:
- New instance has the override
- Original instance unchanged (immutable contract preserved)

Locks in the contract so a future PR doesn't reintroduce the
mutation pattern. Worker tests aren't in CI (need `heimdex_media_pipelines`),
but the test runs whenever someone exercises the worker suite or
the GPU image build pipeline.

## Test plan

- [x] AST parses
- [x] No bare `cfg.min_window_duration_ms =` assignments left
- [ ] CI green (no behavior change for surrounding code)
- [ ] After merge: `gh workflow run build-gpu-images.yml -f workers=product-track`
- [ ] After build: stop+start the Aircloud track container `d809c6e8`
- [ ] Re-trigger wizard scan → parent should reach `tracking` and progress past the cfg line into the per-product loop