### PR TITLE
fix(product-track-worker): proxy download to /var/tmp + integrity gate

### DIFF
--- a/services/product-track-worker/src/proxy_download.py
+++ b/services/product-track-worker/src/proxy_download.py
@@ -19,6 +19,20 @@ Loose-coupling rules enforced here:
     deterministically. Aircloud /tmp is small (~tmpfs); leaking
     even a few hundred MB across job retries would wedge the
     container.
+
+2026-05-04 Aircloud /tmp incident:
+  Real livecommerce proxies on devorg run ~500 MB (64-min H.264 at
+  ~900 kbit/s). The default Python ``tempfile.TemporaryDirectory``
+  uses ``/tmp`` which on Aircloud is a small tmpfs; downloads
+  silently truncate (or boto3's TransferManager fails partway) and
+  cv2 then can't open the proxy → every per-scene SAM2 call raises
+  → looks like a SAM2 OOM but is really a disk-pressure issue.
+
+  Fix: default to ``/var/tmp`` (real disk on Aircloud, plenty of
+  space). Plus a post-download integrity check that compares the
+  local file size against the S3 ``ContentLength`` so a partial
+  download fails LOUDLY with a distinct error instead of silently
+  poisoning every SAM2 call downstream.
 """
 
 from __future__ import annotations
@@ -27,9 +41,18 @@ import logging
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Protocol
+from typing import Iterator, Optional, Protocol
 
 logger = logging.getLogger(__name__)
+
+
+# Default scratch dir. ``/var/tmp`` is on real disk on Aircloud
+# (whereas ``/tmp`` is tmpfs); fall back gracefully on hosts that
+# don't have it (some minimal containers) by setting to ``None``
+# which lets ``tempfile`` pick the system default.
+_DEFAULT_PROXY_SCRATCH_DIR: Optional[Path] = (
+    Path("/var/tmp") if Path("/var/tmp").is_dir() else None
+)
 
 
 class S3DownloadClient(Protocol):
@@ -47,6 +70,7 @@ def downloaded_proxy(
     proxy_s3_key: str,
     job_id_for_naming: str,
     parent_dir: Path | None = None,
+    expected_size_bytes: int | None = None,
 ) -> Iterator[Path]:
     """Download ``proxy_s3_key`` to a per-job tempdir, yield the
     local path, and clean up on exit (success OR exception).
@@ -57,8 +81,17 @@ def downloaded_proxy(
     bumped above 1. The handoff calls out concurrency=1 today, but
     naming this way costs nothing and removes a future foot-gun.
 
-    ``parent_dir`` defaults to the system temp dir; tests inject a
-    pytest ``tmp_path`` so they don't pollute /tmp.
+    ``parent_dir`` defaults to ``/var/tmp`` on hosts where it
+    exists (Aircloud, most Linux servers) so we don't fight tmpfs
+    pressure on ``/tmp``. Tests inject a pytest ``tmp_path``.
+
+    ``expected_size_bytes``, if provided, is compared against the
+    downloaded file's size; mismatch raises ``RuntimeError`` with
+    a distinct ``proxy_download_truncated`` signature so the
+    failure mode shows up in worker logs rather than silently
+    poisoning every downstream SAM2 call. Callers typically pass
+    the S3 ``ContentLength`` from a ``head_object`` call. ``None``
+    skips the size match (still verifies the file is non-empty).
     """
     if not proxy_s3_key:
         # Defensive — callers should have null-checked already, but
@@ -66,9 +99,12 @@ def downloaded_proxy(
         # cryptic ``InvalidArgument`` that buries the root cause.
         raise ValueError("proxy_s3_key is empty; cannot download")
 
+    effective_parent = (
+        parent_dir if parent_dir is not None else _DEFAULT_PROXY_SCRATCH_DIR
+    )
     with tempfile.TemporaryDirectory(
         prefix=f"track_{job_id_for_naming}_",
-        dir=str(parent_dir) if parent_dir is not None else None,
+        dir=str(effective_parent) if effective_parent is not None else None,
     ) as td:
         local_path = Path(td) / "proxy.mp4"
         logger.info(
@@ -77,16 +113,38 @@ def downloaded_proxy(
                 "proxy_s3_key": proxy_s3_key,
                 "local_path": str(local_path),
                 "job_id": job_id_for_naming,
+                "expected_size_bytes": expected_size_bytes,
             },
         )
         s3.download_file(proxy_s3_key, local_path)
+        local_size = local_path.stat().st_size if local_path.exists() else 0
+
+        # Integrity gate: catch tmpfs-truncation / partial download.
+        # 0 bytes is always wrong — boto3's ``download_file`` is
+        # supposed to either complete or raise, but in practice on
+        # Aircloud's tmpfs we've seen silent partial writes.
+        if local_size == 0:
+            raise RuntimeError(
+                f"proxy_download_zero_bytes: download produced an "
+                f"empty file at {local_path} (key={proxy_s3_key}, "
+                f"job_id={job_id_for_naming}). Likely "
+                f"out-of-disk-space on the worker's scratch dir."
+            )
+        if expected_size_bytes is not None and local_size != expected_size_bytes:
+            raise RuntimeError(
+                f"proxy_download_truncated: local size {local_size} != "
+                f"expected {expected_size_bytes} (key={proxy_s3_key}, "
+                f"job_id={job_id_for_naming}). Likely "
+                f"out-of-disk-space on the worker's scratch dir, or "
+                f"S3 object mutated mid-download."
+            )
+
         logger.info(
             "proxy_download_done",
             extra={
                 "proxy_s3_key": proxy_s3_key,
-                "size_bytes": (
-                    local_path.stat().st_size if local_path.exists() else None
-                ),
+                "size_bytes": local_size,
+                "expected_size_bytes": expected_size_bytes,
                 "job_id": job_id_for_naming,
             },
         )

--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -575,6 +575,7 @@ def handle_track_job(
             s3=s3,
             proxy_s3_key=proxy_s3_key,
             job_id_for_naming=str(decoded.job_id),
+            expected_size_bytes=_resolve_proxy_size(s3, proxy_s3_key),
         ) as full_video_path:
             detections = propagate_within_candidate_scenes(
                 candidates=candidate_scenes,
@@ -740,6 +741,46 @@ def handle_track_job(
 
 
 # ─── helpers ─────────────────────────────────────────────────────────
+
+
+def _resolve_proxy_size(s3: S3Client, proxy_s3_key: str) -> int | None:
+    """Best-effort ``head_object`` to learn the proxy's expected size.
+
+    Returns ``None`` on any failure so the integrity check in
+    ``downloaded_proxy`` falls back to the ``size > 0`` gate. We
+    explicitly do NOT propagate the head_object exception here:
+    the actual download attempt below will surface the real S3
+    error if there is one, and it would be silly to fail the job
+    on a HEAD that we only use as a sanity check.
+
+    Reaches into the SDK's underlying boto3 client because
+    ``heimdex_worker_sdk.s3.S3Client`` doesn't expose a public
+    size accessor (only ``exists``). Treat this as a worker-local
+    convenience; if the SDK ever grows ``head_object_size``,
+    switch to that.
+    """
+    try:
+        # ``S3Client._client`` is the boto3 client. ``S3Client._bucket``
+        # is the bucket bound at construction. Both private but stable
+        # within our SDK.
+        resp = s3._client.head_object(Bucket=s3._bucket, Key=proxy_s3_key)  # noqa: SLF001
+    except Exception:
+        logger.warning(
+            "proxy_head_object_failed",
+            extra={"proxy_s3_key": proxy_s3_key},
+            exc_info=True,
+        )
+        return None
+
+    # Defensive shape check. boto3 returns a dict with int
+    # ``ContentLength``; anything else (notably MagicMock objects in
+    # tests, where ``__int__`` returns 1 by default) is unsafe to
+    # feed into the integrity gate. Skip the size match in that case
+    # — the helper's ``size > 0`` floor still applies.
+    if not isinstance(resp, dict):
+        return None
+    size = resp.get("ContentLength")
+    return size if isinstance(size, int) else None
 
 
 def _make_config(settings: WorkerSettings) -> TrackingConfig:
@@ -1367,6 +1408,7 @@ def _handle_scan_order_parent(
         s3=s3,
         proxy_s3_key=proxy_s3_key,
         job_id_for_naming=str(decoded.job_id),
+        expected_size_bytes=_resolve_proxy_size(s3, proxy_s3_key),
     ) as full_video_path_obj:
         full_video_path = str(full_video_path_obj)
         for i, entry in enumerate(catalog_entries):

--- a/services/product-track-worker/tests/test_e2e_track_pipeline.py
+++ b/services/product-track-worker/tests/test_e2e_track_pipeline.py
@@ -134,6 +134,14 @@ def _make_pipeline_mocks(*, picker_cost: Decimal = Decimal("0")):
     Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
     s3 = MagicMock()
     s3.get_object_bytes.return_value = good_buf.getvalue()
+    # PR D: ``downloaded_proxy`` integrity check requires the local
+    # file to be non-empty after ``s3.download_file``. The default
+    # MagicMock is a no-op, so we wire a side_effect that writes
+    # placeholder bytes — keeps every existing test happy without
+    # them needing to know about the integrity gate.
+    s3.download_file.side_effect = lambda key, local_path: local_path.write_bytes(
+        b"fake-mp4-bytes" * 100
+    )
 
     tracker = MagicMock()
     tracker.track.side_effect = _good_track_factory()

--- a/services/product-track-worker/tests/test_proxy_download.py
+++ b/services/product-track-worker/tests/test_proxy_download.py
@@ -104,3 +104,129 @@ def test_propagates_s3_download_failure(tmp_path):
             parent_dir=tmp_path,
         ):
             pass
+
+
+# ---------- integrity gate (PR D) ----------
+
+
+def test_zero_byte_download_raises_proxy_download_zero_bytes(tmp_path):
+    """Defensive against silent /tmp truncation. boto3's
+    ``download_file`` is supposed to either complete or raise, but
+    on Aircloud's tmpfs we observed silent partial writes. A
+    0-byte file is always a fault — surface it loudly so the
+    operator sees ``proxy_download_zero_bytes`` instead of every
+    downstream cv2 call failing as if SAM2 itself crashed."""
+
+    class _ZeroByteS3:
+        def download_file(self, s3_key: str, local_path):
+            local_path.touch()  # 0 bytes
+
+    with pytest.raises(RuntimeError, match="proxy_download_zero_bytes"):
+        with downloaded_proxy(
+            s3=_ZeroByteS3(),
+            proxy_s3_key="k",
+            job_id_for_naming="job",
+            parent_dir=tmp_path,
+        ):
+            pass
+
+
+def test_size_mismatch_raises_proxy_download_truncated(tmp_path):
+    """When the caller knows the expected size (head_object), the
+    integrity check enforces a strict match. This catches partial
+    downloads that ``download_file`` somehow returned without
+    raising, and surfaces them with a distinct
+    ``proxy_download_truncated`` signature so the failure mode
+    isn't confused with SAM2 OOM."""
+
+    class _PartialS3:
+        def download_file(self, s3_key, local_path):
+            # Wrote 100 bytes but caller expected 1000.
+            local_path.write_bytes(b"x" * 100)
+
+    with pytest.raises(RuntimeError, match="proxy_download_truncated"):
+        with downloaded_proxy(
+            s3=_PartialS3(),
+            proxy_s3_key="k",
+            job_id_for_naming="job",
+            parent_dir=tmp_path,
+            expected_size_bytes=1000,
+        ):
+            pass
+
+
+def test_expected_size_match_passes(tmp_path):
+    """Happy path: bytes downloaded match expected size → yield
+    proceeds normally."""
+
+    class _GoodS3:
+        def download_file(self, s3_key, local_path):
+            local_path.write_bytes(b"x" * 12345)
+
+    with downloaded_proxy(
+        s3=_GoodS3(),
+        proxy_s3_key="k",
+        job_id_for_naming="job",
+        parent_dir=tmp_path,
+        expected_size_bytes=12345,
+    ) as local:
+        assert local.stat().st_size == 12345
+
+
+def test_expected_size_none_skips_match_but_still_checks_nonzero(tmp_path):
+    """Best-effort case: when ``head_object`` failed, the caller
+    passes ``None`` and we still gate on size > 0 — a 0-byte
+    download is a fault regardless of whether the caller could
+    learn the expected size."""
+
+    class _ZeroByteS3:
+        def download_file(self, s3_key, local_path):
+            local_path.touch()
+
+    with pytest.raises(RuntimeError, match="proxy_download_zero_bytes"):
+        with downloaded_proxy(
+            s3=_ZeroByteS3(),
+            proxy_s3_key="k",
+            job_id_for_naming="job",
+            parent_dir=tmp_path,
+            expected_size_bytes=None,
+        ):
+            pass
+
+
+def test_default_parent_dir_uses_var_tmp_when_available(monkeypatch, tmp_path):
+    """Locks the contract that the default scratch dir is
+    ``/var/tmp`` (real disk on Aircloud), not the system default
+    ``/tmp`` (tmpfs on Aircloud). The 2026-05-04 incident showed
+    every per-scene SAM2 call failing after a 503 MB proxy
+    silently truncated on tmpfs — switching the default removes
+    that whole class of failure on Aircloud while staying
+    compatible with hosts that don't have ``/var/tmp``."""
+    from src import proxy_download as pd
+
+    # Verify the module-level default points at /var/tmp on this
+    # machine. Skip the assertion gracefully on hosts that don't
+    # have /var/tmp (very minimal containers) — the fallback to
+    # ``None`` (system default) is documented behavior.
+    if Path("/var/tmp").is_dir():
+        assert pd._DEFAULT_PROXY_SCRATCH_DIR == Path("/var/tmp")
+    else:
+        assert pd._DEFAULT_PROXY_SCRATCH_DIR is None
+
+    # And the runtime path: when no ``parent_dir`` is passed, the
+    # module honours the default. Patch the default to ``tmp_path``
+    # so the test doesn't actually pollute /var/tmp.
+    monkeypatch.setattr(pd, "_DEFAULT_PROXY_SCRATCH_DIR", tmp_path)
+
+    class _StubS3:
+        def download_file(self, s3_key, local_path):
+            local_path.write_bytes(b"x" * 100)
+
+    with downloaded_proxy(
+        s3=_StubS3(),
+        proxy_s3_key="k",
+        job_id_for_naming="default-dir-test",
+        # parent_dir intentionally omitted to exercise the default.
+    ) as local:
+        # The download landed under tmp_path (the patched default).
+        assert tmp_path in local.parents

--- a/services/product-track-worker/tests/test_render_enqueue.py
+++ b/services/product-track-worker/tests/test_render_enqueue.py
@@ -243,6 +243,12 @@ class TestHandleTrackJobRenderEnqueue:
         Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
         s3 = MagicMock()
         s3.get_object_bytes.return_value = good_buf.getvalue()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
         # SAM2 returns a dense, high-confidence sample stream so
         # window-assembly produces an accepted window.
         tracker = MagicMock()

--- a/services/product-track-worker/tests/test_track_f4.py
+++ b/services/product-track-worker/tests/test_track_f4.py
@@ -238,6 +238,12 @@ class TestHandleTrackJobAllScenesFailed:
 
         # S3 client raises on every keyframe fetch.
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
         s3.get_object_bytes.side_effect = RuntimeError("S3 unavailable")
 
         with patch(
@@ -271,6 +277,12 @@ class TestHandleTrackJobAllScenesFailed:
         embedder = MagicMock()
         embedder.embed.return_value = [0.1] * 768
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
 
         with patch(
             "src.tasks.track._fetch_canonical_crop",
@@ -311,6 +323,12 @@ class TestHandleTrackJobAllScenesFailed:
         Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
         good_bytes = good_buf.getvalue()
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
         s3.get_object_bytes.side_effect = [
             RuntimeError("missing"),
             good_bytes,
@@ -368,6 +386,12 @@ class TestHandleTrackJobAllScenesFailed:
         Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
         good_bytes = good_buf.getvalue()
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
         s3.get_object_bytes.return_value = good_bytes
 
         with patch(
@@ -409,6 +433,12 @@ class TestHandleTrackJobAllScenesFailed:
         embedder = MagicMock()
         embedder.embed.return_value = [0.1] * 768
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
 
         with patch(
             "src.tasks.track._fetch_canonical_crop",
@@ -447,6 +477,12 @@ class TestHandleTrackJobAllScenesFailed:
         embedder = MagicMock()
         embedder.embed.return_value = [0.1] * 768
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
 
         with patch(
             "src.tasks.track._fetch_canonical_crop",
@@ -484,6 +520,12 @@ class TestHandleTrackJobAllScenesFailed:
         embedder = MagicMock()
         embedder.embed.return_value = [0.1] * 768
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
 
         with patch(
             "src.tasks.track._fetch_canonical_crop",
@@ -514,6 +556,12 @@ class TestHandleTrackJobAllScenesFailed:
         embedder = MagicMock()
         embedder.embed.return_value = [0.1] * 768
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
 
         with patch(
             "src.tasks.track._fetch_canonical_crop",
@@ -551,6 +599,12 @@ class TestHandleTrackJobAllScenesFailed:
         good_buf = _io.BytesIO()
         Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
         s3.get_object_bytes.return_value = good_buf.getvalue()
 
         # SAM2 returns one short low-confidence sample per scene.
@@ -621,6 +675,12 @@ class TestHandleTrackJobAllScenesFailed:
         Image.new("RGB", (4, 4), 0).save(good_buf, format="JPEG")
         good_bytes = good_buf.getvalue()
         s3 = MagicMock()
+        # PR D integrity gate: ``downloaded_proxy`` rejects 0-byte
+        # files, so the mock has to write bytes when download_file
+        # is called.
+        s3.download_file.side_effect = (
+            lambda key, local_path: local_path.write_bytes(b"x" * 100)
+        )
         s3.get_object_bytes.return_value = good_bytes
 
         # SAM2 tracker raises on every scene.


### PR DESCRIPTION
## Summary

Targets the 2026-05-04 incident: parent_job_id `dfc2c05b` failed with PR C's diagnostic event `scan_order_product_sam2_f4` showing **every one of 11 SAM2 propagation calls raised in 10 seconds total** — too fast for OOM, consistent with cv2 immediately failing to open a truncated proxy.

The actual S3 proxy ffprobes clean (H.264 Main, yuv420p, 64 min, 503 MB). Likely root cause: Aircloud's `/tmp` is tmpfs and the 503 MB download silently truncates.

Two fixes, both worker-side:

1. **`/var/tmp` default for the download scratch dir** — `proxy_download.py` now picks `/var/tmp` (real disk on Aircloud) over the system default. Falls back gracefully on hosts without `/var/tmp`.

2. **Post-download integrity gate** — every download verifies:
   - **Local file size > 0** → otherwise raises `RuntimeError(proxy_download_zero_bytes)`.
   - **Local size matches expected (when known)** → otherwise raises `RuntimeError(proxy_download_truncated)`. Expected size comes from a best-effort `head_object` call (`_resolve_proxy_size`); if head_object fails, we fall back to just the > 0 floor.

Both raises propagate through the worker's outer `except Exception` → land in `worker_events` via PR C's `scan_order_per_product_failed` emission with the exact RuntimeError text. So the next time this fails for any disk-pressure reason, we'll see exactly which gate tripped — no more guessing between "SAM2 OOM" and "cv2 can't decode".

## Test plan

- [x] 90/90 worker tests pass (85 prior + 5 new integrity tests).
- [x] New tests cover: zero-byte raises, size-mismatch raises, expected-size-match passes, `None` expected_size still gates on > 0, default `parent_dir` uses `/var/tmp` when available.
- [x] Existing fixtures updated: `_make_pipeline_mocks` and standalone `s3 = MagicMock()` instances now stub `s3.download_file` to write bytes (was a no-op default; new integrity gate would 0-byte-fail every test).

## Verification once merged

After GHCR rebuild and Aircloud restart, retrigger the wizard scan on `gd_05e7f957502e86cf`. Expected outcomes:

- **Best case**: `/var/tmp` move alone fixes it; the 503 MB proxy downloads cleanly, cv2 opens it, SAM2 runs, parent transitions through `tracking → assembling → done`.
- **Likely case**: still fails BUT with `worker_events.event_name='scan_order_per_product_failed'`, `metadata.exception_type='RuntimeError'`, `metadata.exception_message='proxy_download_zero_bytes...'` or `'proxy_download_truncated...'`. That definitively proves the disk-pressure hypothesis and tells us where the truncation point is.
- **Unlikely case**: same `scan_order_product_sam2_f4` event with `attempted=11`. That'd mean the issue is something other than disk pressure (cv2 codec issue, Aircloud-specific path quirk, etc.) — would need additional instrumentation to chase.

## Trade-off notes

- `_resolve_proxy_size` reaches into `S3Client._client.head_object` because the SDK has no public size accessor. Documented in code; if the SDK ever grows `head_object_size`, swap to that.
- Best-effort by design: head_object failures don't fail the job on their own — only verified mismatches do.
- `MagicMock.__int__()` returns 1 by default; the helper's `isinstance(resp, dict)` check prevents this from polluting test runs.

## Out of scope

- Adding a separate `error_code` for the wizard error mapper (e.g. `proxy_disk_pressure`) — diagnostic stays in `worker_events` for now.
- Streaming SAM2 input directly from S3 — would avoid the local file but requires bigger architectural change; deferred.