### PR TITLE
feat: single full-video proxy + scene window slicing for SAM2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
             tests/test_shorts_auto_product_phase4_foundation.py \
             tests/test_create_scan_order_video_id_resolution.py \
             tests/test_v2_router_video_id_resolution.py \
+            tests/test_videos_internal_scenes_with_keyframes.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/modules/videos/internal_router.py
+++ b/services/api/app/modules/videos/internal_router.py
@@ -254,6 +254,7 @@ async def get_scenes_with_keyframes(
           "video_id": "gd_<...>",        # string id used by OS
           "drive_file_id": "<uuid>",
           "total_duration_ms": <int>,    # max(end_ms) across scenes
+          "proxy_s3_key": "<org>/drive/<drive>/<gfid>/proxy.mp4" | null,
           "scenes": [
             {
               "scene_id": "gd_<...>_scene_007",
@@ -265,6 +266,16 @@ async def get_scenes_with_keyframes(
             ...
           ]
         }
+
+    ``proxy_s3_key`` mirrors ``DriveFile.proxy_s3_key`` verbatim
+    (canonical path written by drive-transcode-worker via
+    ``heimdex_worker_sdk.drive_keys.proxy_s3_key``). It is ``None``
+    when transcode hasn't completed for this video; callers should
+    treat that as a terminal "not ready" state rather than retry —
+    the field only flips populated after a successful transcode.
+    The product-track-worker uses this field to download the full
+    proxy ONCE per job and slice scene windows in-memory, instead
+    of reaching for a per-scene mp4 (which doesn't exist).
     """
     from app.modules.drive.keys import enrichment_keyframe_s3_key
 
@@ -322,6 +333,10 @@ async def get_scenes_with_keyframes(
         "video_id": video_id_str,
         "drive_file_id": str(file_id),
         "total_duration_ms": total_duration_ms,
+        # ``DriveFile.proxy_s3_key`` is nullable — None means transcode
+        # hasn't completed. Pass through verbatim; callers (product-
+        # track-worker) decide how to surface that to the user.
+        "proxy_s3_key": drive_file.proxy_s3_key,
         "scenes": enriched,
     }
 

--- a/services/api/tests/test_videos_internal_scenes_with_keyframes.py
+++ b/services/api/tests/test_videos_internal_scenes_with_keyframes.py
@@ -68,14 +68,27 @@ def _build_app(monkeypatch):
     return _factory
 
 
-def _drive_file(*, file_id: UUID, video_id: str = "gd_abc123", org_id: UUID | None = None):
+def _drive_file(
+    *,
+    file_id: UUID,
+    video_id: str = "gd_abc123",
+    org_id: UUID | None = None,
+    proxy_s3_key: str | None = "tenant-uuid/drive/drive-uuid/gfid/proxy.mp4",
+):
     """Mocked DriveFile row. Pattern B endpoint derives ``org_id``
     from the resource itself, so the test fixture must populate
-    ``obj.org_id`` (not just rely on the asserted header)."""
+    ``obj.org_id`` (not just rely on the asserted header).
+
+    ``proxy_s3_key`` defaults to a stable canonical-shaped value so
+    the existing tests' assertions stay decoupled from this PR's
+    new field. Tests that exercise the null path pass
+    ``proxy_s3_key=None`` explicitly.
+    """
     obj = MagicMock()
     obj.id = file_id
     obj.video_id = video_id
     obj.org_id = org_id if org_id is not None else uuid4()
+    obj.proxy_s3_key = proxy_s3_key
     return obj
 
 
@@ -121,6 +134,10 @@ def test_returns_chronologically_ordered_scenes_with_keyframe_keys(_build_app):
     assert body["video_id"] == "gd_abc123"
     assert body["drive_file_id"] == str(file_id)
     assert body["total_duration_ms"] == 60000
+    # ``proxy_s3_key`` is the canonical mp4 path the worker downloads
+    # once per job. Verbatim mirror of ``DriveFile.proxy_s3_key`` —
+    # never reconstruct in the endpoint.
+    assert body["proxy_s3_key"] == "tenant-uuid/drive/drive-uuid/gfid/proxy.mp4"
 
     scenes = body["scenes"]
     assert [s["scene_id"] for s in scenes] == [
@@ -312,3 +329,62 @@ def test_drops_malformed_scene_rows_silently(_build_app):
     assert {s["scene_id"] for s in body["scenes"]} == {
         "gd_x_scene_001", "gd_x_scene_002",
     }
+
+
+# ---------- proxy_s3_key field ----------
+
+def test_proxy_s3_key_is_null_when_drivefile_has_no_proxy(_build_app):
+    """Transcode-incomplete videos have ``proxy_s3_key=None`` on the
+    DriveFile row. The endpoint passes through verbatim — null,
+    not omitted. Worker maps this to a clean ``proxy_missing`` fail
+    rather than the opaque ``internal_error``."""
+    file_id = uuid4()
+    org_id = uuid4()
+    drive_file = _drive_file(file_id=file_id, org_id=org_id, proxy_s3_key=None)
+    app = _build_app(
+        drive_file_obj=drive_file, scene_response={"scenes": []},
+    )
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/videos/{file_id}/scenes-with-keyframes",
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "proxy_s3_key" in body, "field must be present (explicit null), not omitted"
+    assert body["proxy_s3_key"] is None
+
+
+def test_proxy_s3_key_passes_through_canonical_drive_path_unchanged(_build_app):
+    """Canonical layout: ``{org_id}/drive/{drive_id}/{google_file_id}/proxy.mp4``
+    (heimdex_worker_sdk.drive_keys.proxy_s3_key). The endpoint does
+    NOT reconstruct — it mirrors the DB column verbatim — so the
+    test asserts the raw string is echoed regardless of shape. This
+    locks the contract that no endpoint-side path massaging happens
+    (drift between transcode-write and track-read would silently
+    404 every download)."""
+    file_id = uuid4()
+    org_id = uuid4()
+    canonical_key = (
+        f"{org_id}/drive/2d0a3f2e-9999-4321-aaaa-111111111111/"
+        f"1A2BcDeF_googleFileId/proxy.mp4"
+    )
+    drive_file = _drive_file(
+        file_id=file_id, org_id=org_id, proxy_s3_key=canonical_key,
+    )
+    app = _build_app(
+        drive_file_obj=drive_file, scene_response={"scenes": []},
+    )
+    with TestClient(app) as client:
+        resp = client.get(
+            f"/internal/videos/{file_id}/scenes-with-keyframes",
+            headers={
+                "Authorization": "Bearer test-internal-token",
+                "X-Heimdex-Org-Id": str(org_id),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["proxy_s3_key"] == canonical_key

--- a/services/product-track-worker/src/proxy_download.py
+++ b/services/product-track-worker/src/proxy_download.py
@@ -1,0 +1,97 @@
+"""Per-job proxy download + tempdir lifecycle.
+
+Phase 3c-B locked decision (handoff sam2-proxy-handoff-2026-05-04):
+the SAM2 wrapper consumes a SINGLE full-video proxy and slices each
+candidate scene's window in-memory, instead of expecting per-scene
+mp4s that no production pipeline writes. This module owns the
+download + cleanup so ``tasks/track.py`` stays small and the
+S3-side concerns are testable in isolation.
+
+Loose-coupling rules enforced here:
+  * Lib (heimdex_media_pipelines) is NOT imported — pipelines is
+    pure data flow and never sees this path; the worker passes the
+    local path through as opaque data.
+  * The downloader takes a structural ``S3DownloadClient`` protocol,
+    not a concrete ``S3Client``, so unit tests can pass a stub
+    without touching boto3.
+  * Tempdir lifetime is tied to a context manager so the F4 path
+    (every SAM2 call raises) and the happy path both clean up
+    deterministically. Aircloud /tmp is small (~tmpfs); leaking
+    even a few hundred MB across job retries would wedge the
+    container.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class S3DownloadClient(Protocol):
+    """Structural type for the subset of ``heimdex_worker_sdk.s3.S3Client``
+    we use here. Keeping this narrow lets test stubs implement just
+    ``download_file`` without faking the full S3Client surface."""
+
+    def download_file(self, s3_key: str, local_path: Path) -> None: ...
+
+
+@contextmanager
+def downloaded_proxy(
+    *,
+    s3: S3DownloadClient,
+    proxy_s3_key: str,
+    job_id_for_naming: str,
+    parent_dir: Path | None = None,
+) -> Iterator[Path]:
+    """Download ``proxy_s3_key`` to a per-job tempdir, yield the
+    local path, and clean up on exit (success OR exception).
+
+    ``job_id_for_naming`` is incorporated into the tempdir name so
+    concurrent jobs in the same worker process never collide on
+    disk — even when ``DRIVE_PRODUCT_TRACK_CONCURRENCY`` is ever
+    bumped above 1. The handoff calls out concurrency=1 today, but
+    naming this way costs nothing and removes a future foot-gun.
+
+    ``parent_dir`` defaults to the system temp dir; tests inject a
+    pytest ``tmp_path`` so they don't pollute /tmp.
+    """
+    if not proxy_s3_key:
+        # Defensive — callers should have null-checked already, but
+        # raise loudly here rather than letting boto3 produce a
+        # cryptic ``InvalidArgument`` that buries the root cause.
+        raise ValueError("proxy_s3_key is empty; cannot download")
+
+    with tempfile.TemporaryDirectory(
+        prefix=f"track_{job_id_for_naming}_",
+        dir=str(parent_dir) if parent_dir is not None else None,
+    ) as td:
+        local_path = Path(td) / "proxy.mp4"
+        logger.info(
+            "proxy_download_start",
+            extra={
+                "proxy_s3_key": proxy_s3_key,
+                "local_path": str(local_path),
+                "job_id": job_id_for_naming,
+            },
+        )
+        s3.download_file(proxy_s3_key, local_path)
+        logger.info(
+            "proxy_download_done",
+            extra={
+                "proxy_s3_key": proxy_s3_key,
+                "size_bytes": (
+                    local_path.stat().st_size if local_path.exists() else None
+                ),
+                "job_id": job_id_for_naming,
+            },
+        )
+        yield local_path
+        # Tempdir auto-cleans on context exit (success path).
+
+    # On exception, the ``with`` above still runs cleanup before
+    # re-raising — verified in test_proxy_download.py.

--- a/services/product-track-worker/src/sam2_tracker.py
+++ b/services/product-track-worker/src/sam2_tracker.py
@@ -1,41 +1,49 @@
 """Concrete :class:`heimdex_media_pipelines.product_track.Sam2Tracker`
 implementation.
 
-Phase 3c-B: real SAM2 video propagation against a single scene's
-proxy video. The lib's ``propagate_within_candidate_scenes`` calls
-``track(scene_id, anchor_bbox, anchor_keyframe, scene_video_url,
-sample_fps)`` per candidate; per-scene errors are caught + logged
-upstream so a single bad scene never aborts the whole job (the
-Phase 3c-A F4 ``_CountingSam2Tracker`` then catches the
-stage-wide-failure case if every scene errors).
+Phase 3c-B (post-2026-05-04): real SAM2 video propagation against
+a SINGLE full-video proxy with per-scene in-memory window slicing.
+The lib's ``propagate_within_candidate_scenes`` calls
+``track(scene_id, anchor_bbox, anchor_keyframe, full_video_path,
+scene_start_ms, scene_end_ms, sample_fps)`` per candidate; per-scene
+errors are caught + logged upstream so a single bad scene never
+aborts the whole job (the Phase 3c-A F4 ``_CountingSam2Tracker``
+then catches the stage-wide-failure case if every scene errors).
 
 Implementation flow:
 
-  1. Open the proxy video. ``scene_video_url`` may be presigned S3
-     HTTP, plain HTTP, or a local path; OpenCV's ``VideoCapture``
-     handles all three. (S3 ``s3://`` URLs require explicit
-     download first — tracker doesn't see those because the worker
-     resolves to presigned HTTP before passing.)
-  2. Sample frames at ``sample_fps``. The capture's reported FPS
-     drives the stride; sub-sampling is done on the input side so
-     SAM2 never sees frames it won't be asked about.
-  3. Anchor placement: Phase 3c-B v1 uses the first sampled frame
+  1. Open the full-video proxy that the worker downloaded once
+     per job message. ``full_video_path`` is a local filesystem
+     path the worker manages; we never reach for a per-scene mp4.
+  2. Seek to ``scene_start_ms`` via ``CAP_PROP_POS_MSEC``. The
+     seek is keyframe-aligned — cv2 may decode from the keyframe
+     BEFORE the requested ms — so the sampling loop drops any
+     pre-roll frames whose timestamp is < ``scene_start_ms``.
+  3. Sample frames at ``sample_fps`` cadence (timestamp-based, not
+     stride-based — the seek decouples us from "frames since file
+     start"). Stop the loop once the decoded timestamp exceeds
+     ``scene_end_ms`` so we don't pay decode cost outside the
+     candidate window.
+  4. Anchor placement: Phase 3c-B v1 uses the first sampled frame
      as the anchor — the lib already passes us the keyframe of an
      accepted candidate scene, so anchor placement is approximate
      but adequate for calibration. A future revision may switch to
      phash-nearest matching against ``anchor_keyframe`` if
      calibration motivates it.
-  4. Initialize SAM2's video predictor with ``anchor_bbox``.
-  5. Propagate forward + backward across the sampled frames; the
+  5. Initialize SAM2's video predictor with ``anchor_bbox``.
+  6. Propagate forward + backward across the sampled frames; the
      predictor returns a per-frame mask + confidence.
-  6. Convert each mask to an axis-aligned bbox. Empty masks (SAM2
+  7. Convert each mask to an axis-aligned bbox. Empty masks (SAM2
      lost the object) emit a low-confidence sample so window
      assembly's threshold filter drops them naturally.
 
 Failure modes (per ``Sam2Tracker`` contract — raise on any of
 these so the lib's per-scene try/except records the failure and
 continues):
-  * Scene proxy missing / S3 404 → ``RuntimeError``.
+  * Proxy missing / unreadable → ``RuntimeError``.
+  * No frames decoded inside the scene window → ``RuntimeError``
+    (corrupted proxy, seek fell off the end, or the scene window
+    is degenerate).
   * Anchor bbox falls outside frame bounds → ``ValueError``.
   * SAM2 OOM → ``RuntimeError`` (CUDA propagates as RuntimeError).
 """
@@ -75,7 +83,9 @@ class Sam2TrackerImpl:
         scene_id: str,
         anchor_bbox: BBoxXYWH,
         anchor_keyframe: "Image.Image",
-        scene_video_url: str,
+        full_video_path: str,
+        scene_start_ms: int,
+        scene_end_ms: int,
         sample_fps: int,
     ) -> list[TrackedSample]:
         # Lazy imports — keep module-import cheap for tests.
@@ -87,46 +97,77 @@ class Sam2TrackerImpl:
 
         loaded = load_sam2(model_id=self._model_id)
 
-        # ── 1. Open the proxy video.
-        cap = cv2.VideoCapture(scene_video_url)
+        # ── 1. Open the full-video proxy (worker downloaded it once
+        #      per job; we get a local filesystem path).
+        cap = cv2.VideoCapture(full_video_path)
         if not cap.isOpened():
             raise RuntimeError(
-                f"failed to open scene video for SAM2 tracking "
-                f"(scene_id={scene_id} url={scene_video_url})"
+                f"failed to open proxy video for SAM2 tracking "
+                f"(scene_id={scene_id} path={full_video_path})"
             )
 
         try:
             frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
             frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
             source_fps = float(cap.get(cv2.CAP_PROP_FPS) or 30.0)
-            total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
 
-            # ── 2. Sample frames at sample_fps.
-            stride = max(1, int(round(source_fps / max(sample_fps, 1))))
+            # ── 2. Seek to the scene window's start. CAP_PROP_POS_MSEC
+            #      is keyframe-aligned, so cv2 may land on the keyframe
+            #      BEFORE scene_start_ms. The sampling loop below
+            #      drops any pre-roll frames whose timestamp falls
+            #      below scene_start_ms; correctness, not just
+            #      efficiency.
+            cap.set(cv2.CAP_PROP_POS_MSEC, float(scene_start_ms))
+
+            # ── 3. Sample frames at sample_fps cadence within the
+            #      scene window. ``next_sample_ts_ms`` advances by
+            #      ``sample_interval_ms`` after each accepted sample;
+            #      a decoded frame whose timestamp falls between two
+            #      sample boundaries is skipped.
+            sample_interval_ms = max(1, int(round(1000.0 / max(sample_fps, 1))))
             sampled_frames: list[tuple[int, "np.ndarray"]] = []
-            frame_idx = 0
+            next_sample_ts_ms = scene_start_ms
+
             while True:
+                # Query position BEFORE reading. CAP_PROP_POS_MSEC
+                # returns the time of the NEXT frame to be decoded,
+                # so this is the timestamp of the frame ``cap.read``
+                # is about to return.
+                pos_ms = float(cap.get(cv2.CAP_PROP_POS_MSEC))
                 ok, bgr = cap.read()
                 if not ok:
                     break
-                if frame_idx % stride == 0:
-                    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-                    sampled_frames.append((frame_idx, rgb))
-                frame_idx += 1
-                if total_frames and frame_idx >= total_frames:
+                # Past the scene end → stop. Don't pay further
+                # decode cost outside the candidate window.
+                if pos_ms > scene_end_ms:
                     break
+                # Pre-roll from the keyframe-aligned seek → drop.
+                if pos_ms < scene_start_ms:
+                    continue
+                # Inside the window but ahead of the next sample
+                # boundary → skip (downsample to ``sample_fps``).
+                if pos_ms < next_sample_ts_ms:
+                    continue
+                rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+                sampled_frames.append((int(pos_ms), rgb))
+                next_sample_ts_ms = int(pos_ms) + sample_interval_ms
         finally:
             cap.release()
 
         if not sampled_frames:
-            # Empty scene (proxy decoded zero frames) — surface as a
-            # runtime error so the lib's per-scene try/except marks
-            # this scene as failed. Checked BEFORE the bbox bounds
-            # check so corrupted-proxy cases (where metadata is 0x0)
-            # surface as the correct error class.
+            # Zero frames decoded inside the requested window —
+            # corrupted proxy, seek fell off the end, or the scene
+            # window is degenerate. Surface as a runtime error so
+            # the lib's per-scene try/except marks this scene as
+            # failed. Checked BEFORE the bbox bounds check so
+            # corrupted-proxy cases (where metadata is 0x0) surface
+            # as the correct error class.
             raise RuntimeError(
-                f"no frames decoded from scene proxy "
-                f"(scene_id={scene_id} url={scene_video_url})"
+                f"no frames decoded in scene window "
+                f"(scene_id={scene_id} "
+                f"scene_start_ms={scene_start_ms} "
+                f"scene_end_ms={scene_end_ms} "
+                f"path={full_video_path})"
             )
 
         # If metadata reported 0x0 but we still got frames, fall
@@ -187,7 +228,11 @@ class Sam2TrackerImpl:
             ):
                 if prop_idx >= len(sampled_frames):
                     continue  # defensive — should never exceed
-                source_frame_idx, _ = sampled_frames[prop_idx]
+                # First tuple element is now an absolute millisecond
+                # timestamp on the FULL-video timeline (not a 0-based
+                # counter), set during the seek+sample loop above.
+                # No conversion needed.
+                frame_ts_ms, _ = sampled_frames[prop_idx]
                 # ``masks`` is shape (num_obj, H, W) — we added
                 # exactly one object so index 0 is the only mask.
                 mask_t = masks[0]
@@ -199,7 +244,6 @@ class Sam2TrackerImpl:
                 )
                 mask_np = mask_t.detach().cpu().numpy()
                 bbox = _mask_to_bbox(mask_np)
-                frame_ts_ms = int(source_frame_idx * 1000 / source_fps)
                 if bbox is None:
                     # Empty mask — SAM2 lost the object. Emit a
                     # low-confidence sample with the original

--- a/services/product-track-worker/src/siglip2_clients.py
+++ b/services/product-track-worker/src/siglip2_clients.py
@@ -52,7 +52,18 @@ class CoarseRetrievalClientImpl:
     endpoint. ``file_id`` and ``org_id`` are bound at construction time
     because the lib's Protocol signature only accepts ``video_id`` (the
     OS string id) at the call site — the http endpoint needs the
-    DriveFile UUID, which the worker resolves from the job message."""
+    DriveFile UUID, which the worker resolves from the job message.
+
+    ``scene_id_to_timing`` is the worker's ``scene_id → (start_ms,
+    end_ms)`` map built once per job from the
+    ``scenes-with-keyframes`` response. We use it here to populate
+    ``CoarseCandidate.start_ms`` / ``end_ms`` so the SAM2 pass can
+    window-slice a single full-video proxy without an extra fetch.
+    Scenes the OS coarse-similarity endpoint returns but the
+    timing map doesn't know about (race with re-split, deletion,
+    etc.) are dropped silently — the lib tolerates a sparse
+    candidate set per its per-scene-failure-isolation contract.
+    """
 
     def __init__(
         self,
@@ -60,10 +71,12 @@ class CoarseRetrievalClientImpl:
         api: "ApiClient",
         file_id: UUID,
         org_id: UUID,
+        scene_id_to_timing: dict[str, tuple[int, int]],
     ) -> None:
         self._api = api
         self._file_id = file_id
         self._org_id = org_id
+        self._scene_id_to_timing = scene_id_to_timing
 
     def find_similar_scenes(
         self,
@@ -90,13 +103,32 @@ class CoarseRetrievalClientImpl:
             top_k=top_k,
             min_similarity=min_similarity,
         )
-        return [
-            CoarseCandidate(
-                scene_id=str(s["scene_id"]),
-                coarse_similarity=float(s.get("similarity", 0.0)),
+        out: list[CoarseCandidate] = []
+        for s in scenes:
+            scene_id = str(s["scene_id"])
+            timing = self._scene_id_to_timing.get(scene_id)
+            if timing is None:
+                # Scene known to OS but missing from the worker's
+                # scenes-with-keyframes timing map. Drop with a debug
+                # log — the lib's per-scene-failure isolation handles
+                # the missing-candidate case downstream, and silently
+                # missing rows here is preferable to a hard crash on
+                # what's almost always a benign race.
+                logger.debug(
+                    "coarse_candidate_dropped_no_timing",
+                    extra={"scene_id": scene_id, "file_id": str(self._file_id)},
+                )
+                continue
+            start_ms, end_ms = timing
+            out.append(
+                CoarseCandidate(
+                    scene_id=scene_id,
+                    coarse_similarity=float(s.get("similarity", 0.0)),
+                    start_ms=start_ms,
+                    end_ms=end_ms,
+                )
             )
-            for s in scenes
-        ]
+        return out
 
 
 class KeyframeFetcherImpl:

--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -77,6 +77,7 @@ from heimdex_worker_sdk.s3 import S3Client
 
 from src.api_client import ApiClient
 from src.openai_picker import OpenAIPicker
+from src.proxy_download import downloaded_proxy
 from src.sam2_tracker import Sam2TrackerImpl
 from src.settings import WorkerSettings
 from src.siglip2_clients import (
@@ -179,7 +180,9 @@ class _CountingSam2Tracker:
         scene_id: str,
         anchor_bbox: BBoxXYWH,
         anchor_keyframe: "Image.Image",
-        scene_video_url: str,
+        full_video_path: str,
+        scene_start_ms: int,
+        scene_end_ms: int,
         sample_fps: int,
     ) -> list:
         self.attempted += 1
@@ -188,7 +191,9 @@ class _CountingSam2Tracker:
                 scene_id=scene_id,
                 anchor_bbox=anchor_bbox,
                 anchor_keyframe=anchor_keyframe,
-                scene_video_url=scene_video_url,
+                full_video_path=full_video_path,
+                scene_start_ms=scene_start_ms,
+                scene_end_ms=scene_end_ms,
                 sample_fps=sample_fps,
             )
         except Exception:
@@ -460,15 +465,42 @@ def handle_track_job(
                 )
                 return
             raise
+        raw_scenes = scenes_resp.get("scenes", [])
         scene_id_to_kf = {
-            s["scene_id"]: s["keyframe_s3_key"]
-            for s in scenes_resp.get("scenes", [])
+            s["scene_id"]: s["keyframe_s3_key"] for s in raw_scenes
+        }
+        scene_id_to_timing: dict[str, tuple[int, int]] = {
+            s["scene_id"]: (int(s["start_ms"]), int(s["end_ms"]))
+            for s in raw_scenes
         }
         os_video_id = scenes_resp.get("video_id", "")
 
+        # Single-proxy fast-fail: ``proxy_s3_key`` is None when
+        # transcode hasn't completed for this video. Surface as a
+        # distinct ``proxy_missing`` error code so the wizard can
+        # show "video isn't ready yet" rather than the generic
+        # ``internal_error``.
+        proxy_s3_key = scenes_resp.get("proxy_s3_key")
+        if not proxy_s3_key:
+            api.fail(
+                job_id=decoded.job_id,
+                claimed_by=settings.worker_id,
+                cost_delta_usd=cost_accumulator,
+                error_code="proxy_missing",
+                error_message=(
+                    f"DriveFile {decoded.video_id} has no proxy_s3_key — "
+                    f"transcode incomplete; retry once the video shows "
+                    f"as indexed."
+                ),
+            )
+            return
+
         embedder_impl = _CountingEmbedder(embedder or SiglipEmbedderImpl())
         coarse_client = CoarseRetrievalClientImpl(
-            api=api, file_id=decoded.video_id, org_id=decoded.org_id,
+            api=api,
+            file_id=decoded.video_id,
+            org_id=decoded.org_id,
+            scene_id_to_timing=scene_id_to_timing,
         )
         keyframe_fetcher = _CountingKeyframeFetcher(
             KeyframeFetcherImpl(
@@ -530,26 +562,26 @@ def handle_track_job(
             lease_seconds=settings.worker_lease_seconds,
         )
 
-        # TODO Phase 3c-B: real scene_video_urls. Drive proxies live
-        # at known S3 paths; needs a presigned URL helper or a
-        # dedicated /internal endpoint. Stubbed here as
-        # ``s3://{bucket}/proxies/{video_id}/{scene_id}.mp4`` which
-        # the SAM2 stub raises on anyway.
-        scene_video_urls = {
-            cs.scene_id: f"s3://{settings.drive_s3_bucket}/proxies/{os_video_id}/{cs.scene_id}.mp4"
-            for cs in candidate_scenes
-        }
-
+        # Download the full-video proxy ONCE per job message; the
+        # SAM2 wrapper seeks each scene's window in-memory. Tempdir
+        # is cleaned up on context exit (success OR exception via
+        # F4) so we never leak across retries on Aircloud's tight
+        # /tmp.
         tracker_impl = _CountingSam2Tracker(
             tracker or Sam2TrackerImpl(model_id=settings.sam2_model_id)
         )
-        detections = propagate_within_candidate_scenes(
-            candidates=candidate_scenes,
-            canonical_bbox=canonical_bbox,
-            tracker=tracker_impl,
-            scene_video_urls=scene_video_urls,
-            config=cfg,
-        )
+        with downloaded_proxy(
+            s3=s3,
+            proxy_s3_key=proxy_s3_key,
+            job_id_for_naming=str(decoded.job_id),
+        ) as full_video_path:
+            detections = propagate_within_candidate_scenes(
+                candidates=candidate_scenes,
+                canonical_bbox=canonical_bbox,
+                tracker=tracker_impl,
+                full_video_path=str(full_video_path),
+                config=cfg,
+            )
 
         # F4: every SAM2 track raised → systemic regression (model
         # OOM, every proxy URL 404, SAM2 weights wrong). Treat as a
@@ -1099,13 +1131,20 @@ def _filter_scenes_by_time_range(
     range_start_ms: int | None,
     range_end_ms: int | None,
     soft_padding_ms: int = 30_000,
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Pre-filter scenes by time-range with soft padding (codex Q3).
 
-    Returns a ``scene_id_to_keyframe_s3_key`` map containing only
-    scenes whose ``[start_ms, end_ms]`` overlaps
-    ``[range_start - pad, range_end + pad]``. If both bounds are
-    None, returns the full map (no filtering).
+    Returns the filtered scene-dict list (same shape as input, with
+    only scenes whose ``[start_ms, end_ms]`` overlaps
+    ``[range_start - pad, range_end + pad]``). If both bounds are
+    None, returns the input list verbatim (no filtering).
+
+    Returning the dicts (not just one map) lets the caller derive
+    BOTH the keyframe map (``scene_id → keyframe_s3_key``) and the
+    timing map (``scene_id → (start_ms, end_ms)``) from the same
+    filtered set — important so coarse-retrieval candidates outside
+    the user's time-range don't sneak through one map but get
+    filtered by the other.
 
     The ±30s padding handles windows straddling the user's chosen
     boundary; the API's ``ck_psj_aggregate_output`` CHECK guarantees
@@ -1113,15 +1152,15 @@ def _filter_scenes_by_time_range(
     with padding.
     """
     if range_start_ms is None or range_end_ms is None:
-        return {s["scene_id"]: s["keyframe_s3_key"] for s in scenes}
+        return list(scenes)
     padded_start = max(0, range_start_ms - soft_padding_ms)
     padded_end = range_end_ms + soft_padding_ms
-    return {
-        s["scene_id"]: s["keyframe_s3_key"]
+    return [
+        s
         for s in scenes
         if int(s.get("end_ms", 0)) > padded_start
         and int(s.get("start_ms", 0)) < padded_end
-    }
+    ]
 
 
 def _handle_scan_order_parent(
@@ -1255,12 +1294,38 @@ def _handle_scan_order_parent(
     scenes = scenes_resp.get("scenes", [])
     os_video_id = scenes_resp.get("video_id", "")
 
+    # Single-proxy fast-fail: ``proxy_s3_key`` is None when transcode
+    # hasn't completed for this video. Surface a distinct
+    # ``proxy_missing`` error code so the wizard can show "video isn't
+    # ready yet" rather than the generic ``internal_error``.
+    proxy_s3_key = scenes_resp.get("proxy_s3_key")
+    if not proxy_s3_key:
+        api.fail(
+            job_id=decoded.job_id,
+            claimed_by=settings.worker_id,
+            cost_delta_usd=cost_accumulator,
+            error_code="proxy_missing",
+            error_message=(
+                f"DriveFile {decoded.video_id} has no proxy_s3_key — "
+                f"transcode incomplete; retry once the video shows "
+                f"as indexed."
+            ),
+        )
+        return
+
     # ── 3.5 time-range pre-filter (codex Q3) ──────────────────
-    scene_id_to_kf = _filter_scenes_by_time_range(
+    filtered_scenes = _filter_scenes_by_time_range(
         scenes,
         range_start_ms=decoded.time_range_start_ms,
         range_end_ms=decoded.time_range_end_ms,
     )
+    scene_id_to_kf = {
+        s["scene_id"]: s["keyframe_s3_key"] for s in filtered_scenes
+    }
+    scene_id_to_timing: dict[str, tuple[int, int]] = {
+        s["scene_id"]: (int(s["start_ms"]), int(s["end_ms"]))
+        for s in filtered_scenes
+    }
     if not scene_id_to_kf:
         api.fail(
             job_id=decoded.job_id,
@@ -1292,56 +1357,69 @@ def _handle_scan_order_parent(
     products_f4_failed = 0
     products_no_qualifying = 0
 
-    for i, entry in enumerate(catalog_entries):
-        entry_id = UUID(str(entry["catalog_entry_id"]))
-        entry_label = str(entry["llm_label"])
-        progress_pct = 10 + int((i + 1) * progress_per_entry)
-        try:
-            api.heartbeat(
-                job_id=decoded.job_id,
-                claimed_by=settings.worker_id,
-                stage="tracking",
-                progress_pct=min(progress_pct, 89),
-                progress_label=(
-                    f"tracking {entry_label} ({i+1}/{len(catalog_entries)})"
-                ),
-                cost_delta_usd=Decimal("0"),
-                lease_seconds=settings.worker_lease_seconds,
-            )
+    # Download the full-video proxy ONCE for the whole order. Every
+    # product's SAM2 pass reuses the same local file; the wrapper
+    # seeks to per-scene windows in-memory. Tempdir is cleaned up
+    # on context exit, including the F4-everywhere path where every
+    # product raises.
+    with downloaded_proxy(
+        s3=s3,
+        proxy_s3_key=proxy_s3_key,
+        job_id_for_naming=str(decoded.job_id),
+    ) as full_video_path_obj:
+        full_video_path = str(full_video_path_obj)
+        for i, entry in enumerate(catalog_entries):
+            entry_id = UUID(str(entry["catalog_entry_id"]))
+            entry_label = str(entry["llm_label"])
+            progress_pct = 10 + int((i + 1) * progress_per_entry)
+            try:
+                api.heartbeat(
+                    job_id=decoded.job_id,
+                    claimed_by=settings.worker_id,
+                    stage="tracking",
+                    progress_pct=min(progress_pct, 89),
+                    progress_label=(
+                        f"tracking {entry_label} ({i+1}/{len(catalog_entries)})"
+                    ),
+                    cost_delta_usd=Decimal("0"),
+                    lease_seconds=settings.worker_lease_seconds,
+                )
 
-            entry_appearances = _process_one_product_for_parent(
-                entry=entry,
-                scene_id_to_kf=scene_id_to_kf,
-                os_video_id=os_video_id,
-                cfg=cfg,
-                api=api,
-                s3=s3,
-                decoded=decoded,
-                settings=settings,
-                embedder=embedder,
-                tracker=tracker,
-            )
-            if entry_appearances is None:
-                # F4 stage-wide outage for THIS product. Don't kill
-                # the whole order — log + skip.
+                entry_appearances = _process_one_product_for_parent(
+                    entry=entry,
+                    scene_id_to_kf=scene_id_to_kf,
+                    scene_id_to_timing=scene_id_to_timing,
+                    full_video_path=full_video_path,
+                    os_video_id=os_video_id,
+                    cfg=cfg,
+                    api=api,
+                    s3=s3,
+                    decoded=decoded,
+                    settings=settings,
+                    embedder=embedder,
+                    tracker=tracker,
+                )
+                if entry_appearances is None:
+                    # F4 stage-wide outage for THIS product. Don't kill
+                    # the whole order — log + skip.
+                    products_f4_failed += 1
+                    continue
+                if not entry_appearances:
+                    products_no_qualifying += 1
+                    continue
+                aggregated_appearances.extend(entry_appearances)
+                products_succeeded += 1
+            except Exception:
+                logger.exception(
+                    "scan_order_per_product_failed",
+                    extra={
+                        "job_id": str(decoded.job_id),
+                        "catalog_entry_id": str(entry_id),
+                        "entry_label": entry_label,
+                    },
+                )
                 products_f4_failed += 1
                 continue
-            if not entry_appearances:
-                products_no_qualifying += 1
-                continue
-            aggregated_appearances.extend(entry_appearances)
-            products_succeeded += 1
-        except Exception:
-            logger.exception(
-                "scan_order_per_product_failed",
-                extra={
-                    "job_id": str(decoded.job_id),
-                    "catalog_entry_id": str(entry_id),
-                    "entry_label": entry_label,
-                },
-            )
-            products_f4_failed += 1
-            continue
 
     # ── 5. /complete or /fail ─────────────────────────────────
     if not aggregated_appearances:
@@ -1404,6 +1482,8 @@ def _process_one_product_for_parent(
     *,
     entry: dict[str, Any],
     scene_id_to_kf: dict[str, str],
+    scene_id_to_timing: dict[str, tuple[int, int]],
+    full_video_path: str,
     os_video_id: str,
     cfg: TrackingConfig,
     api: ApiClient,
@@ -1439,7 +1519,10 @@ def _process_one_product_for_parent(
     # F4 wrappers — per-product so failures are isolated.
     embedder_impl = _CountingEmbedder(embedder or SiglipEmbedderImpl())
     coarse_client = CoarseRetrievalClientImpl(
-        api=api, file_id=decoded.video_id, org_id=decoded.org_id,
+        api=api,
+        file_id=decoded.video_id,
+        org_id=decoded.org_id,
+        scene_id_to_timing=scene_id_to_timing,
     )
     keyframe_fetcher = _CountingKeyframeFetcher(
         KeyframeFetcherImpl(
@@ -1478,11 +1561,9 @@ def _process_one_product_for_parent(
         # Not an F4 — the product just has no scenes that match.
         return []
 
-    # SAM2 propagation per-product.
-    scene_video_urls = {
-        cs.scene_id: f"s3://{settings.drive_s3_bucket}/proxies/{os_video_id}/{cs.scene_id}.mp4"
-        for cs in candidate_scenes
-    }
+    # SAM2 propagation per-product. Reuses the single full-video
+    # proxy the parent already downloaded — the SAM2 wrapper seeks
+    # to each scene window in-memory.
     tracker_impl = _CountingSam2Tracker(
         tracker or Sam2TrackerImpl(model_id=settings.sam2_model_id)
     )
@@ -1490,7 +1571,7 @@ def _process_one_product_for_parent(
         candidates=candidate_scenes,
         canonical_bbox=canonical_bbox,
         tracker=tracker_impl,
-        scene_video_urls=scene_video_urls,
+        full_video_path=full_video_path,
         config=cfg,
     )
     if tracker_impl.all_attempts_failed:

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -70,8 +70,17 @@ def _job_body() -> dict:
 def _scenes_response(n: int = 3) -> dict:
     return {
         "video_id": "gd_test",
+        # PR B: proxy_s3_key is the canonical full-video proxy path
+        # the worker downloads ONCE per job (replaces the per-scene
+        # URL stub). Tests assert on this via download_file mock.
+        "proxy_s3_key": "tenant/drive/d/g/proxy.mp4",
         "scenes": [
-            {"scene_id": f"gd_test_scene_{i:03d}", "keyframe_s3_key": f"k{i}.jpg"}
+            {
+                "scene_id": f"gd_test_scene_{i:03d}",
+                "keyframe_s3_key": f"k{i}.jpg",
+                "start_ms": i * 5000,
+                "end_ms": (i + 1) * 5000,
+            }
             for i in range(n)
         ],
     }
@@ -454,7 +463,13 @@ def test_scan_order_with_catalog_entry_id_uses_single_entry_fetch():
     }
     # No scenes → per-product loop produces no qualifying windows →
     # parent /fails as tracker_low_confidence_global. Skips SAM2.
-    api.fetch_scenes_with_keyframes.return_value = {"video_id": "gd_test", "scenes": []}
+    # ``proxy_s3_key`` populated so we don't trip the upstream
+    # ``proxy_missing`` fast-fail (which is exercised by its own test).
+    api.fetch_scenes_with_keyframes.return_value = {
+        "video_id": "gd_test",
+        "proxy_s3_key": "tenant/drive/d/g/proxy.mp4",
+        "scenes": [],
+    }
     embedder, s3, tracker, picker = _make_pipeline_mocks()
 
     body = _scan_order_body()
@@ -541,3 +556,130 @@ def test_scan_order_cfg_override_uses_dataclass_replace():
     # Original instance is immutable — the override returns a new
     # value, doesn't mutate in place.
     assert cfg.min_window_duration_ms != 999
+
+
+# =====================================================================
+# Single-proxy contract (PR B, post-2026-05-04 sam2-proxy handoff)
+# =====================================================================
+
+
+def test_legacy_path_proxy_missing_returns_proxy_missing_error_code():
+    """Transcode-incomplete videos: ``DriveFile.proxy_s3_key`` is
+    NULL → API echoes ``proxy_s3_key=None`` → worker MUST fail with
+    ``error_code=proxy_missing`` (not the opaque ``internal_error``)
+    so the wizard can show "video isn't ready yet" cleanly. SAM2
+    must NEVER be invoked on a missing-proxy job — every call would
+    F4 anyway."""
+    api = _make_apis(render_job_id=uuid4())
+    # Override the fixture's proxy_s3_key to None.
+    api.fetch_scenes_with_keyframes.return_value = {
+        **_scenes_response(n=3),
+        "proxy_s3_key": None,
+    }
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=_job_body(),
+            settings=_settings(),
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    # Distinct error code so the wizard maps it to a friendly message.
+    api.fail.assert_called_once()
+    assert api.fail.call_args.kwargs["error_code"] == "proxy_missing"
+    # SAM2 wrapper never invoked — saves a fruitless GPU call.
+    tracker.track.assert_not_called()
+    # And no S3 download attempt on the proxy.
+    s3.download_file.assert_not_called()
+
+
+def test_scan_order_parent_proxy_missing_returns_proxy_missing_error_code():
+    """Same fast-fail in the wizard scan_order parent. Locks the
+    contract that BOTH dispatch paths surface ``proxy_missing``
+    consistently — wizard error UI maps a single code, not two."""
+    api = MagicMock()
+    api.fetch_catalog_entries_for_video.return_value = [
+        {
+            "catalog_entry_id": str(uuid4()),
+            "org_id": str(uuid4()),
+            "video_id": "gd_test",
+            "canonical_crop_s3_key": "k.jpg",
+            "canonical_bbox": {"x": 0, "y": 0, "w": 10, "h": 10},
+            "llm_label": "테스트 제품",
+        }
+    ]
+    api.fetch_scenes_with_keyframes.return_value = {
+        **_scenes_response(n=3),
+        "proxy_s3_key": None,
+    }
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    handle_track_job(
+        message=_scan_order_body(),
+        settings=_settings(),
+        api_client=api,
+        embedder=embedder,
+        tracker=tracker,
+        picker=picker,
+        s3_client=s3,
+    )
+
+    api.fail.assert_called_once()
+    assert api.fail.call_args.kwargs["error_code"] == "proxy_missing"
+    tracker.track.assert_not_called()
+    s3.download_file.assert_not_called()
+
+
+def test_scan_order_parent_downloads_proxy_once_for_multiple_products():
+    """Critical invariant: N products in one scan order → exactly
+    ONE S3 GET on the proxy. The download lives in
+    ``_handle_scan_order_parent`` (outside the per-product loop)
+    so each product reuses the same local file. A regression here
+    would multiply Aircloud's cold-start S3 cost N× without any
+    pipeline benefit."""
+    api = _make_apis(render_job_id=uuid4())
+    # Three catalog entries; each kicks off retrieve+SAM2.
+    api.fetch_catalog_entries_for_video.return_value = [
+        {
+            "catalog_entry_id": str(uuid4()),
+            "org_id": str(uuid4()),
+            "video_id": "gd_test",
+            "canonical_crop_s3_key": f"k{i}.jpg",
+            "canonical_bbox": {"x": 0, "y": 0, "w": 10, "h": 10},
+            "llm_label": f"제품{i}",
+        }
+        for i in range(3)
+    ]
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+
+    with patch(
+        "src.tasks.track._fetch_canonical_crop",
+        return_value=_fake_canonical(),
+    ):
+        handle_track_job(
+            message=_scan_order_body(),
+            settings=_settings(),
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    # The contract — one download per scan_order, NOT per product.
+    assert s3.download_file.call_count == 1, (
+        f"expected exactly one proxy download per scan_order, got "
+        f"{s3.download_file.call_count} — per-product download regression"
+    )
+    # And the path used was the canonical proxy_s3_key from the
+    # scenes-with-keyframes response.
+    download_args = s3.download_file.call_args.args
+    assert download_args[0] == "tenant/drive/d/g/proxy.mp4"

--- a/services/product-track-worker/tests/test_proxy_download.py
+++ b/services/product-track-worker/tests/test_proxy_download.py
@@ -1,0 +1,106 @@
+"""Unit tests for ``src.proxy_download``. No real S3 in the loop —
+the helper is structural-typed against an ``S3DownloadClient``
+Protocol, so a stub class is enough."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.proxy_download import downloaded_proxy
+
+
+class _StubS3:
+    """Records calls + simulates a successful download by writing
+    placeholder bytes at the requested local path. Tests assert
+    against ``calls`` and against the file existing during the
+    ``with`` block."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Path]] = []
+
+    def download_file(self, s3_key: str, local_path: Path) -> None:
+        self.calls.append((s3_key, local_path))
+        # Simulate the real boto3 download by creating a file at the
+        # target. Tests use this to verify the path is reachable
+        # inside the ``with`` and gone after.
+        local_path.write_bytes(b"fake-mp4-bytes")
+
+
+def test_downloads_to_tempdir_named_by_job_id(tmp_path):
+    s3 = _StubS3()
+    with downloaded_proxy(
+        s3=s3,
+        proxy_s3_key="org/drive/d/g/proxy.mp4",
+        job_id_for_naming="job-abc",
+        parent_dir=tmp_path,
+    ) as local:
+        # Path lives under tmp_path (not /tmp) and the dirname
+        # carries the job id so concurrent jobs can't collide.
+        assert tmp_path in local.parents
+        assert "job-abc" in local.parent.name
+        assert local.name == "proxy.mp4"
+        assert local.exists()
+
+    # Tempdir cleaned up on normal exit.
+    assert not local.exists()
+    # Exactly one S3 GET issued (key contract — the worker calls
+    # this once per message, not once per scene).
+    assert s3.calls == [("org/drive/d/g/proxy.mp4", local)]
+
+
+def test_cleans_up_on_exception_inside_with_block(tmp_path):
+    """The ``with`` cleanup MUST run even when the body raises (F4
+    stage-wide-failure path). Aircloud /tmp is tight; a leak across
+    retries would wedge the container."""
+    s3 = _StubS3()
+    captured_path: Path | None = None
+    with pytest.raises(RuntimeError, match="boom"):
+        with downloaded_proxy(
+            s3=s3,
+            proxy_s3_key="k",
+            job_id_for_naming="job-xyz",
+            parent_dir=tmp_path,
+        ) as local:
+            captured_path = local
+            assert captured_path.exists()
+            raise RuntimeError("boom")
+
+    assert captured_path is not None
+    assert not captured_path.exists()
+    assert not captured_path.parent.exists(), "tempdir must be removed on exception"
+
+
+def test_raises_value_error_on_empty_key(tmp_path):
+    """Defensive: callers should null-check before calling, but if
+    they don't, fail loudly rather than letting boto3 emit a
+    cryptic ``InvalidArgument`` that buries the root cause."""
+    s3 = _StubS3()
+    with pytest.raises(ValueError, match="proxy_s3_key is empty"):
+        with downloaded_proxy(
+            s3=s3,
+            proxy_s3_key="",
+            job_id_for_naming="job-xyz",
+            parent_dir=tmp_path,
+        ):
+            pass
+    # No S3 call attempted on the empty-key path.
+    assert s3.calls == []
+
+
+def test_propagates_s3_download_failure(tmp_path):
+    """Real S3 errors propagate so the worker's outer try/except
+    can map them to ``error_code=proxy_download_failed`` rather than
+    swallowing — the worker would silently bill the user otherwise."""
+    s3 = MagicMock()
+    s3.download_file.side_effect = RuntimeError("S3 timeout")
+    with pytest.raises(RuntimeError, match="S3 timeout"):
+        with downloaded_proxy(
+            s3=s3,
+            proxy_s3_key="k",
+            job_id_for_naming="job",
+            parent_dir=tmp_path,
+        ):
+            pass

--- a/services/product-track-worker/tests/test_render_enqueue.py
+++ b/services/product-track-worker/tests/test_render_enqueue.py
@@ -65,8 +65,14 @@ def _fake_canonical():
 def _scenes_response(n: int = 3) -> dict:
     return {
         "video_id": "gd_test",
+        "proxy_s3_key": "tenant/drive/d/g/proxy.mp4",
         "scenes": [
-            {"scene_id": f"gd_test_scene_{i:03d}", "keyframe_s3_key": f"k{i}.jpg"}
+            {
+                "scene_id": f"gd_test_scene_{i:03d}",
+                "keyframe_s3_key": f"k{i}.jpg",
+                "start_ms": i * 5000,
+                "end_ms": (i + 1) * 5000,
+            }
             for i in range(n)
         ],
     }

--- a/services/product-track-worker/tests/test_sam2.py
+++ b/services/product-track-worker/tests/test_sam2.py
@@ -115,21 +115,39 @@ class TestMaskToBbox:
 class _FakeVideoCapture:
     """Mimics cv2.VideoCapture for tests — returns a programmable
     sequence of (ok, frame) pairs and reports configurable
-    metadata."""
+    metadata.
 
-    def __init__(self, *, frames: list[np.ndarray], fps: float = 30.0):
+    Tracks playback position so the tracker's ``cap.set(POS_MSEC)``
+    seek + ``cap.get(POS_MSEC)`` window-trim logic can be exercised
+    without a real video file. ``keyframe_interval_ms`` simulates
+    the keyframe-aligned seek behaviour of real cv2 + H.264 — when
+    set, ``set(POS_MSEC, t)`` snaps to the largest keyframe <= t,
+    which is exactly the scenario the pre-roll-drop logic in
+    ``Sam2TrackerImpl`` defends against.
+    """
+
+    def __init__(
+        self,
+        *,
+        frames: list[np.ndarray],
+        fps: float = 30.0,
+        keyframe_interval_ms: int | None = None,
+    ):
         self._frames = frames
         self._idx = 0
         self._fps = fps
         self._w = frames[0].shape[1] if frames else 0
         self._h = frames[0].shape[0] if frames else 0
         self._opened = bool(frames)
+        self._keyframe_interval_ms = keyframe_interval_ms
+        # Public so tests can assert against seek calls without
+        # reaching for a MagicMock spy.
+        self.set_calls: list[tuple[int, float]] = []
 
     def isOpened(self) -> bool:
         return self._opened
 
     def get(self, prop: int) -> float:
-        # Mirror the cv2 prop ids the tracker queries.
         import cv2
         if prop == cv2.CAP_PROP_FRAME_WIDTH:
             return float(self._w)
@@ -139,7 +157,29 @@ class _FakeVideoCapture:
             return self._fps
         if prop == cv2.CAP_PROP_FRAME_COUNT:
             return float(len(self._frames))
+        if prop == cv2.CAP_PROP_POS_MSEC:
+            # cv2 convention: time of the NEXT frame to be decoded.
+            if self._fps <= 0:
+                return 0.0
+            return self._idx * 1000.0 / self._fps
         return 0.0
+
+    def set(self, prop: int, value: float) -> bool:
+        import cv2
+        self.set_calls.append((prop, float(value)))
+        if prop == cv2.CAP_PROP_POS_MSEC:
+            target_ms = float(value)
+            if self._keyframe_interval_ms is not None:
+                # Snap to largest keyframe <= target — mirrors real
+                # cv2 + H.264 with a finite GOP.
+                kf = self._keyframe_interval_ms
+                target_ms = (int(target_ms) // kf) * kf
+            if self._fps <= 0:
+                self._idx = 0
+            else:
+                self._idx = max(0, int(round(target_ms * self._fps / 1000.0)))
+            return True
+        return False
 
     def read(self) -> tuple[bool, np.ndarray | None]:
         if self._idx >= len(self._frames):
@@ -179,7 +219,9 @@ class TestSam2TrackerImplFailureModes:
                     scene_id="s1",
                     anchor_bbox=_bbox_for_320x240(),
                     anchor_keyframe=Image.new("RGB", (1, 1)),
-                    scene_video_url="bad://url",
+                    full_video_path="/nonexistent/proxy.mp4",
+                    scene_start_ms=0,
+                    scene_end_ms=1000,
                     sample_fps=5,
                 )
 
@@ -198,7 +240,9 @@ class TestSam2TrackerImplFailureModes:
                     scene_id="s1",
                     anchor_bbox=bad_bbox,
                     anchor_keyframe=Image.new("RGB", (1, 1)),
-                    scene_video_url="x",
+                    full_video_path="/tmp/proxy.mp4",
+                    scene_start_ms=0,
+                    scene_end_ms=1000,
                     sample_fps=5,
                 )
 
@@ -214,12 +258,14 @@ class TestSam2TrackerImplFailureModes:
         cap = _FakeVideoCapture(frames=[])
         cap._opened = True  # noqa: SLF001
         with patch("cv2.VideoCapture", return_value=cap):
-            with pytest.raises(RuntimeError, match="no frames decoded"):
+            with pytest.raises(RuntimeError, match="no frames decoded in scene window"):
                 tracker.track(
                     scene_id="s1",
                     anchor_bbox=_bbox_for_320x240(),
                     anchor_keyframe=Image.new("RGB", (1, 1)),
-                    scene_video_url="x",
+                    full_video_path="/tmp/proxy.mp4",
+                    scene_start_ms=0,
+                    scene_end_ms=1000,
                     sample_fps=5,
                 )
 
@@ -255,8 +301,9 @@ class TestSam2TrackerImplHappyPath:
         """5 propagated frames → 5 ``TrackedSample`` rows in
         monotonic ``frame_timestamp_ms`` order; each carries the
         bbox ``_mask_to_bbox`` derives from the predictor's mask."""
-        # Source video: 30fps, 30 frames total; sample_fps=5 →
-        # stride=6 → 5 sampled frames at indexes [0, 6, 12, 18, 24].
+        # Source video: 30fps, 30 frames covering 0..966 ms. Scene
+        # window 0..1000 ms; sample_fps=5 → 200 ms cadence → frames
+        # accepted at timestamps 0, 200, 400, 600, 800.
         frames = [_green_frame() for _ in range(30)]
         cap = _FakeVideoCapture(frames=frames, fps=30.0)
         model = self._make_fake_predictor()
@@ -272,14 +319,17 @@ class TestSam2TrackerImplHappyPath:
                 scene_id="s1",
                 anchor_bbox=_bbox_for_320x240(),
                 anchor_keyframe=Image.new("RGB", (1, 1)),
-                scene_video_url="x",
+                full_video_path="/tmp/proxy.mp4",
+                scene_start_ms=0,
+                scene_end_ms=1000,
                 sample_fps=5,
             )
 
         assert len(samples) == 5
         timestamps = [s.frame_timestamp_ms for s in samples]
         assert timestamps == sorted(timestamps), "monotonic ascending order"
-        # Frame indexes 0, 6, 12, 18, 24 at 30fps → 0, 200, 400, 600, 800ms.
+        # Sample boundaries at 0, 200, 400, 600, 800 ms hit frames at
+        # the same exact timestamps (30fps lands cleanly).
         assert timestamps == [0, 200, 400, 600, 800]
         # Mask is 60x60 starting at (30, 20) per ``_make_fake_predictor``.
         assert all(s.bbox.width == 60 and s.bbox.height == 60 for s in samples)
@@ -287,3 +337,145 @@ class TestSam2TrackerImplHappyPath:
         assert all(s.frame_width == 320 and s.frame_height == 240 for s in samples)
         # Confidence taken from masks.score per-frame.
         assert all(0.9 < s.mask_confidence <= 1.0 for s in samples)
+
+
+# =====================================================================
+# Sam2TrackerImpl seek + scene-window behaviour (post-2026-05-04)
+# =====================================================================
+
+
+def _adaptive_predictor(*, mask_h: int = 240, mask_w: int = 320) -> MagicMock:
+    """Like ``_make_fake_predictor`` but emits one sample per
+    sampled frame regardless of count — the new tests below sample
+    different numbers of frames depending on the scene window."""
+    import torch
+
+    def _make_mask():
+        m = np.zeros((mask_h, mask_w), dtype=np.uint8)
+        m[20:80, 30:90] = 1
+        return torch.tensor(m)
+
+    captured: dict = {}
+
+    def _propagate(state):
+        # Walk an arbitrary number of indices — the tracker stops
+        # iterating once ``prop_idx >= len(sampled_frames)``.
+        for prop_idx in range(captured.get("sample_count", 1000)):
+            masks = MagicMock()
+            masks.__getitem__.return_value = _make_mask()
+            masks.score = 0.95
+            yield prop_idx, [1], masks
+
+    model = MagicMock()
+    model.init_state.return_value = MagicMock()
+    model.add_new_points_or_box.return_value = None
+    model.propagate_in_video.side_effect = _propagate
+    return model
+
+
+class TestSam2TrackerImplSeekAndWindow:
+    """Exercises the seek + per-scene window-trim logic added when
+    SAM2 switched from per-scene mp4s to a single full-video proxy
+    (handoff sam2-proxy-handoff-2026-05-04)."""
+
+    def _build(self, *, frames, fps=30.0, keyframe_interval_ms=None):
+        cap = _FakeVideoCapture(
+            frames=frames, fps=fps, keyframe_interval_ms=keyframe_interval_ms,
+        )
+        model = _adaptive_predictor()
+        processor = MagicMock()
+        processor.return_value.to.return_value = {"pixel_values": MagicMock()}
+        set_singleton_for_testing(_fake_loaded(model, processor=processor))
+        return cap, Sam2TrackerImpl(model_id="x")
+
+    def test_seek_called_once_with_scene_start_ms(self):
+        """Tracker MUST call ``cap.set(CAP_PROP_POS_MSEC, scene_start_ms)``
+        exactly once before reading any frames. Locks the contract
+        so a future refactor that "optimizes away" the seek for
+        scene_start_ms=0 doesn't silently regress non-zero windows."""
+        import cv2
+        cap, tracker = self._build(frames=[_green_frame() for _ in range(60)])
+
+        with patch("cv2.VideoCapture", return_value=cap):
+            tracker.track(
+                scene_id="s1",
+                anchor_bbox=_bbox_for_320x240(),
+                anchor_keyframe=Image.new("RGB", (1, 1)),
+                full_video_path="/tmp/proxy.mp4",
+                scene_start_ms=400,
+                scene_end_ms=1000,
+                sample_fps=5,
+            )
+
+        seek_calls = [
+            (prop, val) for prop, val in cap.set_calls
+            if prop == cv2.CAP_PROP_POS_MSEC
+        ]
+        assert seek_calls == [(cv2.CAP_PROP_POS_MSEC, 400.0)], (
+            f"expected exactly one POS_MSEC seek to 400.0, got {seek_calls}"
+        )
+
+    def test_pre_roll_frames_dropped_when_seek_keyframe_aligned(self):
+        """Real cv2 + H.264 seeks to the keyframe BEFORE the
+        requested ms (every 2s GOP here). The tracker must drop
+        those pre-roll frames so SAM2 only sees frames inside the
+        candidate window. Without this, scene-boundary detection
+        would be polluted by frames from the PRECEDING scene."""
+        # 6s video at 30fps = 180 frames; keyframes every 2000ms.
+        frames = [_green_frame() for _ in range(180)]
+        cap, tracker = self._build(
+            frames=frames, fps=30.0, keyframe_interval_ms=2000,
+        )
+
+        with patch("cv2.VideoCapture", return_value=cap):
+            samples = tracker.track(
+                scene_id="s1",
+                anchor_bbox=_bbox_for_320x240(),
+                anchor_keyframe=Image.new("RGB", (1, 1)),
+                full_video_path="/tmp/proxy.mp4",
+                # Seek to 5000 ms snaps to keyframe at 4000 ms.
+                # Frames 4000..4966 are pre-roll — must NOT appear
+                # in samples.
+                scene_start_ms=5000,
+                scene_end_ms=6000,
+                sample_fps=5,
+            )
+
+        assert len(samples) > 0, "should have emitted at least one in-window sample"
+        for s in samples:
+            assert s.frame_timestamp_ms >= 5000, (
+                f"pre-roll frame leaked: ts={s.frame_timestamp_ms} < scene_start=5000"
+            )
+            assert s.frame_timestamp_ms <= 6000, (
+                f"post-window frame leaked: ts={s.frame_timestamp_ms} > scene_end=6000"
+            )
+
+    def test_loop_stops_at_scene_end_ms(self):
+        """Decoding the whole proxy when only a scene's worth of
+        frames is needed wastes 10x+ on a typical livecommerce
+        video. The loop must break the moment ``pos_ms >
+        scene_end_ms``, not just filter."""
+        # 4s of video (120 frames at 30fps). Window only covers
+        # the first second.
+        frames = [_green_frame() for _ in range(120)]
+        cap, tracker = self._build(frames=frames, fps=30.0)
+
+        with patch("cv2.VideoCapture", return_value=cap):
+            samples = tracker.track(
+                scene_id="s1",
+                anchor_bbox=_bbox_for_320x240(),
+                anchor_keyframe=Image.new("RGB", (1, 1)),
+                full_video_path="/tmp/proxy.mp4",
+                scene_start_ms=0,
+                scene_end_ms=1000,
+                sample_fps=5,
+            )
+
+        # No sample exceeds the scene end — strong signal that the
+        # loop stopped, not just filtered.
+        assert all(s.frame_timestamp_ms <= 1000 for s in samples)
+        # Cap stopped reading shortly after 1000 ms — index advanced
+        # to ~31 (frame at 1033 ms triggered the break), not 120.
+        assert cap._idx <= 35, (
+            f"loop kept decoding past the window: read {cap._idx} of 120 frames"
+        )

--- a/services/product-track-worker/tests/test_track_f4.py
+++ b/services/product-track-worker/tests/test_track_f4.py
@@ -82,8 +82,14 @@ def _fake_canonical():
 def _scenes_response(n: int = 3) -> dict:
     return {
         "video_id": "gd_test",
+        "proxy_s3_key": "tenant/drive/d/g/proxy.mp4",
         "scenes": [
-            {"scene_id": f"gd_test_scene_{i:03d}", "keyframe_s3_key": f"k{i}.jpg"}
+            {
+                "scene_id": f"gd_test_scene_{i:03d}",
+                "keyframe_s3_key": f"k{i}.jpg",
+                "start_ms": i * 5000,
+                "end_ms": (i + 1) * 5000,
+            }
             for i in range(n)
         ],
     }
@@ -174,7 +180,9 @@ class TestCountingSam2Tracker:
             scene_id="s1",
             anchor_bbox=BBoxXYWH(x=0, y=0, width=10, height=10),
             anchor_keyframe=Image.new("RGB", (1, 1)),
-            scene_video_url="s3://x",
+            full_video_path="/tmp/proxy.mp4",
+            scene_start_ms=0,
+            scene_end_ms=5000,
             sample_fps=5,
         )
 

--- a/services/web/src/features/shorts-auto-product-wizard/__tests__/friendlyParentError.test.ts
+++ b/services/web/src/features/shorts-auto-product-wizard/__tests__/friendlyParentError.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { friendlyParentError } from "../pages/WizardStepResult";
+
+describe("friendlyParentError", () => {
+  it("maps proxy_missing to a transcode-not-ready Korean message", () => {
+    const out = friendlyParentError(
+      "proxy_missing",
+      "DriveFile abc has no proxy_s3_key — transcode incomplete",
+    );
+    // Domain-specific message — does not surface the raw file_id.
+    expect(out).toContain("트랜스코딩");
+    expect(out).not.toContain("DriveFile");
+    expect(out).not.toContain("proxy_s3_key");
+  });
+
+  it("falls back to raw code+message for unknown error codes", () => {
+    // Locks the contract that NEW backend error codes surface
+    // visibly (raw) so a missed mapping is loud, not silent.
+    const out = friendlyParentError("internal_error", "boom");
+    expect(out).toBe("오류: internal_error — boom");
+  });
+
+  it("falls back to just the code when message is null", () => {
+    expect(friendlyParentError("internal_error", null)).toBe(
+      "오류: internal_error",
+    );
+  });
+});

--- a/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepResult.tsx
+++ b/services/web/src/features/shorts-auto-product-wizard/pages/WizardStepResult.tsx
@@ -135,12 +135,38 @@ function ParentProgress({
           className="rounded-md bg-red-50 p-2 text-xs text-red-700"
           data-testid="parent-error"
         >
-          오류: {parent.error_code}
-          {parent.error_message ? ` — ${parent.error_message}` : ""}
+          {friendlyParentError(parent.error_code, parent.error_message)}
         </p>
       ) : null}
     </div>
   );
+}
+
+/**
+ * Map known parent-job error codes to user-facing Korean messages.
+ * Unknown codes fall back to the raw code + message so a backend
+ * regression that adds a new code surfaces visibly rather than
+ * disappearing into a generic "오류" blob.
+ *
+ * Exported for unit tests; not used elsewhere in the file.
+ */
+export function friendlyParentError(
+  errorCode: string,
+  errorMessage: string | null,
+): string {
+  switch (errorCode) {
+    case "proxy_missing":
+      // Transcode hasn't completed for this video yet. The user
+      // sees this when they pick a video whose drive proxy hasn't
+      // been written (or was deleted). Backend message names the
+      // file_id, which isn't useful to users — drop it here.
+      return (
+        "이 영상은 아직 트랜스코딩이 완료되지 않았어요. 영상 목록에서 " +
+        "체크 표시가 뜬 다음 다시 시도해 주세요."
+      );
+    default:
+      return `오류: ${errorCode}${errorMessage ? ` — ${errorMessage}` : ""}`;
+  }
 }
 
 interface ChildListProps {


### PR DESCRIPTION
## Summary

PR B of two for the SAM2 scene-proxy gap. Closes the loop opened in PR A on heimdex-media-pipelines (#5). Wires the `Sam2Tracker` Protocol change into the API, the worker, and the wizard error UI so the auto-shorts wizard can run end-to-end on a populated catalog video.

Three commits, three layers:

1. **api**: `GET /internal/videos/{file_id}/scenes-with-keyframes` returns `proxy_s3_key` (mirrors `DriveFile.proxy_s3_key` verbatim). Nullable; null = transcode incomplete.
2. **product-track-worker**:
   - New `proxy_download.py` context-managed downloader (one S3 GET per job, tempdir cleanup on success + exception).
   - `Sam2TrackerImpl.track` rewritten — `cv2.set(POS_MSEC, scene_start_ms)` + frame-window read, drops pre-roll frames whose ts < scene_start_ms.
   - Both call sites (legacy single-product + wizard scan_order parent) extract `proxy_s3_key`, fast-fail with `error_code='proxy_missing'` if null, wrap SAM2 region in `with downloaded_proxy(...)`.
   - `CoarseRetrievalClientImpl` takes `scene_id_to_timing` so `CoarseCandidate.start_ms`/`end_ms` flow through to the lib without a new fetch.
3. **wizard**: maps `proxy_missing` to a friendly Korean "video isn't ready yet" message; unknown codes still surface raw so missed mappings are loud.

## Cross-repo coordination

This PR depends on **heimdex-media-pipelines [#5](https://github.com/jlee-heimdex/heimdex-media-pipelines/pull/5)** (`v0.13.0`). The Dockerfile.gpu COPYs pipelines from build context, so the GHCR rebuild for product-track will pull whatever the pipelines repo's `main` HEAD points at when triggered.

After merge, the deploy sequence is:
```
1. Merge pipelines #5 -> main
2. Merge this PR -> main (staging api+web auto-deploys)
3. gh workflow run build-gpu-images.yml -f workers=product-track
4. Restart Aircloud product-track container (d809c6e8-...)
5. Re-trigger wizard scan on gd_05e7f957502e86cf to validate
```

## Loose-coupling self-audit

- `proxy_download.py` has no `boto3` / `requests` imports — uses a structural `S3DownloadClient` Protocol so tests stub without touching boto3.
- `proxy_download.py` does NOT import from `tasks/track.py` — no circular deps.
- API never imports `heimdex_media_pipelines` (unchanged).
- Pipelines lib has zero S3 / boto3 imports under `product_track/` (verified in PR A).
- `full_video_path` is opaque to the lib — no parsing, transformation, or resolution inside `propagate_within_candidate_scenes`.
- Drive key construction lives in ONE place (`heimdex_worker_sdk.drive_keys.proxy_s3_key`); the worker reads `proxy_s3_key` from the API, never reconstructs.

## Test plan

- [x] **API** — 10/10 pass: `pytest tests/test_videos_internal_scenes_with_keyframes.py` (3 new assertions: present/null/canonical-passthrough).
- [x] **Worker** — 84/84 pass: full `pytest tests/`. New tests: `test_proxy_download.py` (4), `test_sam2.py::TestSam2TrackerImplSeekAndWindow` (3 — seek called, pre-roll drop, end-of-window break), `test_e2e_track_pipeline.py` (3 — proxy_missing on legacy + scan_order, download-once invariant).
- [x] **Frontend** — 9/9 pass: `vitest run friendlyParentError.test.ts WizardStepResult.test.tsx`. New tests: 3 for the error mapper.
- [x] CI allowlist updated — backend pytest gate now runs the API endpoint test.
- [ ] Staging soak on `gd_05e7f957502e86cf` after Aircloud rebuild — wizard should reach `done` with children carrying `render_job_id`s.
- [ ] Calibration check: confirm cv2 keyframe-aligned seek precision is acceptable on real H.264 proxies (window IoU ≥ 0.6 on staging goldens). If it regresses, fall back to PyAV `any_frame=True` seek as a follow-up.

## Risk + rollback

`AUTO_SHORTS_PRODUCT_V2_ENABLED=false` is the master kill switch — flipping it to false stops all new wizard scans. Each commit revertable independently:

- Revert wizard commit only -> raw error display restored, no behavior change.
- Revert worker commit only -> `proxy_s3_key` field still on the API response (forward-compatible, old workers ignore it).
- Revert API commit only -> requires reverting the worker too (worker reads the field).

## Out of scope

- Production rollout (`AUTO_SHORTS_PRODUCT_V2_ENABLED=true` on prod) — separate Phase 4+ ticket; gates on goldens validation + IAM PR for the 4 SQS ARNs + Aircloud onboarding.
- PyAV fallback for cv2 seek precision — only if the staging soak shows regression.