### PR TITLE
feat(product-track-worker): emit worker_events at every F4 site

### DIFF
--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -73,6 +73,7 @@ from heimdex_media_pipelines.product_track.subset_selector import (
 from heimdex_media_pipelines.product_track.window_assembly import (
     assemble_windows,
 )
+from heimdex_worker_sdk import emit_event
 from heimdex_worker_sdk.s3 import S3Client
 
 from src.api_client import ApiClient
@@ -1409,13 +1410,33 @@ def _handle_scan_order_parent(
                     continue
                 aggregated_appearances.extend(entry_appearances)
                 products_succeeded += 1
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     "scan_order_per_product_failed",
                     extra={
                         "job_id": str(decoded.job_id),
                         "catalog_entry_id": str(entry_id),
                         "entry_label": entry_label,
+                    },
+                )
+                # Surface the exception type + message via worker_events
+                # so failures are SQL-queryable without Aircloud logs.
+                # Truncated to 1000 chars to respect the 16KB metadata
+                # cap on the worker_events ingest endpoint.
+                emit_event(
+                    service="product-track-worker",
+                    event_name="scan_order_per_product_failed",
+                    category="job_failure",
+                    level="ERROR",
+                    org_id=str(decoded.org_id),
+                    job_id=str(decoded.job_id),
+                    video_id=decoded.video_id,
+                    message=f"{type(exc).__name__}: {exc}"[:1000],
+                    metadata={
+                        "catalog_entry_id": str(entry_id),
+                        "entry_label": entry_label,
+                        "exception_type": type(exc).__name__,
+                        "exception_message": str(exc)[:1000],
                     },
                 )
                 products_f4_failed += 1
@@ -1427,6 +1448,27 @@ def _handle_scan_order_parent(
         # from "all products produced no qualifying windows" (correct
         # behavior, just no good content).
         if products_f4_failed == len(catalog_entries):
+            emit_event(
+                service="product-track-worker",
+                event_name="scan_order_all_products_f4_failed",
+                category="job_failure",
+                level="ERROR",
+                org_id=str(decoded.org_id),
+                job_id=str(decoded.job_id),
+                video_id=decoded.video_id,
+                message=(
+                    f"all {len(catalog_entries)} products F4-failed; query "
+                    f"worker_events WHERE job_id={decoded.job_id} for the "
+                    f"per-product reasons (events scan_order_product_*_f4 "
+                    f"and scan_order_per_product_failed carry the cause)."
+                ),
+                metadata={
+                    "products_total": len(catalog_entries),
+                    "products_succeeded": products_succeeded,
+                    "products_no_qualifying": products_no_qualifying,
+                    "products_f4_failed": products_f4_failed,
+                },
+            )
             api.fail(
                 job_id=decoded.job_id,
                 claimed_by=settings.worker_id,
@@ -1435,7 +1477,8 @@ def _handle_scan_order_parent(
                 error_message=(
                     f"all {len(catalog_entries)} products F4-failed — "
                     f"likely a stage-wide regression (SigLIP2 / S3 / SAM2). "
-                    f"Check worker logs for per-product failures."
+                    f"Query worker_events WHERE job_id={decoded.job_id} "
+                    f"for the per-product reasons."
                 ),
             )
         else:
@@ -1546,6 +1589,27 @@ def _process_one_product_for_parent(
             "scan_order_product_keyframe_f4",
             extra={"entry_id": str(entry_id), "attempted": keyframe_fetcher.attempted},
         )
+        emit_event(
+            service="product-track-worker",
+            event_name="scan_order_product_keyframe_f4",
+            category="job_failure",
+            level="WARNING",
+            org_id=str(decoded.org_id),
+            job_id=str(decoded.job_id),
+            video_id=decoded.video_id,
+            message=(
+                f"every keyframe fetch raised for catalog_entry "
+                f"{entry_id} ({entry_label}); attempted="
+                f"{keyframe_fetcher.attempted}. Likely S3 outage, "
+                f"wrong bucket, or MINIO_ENDPOINT regression."
+            ),
+            metadata={
+                "entry_id": str(entry_id),
+                "entry_label": entry_label,
+                "attempted": keyframe_fetcher.attempted,
+                "stage": "keyframe_fetch",
+            },
+        )
         return None
     if embedder_impl.per_scene_all_failed():
         logger.warning(
@@ -1553,6 +1617,27 @@ def _process_one_product_for_parent(
             extra={
                 "entry_id": str(entry_id),
                 "attempted": embedder_impl.per_scene_attempted,
+            },
+        )
+        emit_event(
+            service="product-track-worker",
+            event_name="scan_order_product_siglip_f4",
+            category="job_failure",
+            level="WARNING",
+            org_id=str(decoded.org_id),
+            job_id=str(decoded.job_id),
+            video_id=decoded.video_id,
+            message=(
+                f"every per-scene SigLIP2 embed raised for catalog_entry "
+                f"{entry_id} ({entry_label}); attempted="
+                f"{embedder_impl.per_scene_attempted}. Likely a bad SigLIP2 "
+                f"deploy or corrupted HF cache."
+            ),
+            metadata={
+                "entry_id": str(entry_id),
+                "entry_label": entry_label,
+                "attempted": embedder_impl.per_scene_attempted,
+                "stage": "siglip2_embed",
             },
         )
         return None
@@ -1578,6 +1663,27 @@ def _process_one_product_for_parent(
         logger.warning(
             "scan_order_product_sam2_f4",
             extra={"entry_id": str(entry_id), "attempted": tracker_impl.attempted},
+        )
+        emit_event(
+            service="product-track-worker",
+            event_name="scan_order_product_sam2_f4",
+            category="job_failure",
+            level="WARNING",
+            org_id=str(decoded.org_id),
+            job_id=str(decoded.job_id),
+            video_id=decoded.video_id,
+            message=(
+                f"every SAM2 track raised for catalog_entry {entry_id} "
+                f"({entry_label}); attempted={tracker_impl.attempted}. "
+                f"Likely SAM2 OOM, wrong checkpoint, or proxy decode "
+                f"failure on every candidate scene."
+            ),
+            metadata={
+                "entry_id": str(entry_id),
+                "entry_label": entry_label,
+                "attempted": tracker_impl.attempted,
+                "stage": "sam2_track",
+            },
         )
         return None
 

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -683,3 +683,110 @@ def test_scan_order_parent_downloads_proxy_once_for_multiple_products():
     # scenes-with-keyframes response.
     download_args = s3.download_file.call_args.args
     assert download_args[0] == "tenant/drive/d/g/proxy.mp4"
+
+
+# =====================================================================
+# Per-stage F4 worker_event diagnostics (PR C, post-2026-05-04 incident)
+# =====================================================================
+
+
+def test_canonical_crop_s3_returns_none_emits_per_product_failed_event_with_exception_details():
+    """Regression coverage for the silent-S3-None failure mode that
+    cost us a debugging session 2026-05-04 (Aircloud container lost
+    its ``MINIO_ENDPOINT=disabled`` override on restart, every S3
+    read returned None, ``_fetch_canonical_crop`` raised
+    ``FileNotFoundError``, the outer ``except Exception`` caught it
+    and only logged to stdout — leaving the operator with the
+    opaque ``internal_error`` aggregate message).
+
+    Pin the contract that the per-product exception handler emits a
+    structured worker_event carrying the exception type + message,
+    so the same failure is SQL-queryable from the api DB without
+    chasing Aircloud container logs."""
+    catalog_entry_id = uuid4()
+    api = MagicMock()
+    api.fetch_catalog_entries_for_video.return_value = [
+        {
+            "catalog_entry_id": str(catalog_entry_id),
+            "org_id": str(uuid4()),
+            "video_id": "gd_test",
+            "canonical_crop_s3_key": "tenant/products/x/y.jpg",
+            "canonical_bbox": {"x": 0, "y": 0, "w": 10, "h": 10},
+            "llm_label": "테스트 제품",
+        }
+    ]
+    # _fetch_canonical_crop reads the entry by id, then s3-fetches.
+    # Return the matching payload from the single-entry endpoint
+    # so the org-mismatch defence-in-depth doesn't fire first.
+    org_id = uuid4()
+    api.fetch_catalog_entry.return_value = {
+        "catalog_entry_id": str(catalog_entry_id),
+        "org_id": str(org_id),
+        "video_id": "gd_test",
+        "canonical_crop_s3_key": "tenant/products/x/y.jpg",
+        "canonical_bbox": {"x": 0, "y": 0, "w": 10, "h": 10},
+        "llm_label": "테스트 제품",
+    }
+    # Re-stub the catalog list to the matching org so both paths agree.
+    api.fetch_catalog_entries_for_video.return_value[0]["org_id"] = str(org_id)
+    api.fetch_scenes_with_keyframes.return_value = _scenes_response(n=3)
+
+    embedder, s3, tracker, picker = _make_pipeline_mocks()
+    # Simulate the MINIO_ENDPOINT regression: S3 reads silently
+    # return None instead of raising. _fetch_canonical_crop's null
+    # check then raises FileNotFoundError.
+    s3.get_object_bytes.return_value = None
+
+    # Body uses the matching org_id so Pattern B doesn't 404.
+    body = _scan_order_body()
+    body["org_id"] = str(org_id)
+
+    with patch("src.tasks.track.emit_event") as mock_emit:
+        handle_track_job(
+            message=body,
+            settings=_settings(),
+            api_client=api,
+            embedder=embedder,
+            tracker=tracker,
+            picker=picker,
+            s3_client=s3,
+        )
+
+    # Two events fire on this path:
+    #   1. scan_order_per_product_failed — captures FileNotFoundError
+    #   2. scan_order_all_products_f4_failed — aggregate summary
+    event_names = [c.kwargs.get("event_name") for c in mock_emit.call_args_list]
+    assert "scan_order_per_product_failed" in event_names, (
+        f"per-product event missing — operators have no SQL-queryable "
+        f"signal of which step failed. Got: {event_names}"
+    )
+    assert "scan_order_all_products_f4_failed" in event_names
+
+    # Per-product event MUST carry the exception type/message so a
+    # MINIO regression / S3 outage / catalog-corruption are all
+    # distinguishable in worker_events queries.
+    per_product = next(
+        c for c in mock_emit.call_args_list
+        if c.kwargs.get("event_name") == "scan_order_per_product_failed"
+    )
+    md = per_product.kwargs["metadata"]
+    assert md["exception_type"] == "FileNotFoundError", (
+        f"exception_type missing or wrong; metadata={md}"
+    )
+    assert "canonical crop" in md["exception_message"].lower(), (
+        f"exception_message should reference the failure source; got: {md}"
+    )
+    # job_id + video_id propagated so per-job triage is one query.
+    # ``video_id`` here is ``TrackJobMessage.video_id`` — the
+    # DriveFile UUID, NOT the OS string "gd_test". Worker_events
+    # convention across services.
+    assert per_product.kwargs.get("job_id") is not None
+    assert per_product.kwargs.get("video_id") is not None
+
+    # And api.fail's error_message points operators at worker_events
+    # (instead of "Check worker logs" which means Aircloud-only).
+    api.fail.assert_called_once()
+    fail_msg = api.fail.call_args.kwargs["error_message"]
+    assert "worker_events" in fail_msg, (
+        f"fail message should redirect to worker_events; got: {fail_msg}"
+    )


### PR DESCRIPTION
## Summary

Hardening triggered by today's 2026-05-04 staging incident: the wizard scan on \`gd_05e7f957502e86cf\` failed with the opaque \`internal_error / "all 1 products F4-failed"\` aggregate message. The actual root cause was \`MINIO_ENDPOINT=disabled\` was lost on the Aircloud container's restart with the new image, every \`s3.get_object_bytes\` silently returned \`None\`, and \`_fetch_canonical_crop\` raised \`FileNotFoundError\` — but that exception type and message were only logged to stdout (Aircloud container logs).

This PR makes every F4 site **SQL-queryable** via \`worker_events\`:

| Event name | Fires when | Carries |
|---|---|---|
| \`scan_order_product_keyframe_f4\` | every keyframe fetch raised | entry_id, attempted, stage |
| \`scan_order_product_siglip_f4\` | every per-scene SigLIP2 embed raised | entry_id, attempted, stage |
| \`scan_order_product_sam2_f4\` | every SAM2 track raised | entry_id, attempted, stage |
| \`scan_order_per_product_failed\` | outer per-product \`except Exception\` | **exception_type, exception_message** |
| \`scan_order_all_products_f4_failed\` | aggregate after the loop | products_total, products_succeeded, products_no_qualifying, products_f4_failed |

The aggregate \`api.fail\` message also now redirects operators to query \`worker_events WHERE job_id=...\` instead of "Check worker logs for per-product failures" (which only meant Aircloud-side container logs).

## Test plan

- [x] 85/85 worker tests pass (84 existing + 1 new diagnostic test)
- [x] \`test_canonical_crop_s3_returns_none_emits_per_product_failed_event_with_exception_details\` pins the exact incident pattern: exception_type=\`FileNotFoundError\`, message references "canonical crop", events carry job_id + video_id for SQL triage.

## Verification once merged

After today's incident, query the partitioned \`worker_events\` table for any future F4:

\`\`\`sql
SELECT event_name, message, metadata, created_at
FROM worker_events
WHERE service = 'product-track-worker'
  AND job_id = '<parent-job-id>'
ORDER BY created_at;
\`\`\`

This should return the per-stage F4 events with the exception type/message, instead of operators having to SSH into Aircloud and tail container stdout.

## Scope

- Worker-side only. No API change, no contract bump, no SDK pin to bump.
- \`emit_event\` is fire-and-forget HTTP — POST failures are logged at WARN by the SDK and don't propagate.
- Metadata is truncated to 1000 chars per field to respect the 16KB worker_events ingest cap.

## Out of scope

- Adding a distinct \`error_code\` per F4 stage (would need a contracts bump for the wizard error mapper). The wizard surfaces the existing aggregate; operators triage via worker_events.
- Surfacing first-product exception text in \`api.fail.error_message\` directly (potentially leaks exception detail to end-users; the worker_events redirect is safer).