### PR TITLE
fix(product-track-worker): emit per-scene SAM2 exception via worker_events

### DIFF
--- a/services/product-track-worker/src/tasks/track.py
+++ b/services/product-track-worker/src/tasks/track.py
@@ -168,12 +168,34 @@ class _CountingKeyframeFetcher:
 
 
 class _CountingSam2Tracker:
-    """Wraps a :class:`Sam2Tracker`; counts attempts + failures."""
+    """Wraps a :class:`Sam2Tracker`; counts attempts + failures.
 
-    def __init__(self, inner: Sam2Tracker) -> None:
+    PR F: when ``job_id`` / ``org_id`` / ``video_id`` are provided
+    at construction, also emits a structured ``worker_event`` per
+    scene-level exception with the exception type + message. The
+    lib's ``propagate_within_candidate_scenes`` catches per-scene
+    exceptions and only stdout-logs them — without this wrapper,
+    every SAM2 failure mode collapses into the generic
+    ``scan_order_product_sam2_f4`` aggregate and operators have to
+    chase Aircloud logs for the actual exception text. With this
+    wrapper, the next failure's per-scene exception is one SQL
+    query away.
+    """
+
+    def __init__(
+        self,
+        inner: Sam2Tracker,
+        *,
+        job_id: str | None = None,
+        org_id: str | None = None,
+        video_id: str | None = None,
+    ) -> None:
         self._inner = inner
         self.attempted = 0
         self.failed = 0
+        self._job_id = job_id
+        self._org_id = org_id
+        self._video_id = video_id
 
     def track(
         self,
@@ -197,8 +219,36 @@ class _CountingSam2Tracker:
                 scene_end_ms=scene_end_ms,
                 sample_fps=sample_fps,
             )
-        except Exception:
+        except Exception as exc:
             self.failed += 1
+            # Best-effort per-scene diagnostic — the worker has full
+            # context the lib lacks, so emit before re-raise. Skip
+            # cleanly if construction context wasn't supplied (unit
+            # tests that don't care about the diagnostic path).
+            if self._job_id is not None:
+                try:
+                    emit_event(
+                        service="product-track-worker",
+                        event_name="sam2_track_scene_failed",
+                        category="job_failure",
+                        level="WARNING",
+                        org_id=self._org_id,
+                        job_id=self._job_id,
+                        video_id=self._video_id,
+                        message=f"{type(exc).__name__}: {exc}"[:1000],
+                        metadata={
+                            "scene_id": scene_id,
+                            "scene_start_ms": scene_start_ms,
+                            "scene_end_ms": scene_end_ms,
+                            "exception_type": type(exc).__name__,
+                            "exception_message": str(exc)[:1000],
+                        },
+                    )
+                except Exception:  # noqa: BLE001
+                    # emit_event is fire-and-forget; never let a
+                    # diagnostic-emission failure poison the actual
+                    # error path.
+                    logger.exception("sam2_track_scene_failed_emit_failed")
             raise
 
     @property
@@ -569,7 +619,10 @@ def handle_track_job(
         # F4) so we never leak across retries on Aircloud's tight
         # /tmp.
         tracker_impl = _CountingSam2Tracker(
-            tracker or Sam2TrackerImpl(model_id=settings.sam2_model_id)
+            tracker or Sam2TrackerImpl(model_id=settings.sam2_model_id),
+            job_id=str(decoded.job_id),
+            org_id=str(decoded.org_id),
+            video_id=str(decoded.video_id),
         )
         with downloaded_proxy(
             s3=s3,
@@ -1692,7 +1745,10 @@ def _process_one_product_for_parent(
     # proxy the parent already downloaded — the SAM2 wrapper seeks
     # to each scene window in-memory.
     tracker_impl = _CountingSam2Tracker(
-        tracker or Sam2TrackerImpl(model_id=settings.sam2_model_id)
+        tracker or Sam2TrackerImpl(model_id=settings.sam2_model_id),
+        job_id=str(decoded.job_id),
+        org_id=str(decoded.org_id),
+        video_id=str(decoded.video_id),
     )
     detections = propagate_within_candidate_scenes(
         candidates=candidate_scenes,

--- a/services/product-track-worker/tests/test_track_f4.py
+++ b/services/product-track-worker/tests/test_track_f4.py
@@ -203,6 +203,67 @@ class TestCountingSam2Tracker:
         assert wrapped.failed == 1
         assert wrapped.all_attempts_failed is True
 
+    def test_emits_per_scene_event_on_failure_when_context_set(self):
+        """PR F: when constructed with job_id/org_id/video_id, the
+        wrapper emits a structured ``sam2_track_scene_failed``
+        event with the exception type + message before re-raising.
+        Pin the contract — without this the lib's per-scene
+        try/except only stdout-logs, and operators have to chase
+        Aircloud container logs to learn what fired."""
+        inner = MagicMock()
+        inner.track.side_effect = ValueError("Either images or original_sizes must be provided")
+        wrapped = _CountingSam2Tracker(
+            inner,
+            job_id="00000000-0000-0000-0000-000000000777",
+            org_id="00000000-0000-0000-0000-00000000aaaa",
+            video_id="33faa1ff-f6c6-4069-95b0-03451912227a",
+        )
+
+        with patch("src.tasks.track.emit_event") as mock_emit:
+            with pytest.raises(ValueError):
+                wrapped.track(**self._kwargs())
+
+        mock_emit.assert_called_once()
+        kwargs = mock_emit.call_args.kwargs
+        assert kwargs["event_name"] == "sam2_track_scene_failed"
+        assert kwargs["job_id"] == "00000000-0000-0000-0000-000000000777"
+        assert kwargs["video_id"] == "33faa1ff-f6c6-4069-95b0-03451912227a"
+        assert kwargs["metadata"]["exception_type"] == "ValueError"
+        assert "images or original_sizes" in kwargs["metadata"]["exception_message"]
+        assert kwargs["metadata"]["scene_id"] == "s1"
+
+    def test_does_not_emit_when_context_not_set(self):
+        """Backward-compat: existing call sites that construct
+        without the context kwargs (unit tests, legacy paths) MUST
+        not get an ``emit_event`` side effect — otherwise tests
+        would need a network mock for the fire-and-forget HTTP."""
+        inner = MagicMock()
+        inner.track.side_effect = RuntimeError("boom")
+        wrapped = _CountingSam2Tracker(inner)  # no job_id
+
+        with patch("src.tasks.track.emit_event") as mock_emit:
+            with pytest.raises(RuntimeError):
+                wrapped.track(**self._kwargs())
+
+        mock_emit.assert_not_called()
+
+    def test_emit_failure_does_not_mask_original_exception(self):
+        """Defence-in-depth: a network blip on the
+        worker_events POST must not poison the actual exception
+        path. The original ``RuntimeError`` always re-raises."""
+        inner = MagicMock()
+        inner.track.side_effect = RuntimeError("real failure")
+        wrapped = _CountingSam2Tracker(
+            inner,
+            job_id="00000000-0000-0000-0000-000000000888",
+            org_id="00000000-0000-0000-0000-00000000aaaa",
+            video_id="33faa1ff-f6c6-4069-95b0-03451912227a",
+        )
+
+        with patch("src.tasks.track.emit_event", side_effect=RuntimeError("emit blew up")):
+            with pytest.raises(RuntimeError, match="real failure"):
+                wrapped.track(**self._kwargs())
+
 
 # ─── handle_track_job F4 paths ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The 2026-05-04 incident chain showed that PR C's diagnostics surface UPSTREAM stage failures (keyframe / SigLIP2) but not per-scene SAM2 failures — those collapse into the opaque \`scan_order_product_sam2_f4\` aggregate. Diagnosing each iteration required pulling Aircloud container logs.

PR F: \`_CountingSam2Tracker\` now optionally takes \`job_id\` / \`org_id\` / \`video_id\` at construction. When provided, every per-scene exception emits a structured \`sam2_track_scene_failed\` worker_event with the exception type + message + scene window before re-raising. Wired at both call sites (legacy single-product + scan_order parent).

After this lands, every future SAM2 F4 is one SQL query away:
\`\`\`sql
SELECT event_name, message, metadata FROM worker_events
WHERE event_name = 'sam2_track_scene_failed'
  AND job_id = '<parent>'
ORDER BY created_at;
\`\`\`

Diagnostic-only — no behavior change on the success path. Fire-and-forget; emit failures never mask the real exception.

## Test plan

- [x] 102/102 worker tests pass (was 99 + 3 new)
- [x] \`test_emits_per_scene_event_on_failure_when_context_set\` — pins exception_type, exception_message, scene_id propagation
- [x] \`test_does_not_emit_when_context_not_set\` — backward-compat for unit tests that construct without context
- [x] \`test_emit_failure_does_not_mask_original_exception\` — defence in depth on the diagnostic path

## Why now

Three iteration cycles already ate Aircloud-log round trips. The PR D + E fixes shipped against an opaque aggregate; if either fix was incomplete, we couldn't tell from \`worker_events\` alone. PR F closes that gap so the next iteration is immediate.