### PR TITLE
fix(product-track-worker): rewrite SAM2 model calls for transformers v5 inference-session API

### DIFF
--- a/services/product-track-worker/src/sam2_tracker.py
+++ b/services/product-track-worker/src/sam2_tracker.py
@@ -219,79 +219,105 @@ class Sam2TrackerImpl:
         # ── 3. Anchor selection — first sampled frame (Phase 3c-B v1).
         anchor_idx = 0
 
-        # ── 4. Initialise SAM2 video predictor + add anchor box.
-        # transformers 5.5.4 ``Sam2VideoProcessor.__call__``
-        # signature (verified empirically inside the worker
-        # container 2026-05-04):
+        # ── 4. SAM2 video tracking (transformers 5.5.4 API).
         #
-        #   def __call__(
-        #       self, images: ImageInput | None = None,
-        #       segmentation_maps=..., input_points=...,
-        #       input_labels=..., input_boxes=...,
-        #       original_sizes=..., return_tensors=..., **kwargs
-        #   )
+        # The v5 API is fundamentally different from v4. Replaced:
         #
-        # ``ImageInput`` accepts ``list[PIL.Image.Image]`` directly
-        # — no outer list wrapping. There is NO ``videos=`` kwarg
-        # in v5; passing one falls through to ``**kwargs``,
-        # leaving the processor with no input → it raises
-        # ``ValueError: Either images or original_sizes must be
-        # provided`` (staging incident 2026-05-04, parent_job_id
-        # 79560cf0 — every one of 11 scenes hit this).
+        #   v4:  processor(videos=..., return_tensors="pt") +
+        #        model.init_state(pixel_values=...) +
+        #        model.add_new_points_or_box(state, frame_idx, obj_id, box) +
+        #        model.propagate_in_video(state)
+        #
+        #   v5:  processor.init_video_session(video=frames) → session
+        #        processor.process_new_points_or_boxes_for_video_frame(
+        #            session, frame_idx, obj_ids=[1],
+        #            input_boxes=[[[x1, y1, x2, y2]]],
+        #            original_size=(H, W),
+        #        )
+        #        for output in model.propagate_in_video_iterator(
+        #            inference_session=session,
+        #        ):
+        #            output.pred_masks  # (batch, num_obj, H, W)
+        #
+        # Verified empirically inside the worker container against
+        # ``transformers.Sam2VideoProcessor`` and
+        # ``transformers.models.sam2_video.modeling_sam2_video.Sam2VideoInferenceSession``
+        # signatures on 2026-05-04. The earlier ``init_state``
+        # / ``add_new_points_or_box`` / ``propagate_in_video``
+        # methods do not exist on ``Sam2VideoModel`` in v5.
         from PIL import Image as _PILImage  # noqa: PLC0415 — keep module-import cheap
         frames_pil = [_PILImage.fromarray(rgb) for _, rgb in sampled_frames]
+
         with torch.inference_mode():
-            inputs = loaded.processor(
-                images=frames_pil,
-                return_tensors="pt",
-            ).to(loaded.device)
-            video_state = loaded.model.init_state(
-                pixel_values=inputs["pixel_values"],
-            )
-            loaded.model.add_new_points_or_box(
-                state=video_state,
-                frame_idx=anchor_idx,
-                obj_id=1,
-                box=[
-                    clamped_bbox.x,
-                    clamped_bbox.y,
-                    clamped_bbox.x + clamped_bbox.width,
-                    clamped_bbox.y + clamped_bbox.height,
-                ],
+            # 4a. Build the inference session. The processor handles
+            # all preprocessing (frame resize / normalize / pixel_values
+            # tensor allocation); we don't manually call
+            # ``processor(images=...)`` anymore.
+            inference_session = loaded.processor.init_video_session(
+                video=frames_pil,
+                inference_device=str(loaded.device),
+                dtype=loaded.dtype,
             )
 
-            # ── 5. Propagate. The video model emits masks per
-            # sampled frame as it walks the timeline.
+            # 4b. Add the anchor bbox. ``input_boxes`` is nested
+            # 3-deep: outer batch (one video), middle per-object
+            # (one bbox), innermost xyxy coords. ``original_size``
+            # is required so the processor can scale the bbox from
+            # frame-pixel space to the model's normalized internal
+            # coordinates.
+            loaded.processor.process_new_points_or_boxes_for_video_frame(
+                inference_session=inference_session,
+                frame_idx=anchor_idx,
+                obj_ids=[1],
+                input_boxes=[[[
+                    float(clamped_bbox.x),
+                    float(clamped_bbox.y),
+                    float(clamped_bbox.x + clamped_bbox.width),
+                    float(clamped_bbox.y + clamped_bbox.height),
+                ]]],
+                original_size=(frame_height, frame_width),
+            )
+
+            # 4c. Propagate. The iterator yields one
+            # ``Sam2VideoSegmentationOutput`` per frame in
+            # ascending frame order; ``output.pred_masks`` has
+            # shape ``(batch_size, num_objects, H, W)``.
             samples: list[TrackedSample] = []
-            for prop_idx, _obj_ids, masks in loaded.model.propagate_in_video(
-                video_state,
+            for prop_idx, output in enumerate(
+                loaded.model.propagate_in_video_iterator(
+                    inference_session=inference_session,
+                )
             ):
                 if prop_idx >= len(sampled_frames):
                     continue  # defensive — should never exceed
-                # First tuple element is now an absolute millisecond
-                # timestamp on the FULL-video timeline (not a 0-based
-                # counter), set during the seek+sample loop above.
-                # No conversion needed.
                 frame_ts_ms, _ = sampled_frames[prop_idx]
-                # ``masks`` is shape (num_obj, H, W) — we added
-                # exactly one object so index 0 is the only mask.
-                mask_t = masks[0]
-                mask_score = getattr(masks, "score", None)
-                mask_conf = float(
-                    mask_score
-                    if mask_score is not None
-                    else mask_t.float().mean().item()
-                )
+
+                # We added exactly one object (obj_id=1), so the
+                # first dim of ``pred_masks`` is "this video" and
+                # the second is "this object".
+                mask_t = output.pred_masks[0, 0]
+                # Confidence: prefer iou_scores when SAM2 emits
+                # them on the output object; otherwise fall back
+                # to mean-of-mask. Conservative default; calibration
+                # can tighten later.
+                iou_attr = getattr(output, "iou_scores", None)
+                if iou_attr is not None:
+                    try:
+                        mask_conf = float(iou_attr.flatten()[0].item())
+                    except Exception:  # noqa: BLE001
+                        mask_conf = float(mask_t.float().mean().item())
+                else:
+                    mask_conf = float(mask_t.float().mean().item())
                 mask_np = mask_t.detach().cpu().numpy()
                 bbox = _mask_to_bbox(mask_np)
                 if bbox is None:
                     # Empty mask — SAM2 lost the object. Emit a
-                    # low-confidence sample with the original
-                    # anchor bbox as a placeholder; the lib's
-                    # window-assembly threshold filters drop it.
+                    # low-confidence sample with the anchor bbox
+                    # as a placeholder; the lib's window-assembly
+                    # threshold filters drop it.
                     samples.append(TrackedSample(
                         frame_timestamp_ms=frame_ts_ms,
-                        bbox=anchor_bbox,
+                        bbox=clamped_bbox,
                         mask_confidence=0.0,
                         frame_width=frame_width,
                         frame_height=frame_height,

--- a/services/product-track-worker/tests/test_sam2.py
+++ b/services/product-track-worker/tests/test_sam2.py
@@ -278,25 +278,11 @@ class TestSam2TrackerImplFailureModes:
         overflow_bbox = BBoxXYWH(x=200, y=100, width=200, height=100)
         # x + w = 400 > frame_width 320 → clamp width to 320-200=120.
 
-        # Capture the box passed into add_new_points_or_box so we
-        # can verify it was clamped, not raised.
-        captured: dict = {}
-
-        class _CapturingPredictor:
-            def init_state(self, *, pixel_values):
-                return MagicMock()
-
-            def add_new_points_or_box(self, *, state, frame_idx, obj_id, box):
-                captured["box"] = box
-
-            def propagate_in_video(self, _state):
-                return iter(())  # yield nothing — sampled list empty
-                # is fine; outer code emits empty samples list which
-                # the lib's downstream filter drops gracefully.
-
-        processor = MagicMock()
-        processor.return_value.to.return_value = {"pixel_values": MagicMock()}
-        set_singleton_for_testing(_fake_loaded(_CapturingPredictor(), processor=processor))
+        # Build a v5-shaped predictor pair. We set sample_count=0
+        # because we only care about the bbox sent INTO the
+        # processor, not the propagation output.
+        model, processor, _ = _make_v5_sam2_pair(sample_count=0)
+        set_singleton_for_testing(_fake_loaded(model, processor=processor))
         tracker = Sam2TrackerImpl(model_id="x")
 
         with patch("cv2.VideoCapture", return_value=cap):
@@ -313,11 +299,12 @@ class TestSam2TrackerImplFailureModes:
         # Did NOT raise. Empty samples are fine here; what matters
         # is that the box reaching SAM2 was clamped to the frame.
         assert isinstance(samples, list)
-        assert "box" in captured, "SAM2 add_new_points_or_box never called"
-        # Box format is [x_min, y_min, x_max, y_max]. Clamped width
-        # is 320 - 200 = 120, so x_max = 200 + 120 = 320.
-        assert captured["box"] == [200, 100, 320, 200], (
-            f"expected clamped box [200, 100, 320, 200], got {captured['box']}"
+        # ``input_boxes`` is nested 3-deep: [batch][per-object][xyxy].
+        # Clamped width is 320 - 200 = 120, so x_max = 200 + 120 = 320.
+        processor.process_new_points_or_boxes_for_video_frame.assert_called_once()
+        kwargs = processor.process_new_points_or_boxes_for_video_frame.call_args.kwargs
+        assert kwargs["input_boxes"] == [[[200.0, 100.0, 320.0, 200.0]]], (
+            f"expected clamped box [[[200, 100, 320, 200]]], got {kwargs['input_boxes']}"
         )
 
     def test_raises_runtime_when_no_frames_decoded(self):
@@ -344,32 +331,59 @@ class TestSam2TrackerImplFailureModes:
                 )
 
 
+def _make_v5_sam2_pair(*, mask_h: int = 240, mask_w: int = 320, sample_count: int = 1000):
+    """Build a (model, processor, fake_session) triple that mimics
+    the transformers 5.5.4 SAM2 video API surface used by
+    ``Sam2TrackerImpl.track``:
+
+      - ``processor.init_video_session(video, inference_device, dtype)``
+        returns the fake session.
+      - ``processor.process_new_points_or_boxes_for_video_frame(...)``
+        is called with the anchor bbox.
+      - ``model.propagate_in_video_iterator(inference_session=...)``
+        yields up to ``sample_count`` ``Sam2VideoSegmentationOutput``
+        stand-ins, each with a ``pred_masks`` tensor of shape
+        ``(1, 1, mask_h, mask_w)`` and ``iou_scores=0.95``.
+
+    Tests pass any ``sample_count`` they like; the tracker itself
+    stops iterating once it exhausts ``sampled_frames``, so a high
+    number is fine.
+    """
+    import torch
+
+    def _make_mask():
+        m = np.zeros((mask_h, mask_w), dtype=np.uint8)
+        m[20:80, 30:90] = 1  # 60x60 region starting at (30, 20)
+        return torch.tensor(m)
+
+    def _iter(*_args, **_kwargs):
+        for _ in range(sample_count):
+            output = MagicMock()
+            mask_2d = _make_mask()
+            # pred_masks shape: (batch, num_obj, H, W)
+            output.pred_masks = mask_2d.unsqueeze(0).unsqueeze(0)
+            output.iou_scores = torch.tensor([[0.95]])
+            yield output
+
+    fake_session = MagicMock()
+    processor = MagicMock()
+    processor.init_video_session.return_value = fake_session
+    processor.process_new_points_or_boxes_for_video_frame.return_value = fake_session
+
+    model = MagicMock()
+    model.propagate_in_video_iterator.side_effect = _iter
+
+    return model, processor, fake_session
+
+
 class TestSam2TrackerImplHappyPath:
-    def _make_fake_predictor(
-        self, *, mask_h: int = 240, mask_w: int = 320,
-    ) -> MagicMock:
-        """Produces a model whose ``propagate_in_video`` yields
-        increasing-time samples with a small bbox-sized mask
-        (so ``_mask_to_bbox`` returns a valid bbox)."""
-        import torch
-
-        def _make_mask():
-            m = np.zeros((mask_h, mask_w), dtype=np.uint8)
-            m[20:80, 30:90] = 1
-            return torch.tensor(m)
-
-        def _propagate(_state):
-            for prop_idx in range(5):  # 5 sampled frames
-                masks = MagicMock()
-                masks.__getitem__.return_value = _make_mask()
-                masks.score = 0.95
-                yield prop_idx, [1], masks
-
-        model = MagicMock()
-        model.init_state.return_value = MagicMock()
-        model.add_new_points_or_box.return_value = None
-        model.propagate_in_video.side_effect = _propagate
-        return model
+    def _make_fake_predictor(self, *, mask_h: int = 240, mask_w: int = 320, sample_count: int = 5):
+        """Backward-compat shim that yields exactly ``sample_count``
+        outputs by default, matching the legacy 5-sample
+        expectation."""
+        return _make_v5_sam2_pair(
+            mask_h=mask_h, mask_w=mask_w, sample_count=sample_count,
+        )
 
     def test_emits_one_sample_per_propagated_frame_in_time_order(self):
         """5 propagated frames → 5 ``TrackedSample`` rows in
@@ -380,11 +394,7 @@ class TestSam2TrackerImplHappyPath:
         # accepted at timestamps 0, 200, 400, 600, 800.
         frames = [_green_frame() for _ in range(30)]
         cap = _FakeVideoCapture(frames=frames, fps=30.0)
-        model = self._make_fake_predictor()
-        processor = MagicMock()
-        processor.return_value.to.return_value = {
-            "pixel_values": MagicMock(),
-        }
+        model, processor, _ = self._make_fake_predictor()
         set_singleton_for_testing(_fake_loaded(model, processor=processor))
         tracker = Sam2TrackerImpl(model_id="x")
 
@@ -418,33 +428,12 @@ class TestSam2TrackerImplHappyPath:
 # =====================================================================
 
 
-def _adaptive_predictor(*, mask_h: int = 240, mask_w: int = 320) -> MagicMock:
-    """Like ``_make_fake_predictor`` but emits one sample per
-    sampled frame regardless of count — the new tests below sample
-    different numbers of frames depending on the scene window."""
-    import torch
-
-    def _make_mask():
-        m = np.zeros((mask_h, mask_w), dtype=np.uint8)
-        m[20:80, 30:90] = 1
-        return torch.tensor(m)
-
-    captured: dict = {}
-
-    def _propagate(state):
-        # Walk an arbitrary number of indices — the tracker stops
-        # iterating once ``prop_idx >= len(sampled_frames)``.
-        for prop_idx in range(captured.get("sample_count", 1000)):
-            masks = MagicMock()
-            masks.__getitem__.return_value = _make_mask()
-            masks.score = 0.95
-            yield prop_idx, [1], masks
-
-    model = MagicMock()
-    model.init_state.return_value = MagicMock()
-    model.add_new_points_or_box.return_value = None
-    model.propagate_in_video.side_effect = _propagate
-    return model
+def _adaptive_predictor(*, mask_h: int = 240, mask_w: int = 320):
+    """Backward-compat shim — returns a ``(model, processor, session)``
+    triple from :func:`_make_v5_sam2_pair` with a generous sample
+    count so the tracker's ``len(sampled_frames)`` cap is the only
+    upper bound on iteration."""
+    return _make_v5_sam2_pair(mask_h=mask_h, mask_w=mask_w, sample_count=1000)
 
 
 class TestSam2TrackerImplSeekAndWindow:
@@ -456,9 +445,7 @@ class TestSam2TrackerImplSeekAndWindow:
         cap = _FakeVideoCapture(
             frames=frames, fps=fps, keyframe_interval_ms=keyframe_interval_ms,
         )
-        model = _adaptive_predictor()
-        processor = MagicMock()
-        processor.return_value.to.return_value = {"pixel_values": MagicMock()}
+        model, processor, _ = _adaptive_predictor()
         set_singleton_for_testing(_fake_loaded(model, processor=processor))
         return cap, Sam2TrackerImpl(model_id="x")
 
@@ -565,49 +552,36 @@ class TestSam2ProcessorInputShape:
     ``ValueError: Either images or original_sizes must be provided``
     on every one of 11 scenes — even after PR E switched to
     ``videos=[List[PIL]]``. Root cause: in transformers 5.5.4,
-    ``Sam2VideoProcessor.__call__`` has NO ``videos=`` kwarg. The
-    first positional / keyword arg is ``images: ImageInput | None``,
-    where ``ImageInput`` accepts ``list[PIL.Image.Image]`` directly
-    (no outer wrapping).
+    transformers v5 reworked the SAM2 video API. v4 used
+    ``processor(videos=..., return_tensors='pt')`` then
+    ``model.init_state(pixel_values=...)`` etc. — none of those
+    methods / kwargs exist in v5.5.4. v5 instead uses:
 
-    Inspection on the real worker container ran:
+      processor.init_video_session(video=List[PIL.Image], ...)
+        → returns a Sam2VideoInferenceSession
+      processor.process_new_points_or_boxes_for_video_frame(
+          inference_session=..., frame_idx=..., obj_ids=[1],
+          input_boxes=[[[x1, y1, x2, y2]]],
+          original_size=(H, W),
+      )
+      model.propagate_in_video_iterator(inference_session=...)
 
-        signature: (self, images: ImageInput | None = None,
-                    segmentation_maps=..., input_points=..., ...,
-                    **kwargs)
+    Tests pin the v5.5.4 call-shape contract so a regression
+    re-introducing the v4 ``videos=`` / ``init_state`` /
+    ``add_new_points_or_box`` shapes is caught in CI rather than
+    at SAM2 call time on Aircloud."""
 
-    Tests pin the post-PR-G call-shape contract so this regression
-    class is caught in CI rather than at SAM2 call time on
-    Aircloud."""
-
-    def _build_capturing_processor(self) -> tuple:
-        captured: dict = {}
-
-        class _CapturingProcessor:
-            def __call__(self, *args, **kwargs):
-                captured["args"] = args
-                captured["kwargs"] = kwargs
-                # Mimic the real return_tensors="pt" + .to(device) chain.
-                resp = MagicMock()
-                resp.to.return_value = {"pixel_values": MagicMock()}
-                return resp
-
-        return _CapturingProcessor(), captured
-
-    def test_processor_receives_images_kwarg_with_flat_list_of_pil(self):
-        """Pin the v5.5.4 contract: kwarg is ``images=`` (NOT
-        ``videos=``), and the value is a flat ``list[PIL.Image]``
-        (NOT a list-of-lists)."""
+    def test_init_video_session_called_with_pil_list(self):
+        """Pin: the inference session is created via
+        ``processor.init_video_session(video=List[PIL])``. We do
+        NOT call ``processor(images=...)`` directly anymore — the
+        session takes care of preprocessing."""
         from PIL import Image as _PIL
 
         frames = [_green_frame() for _ in range(30)]
         cap = _FakeVideoCapture(frames=frames, fps=30.0)
-        proc, captured = self._build_capturing_processor()
-        model = MagicMock()
-        model.init_state.return_value = MagicMock()
-        model.add_new_points_or_box.return_value = None
-        model.propagate_in_video.side_effect = lambda _state: iter(())
-        set_singleton_for_testing(_fake_loaded(model, processor=proc))
+        model, processor, _ = _make_v5_sam2_pair(sample_count=0)
+        set_singleton_for_testing(_fake_loaded(model, processor=processor))
         tracker = Sam2TrackerImpl(model_id="x")
 
         with patch("cv2.VideoCapture", return_value=cap):
@@ -621,30 +595,85 @@ class TestSam2ProcessorInputShape:
                 sample_fps=5,
             )
 
-        kwargs = captured["kwargs"]
-        # Kwarg name must be ``images``. ``videos`` does not exist
-        # in v5 — passing it falls through to ``**kwargs``, leaving
-        # the processor input-less.
-        assert "images" in kwargs, (
-            f"processor must be called with ``images=`` kwarg; got "
+        processor.init_video_session.assert_called_once()
+        kwargs = processor.init_video_session.call_args.kwargs
+        # ``video=List[PIL.Image]`` (singular ``video``, NOT
+        # ``videos`` — that's the v4 name).
+        assert "video" in kwargs, (
+            f"init_video_session must be called with ``video=``; got "
             f"kwargs={list(kwargs.keys())}"
         )
-        assert "videos" not in kwargs, (
-            "``videos=`` is the v4 name; in transformers 5.x it's "
-            "absorbed into **kwargs and ignored, leaving the "
-            "processor with no input"
+        video = kwargs["video"]
+        assert isinstance(video, list)
+        assert all(isinstance(f, _PIL.Image) for f in video)
+        assert len(video) == 5, (
+            f"expected 5 sampled frames at 30fps/sample_fps=5/1000ms; "
+            f"got {len(video)}"
         )
-        images = kwargs["images"]
-        # Flat list of PIL images, NOT a list-of-lists.
-        assert isinstance(images, list), (
-            f"images must be a list; got {type(images)}"
-        )
-        assert all(isinstance(f, _PIL.Image) for f in images), (
-            "all items must be PIL images (not wrapped in another list)"
-        )
-        assert len(images) == 5, (
-            f"expected 5 sampled frames at 30fps/sample_fps=5/1000ms window; "
-            f"got {len(images)}"
+
+    def test_process_new_points_or_boxes_called_with_anchor_bbox(self):
+        """Pin: the anchor bbox is added via the v5
+        ``processor.process_new_points_or_boxes_for_video_frame``
+        call with ``input_boxes`` 3-deep-nested
+        ``[[[x1, y1, x2, y2]]]`` and ``original_size=(H, W)``."""
+        from PIL import Image as _PIL
+
+        frames = [_green_frame() for _ in range(30)]
+        cap = _FakeVideoCapture(frames=frames, fps=30.0)
+        model, processor, _ = _make_v5_sam2_pair(sample_count=0)
+        set_singleton_for_testing(_fake_loaded(model, processor=processor))
+        tracker = Sam2TrackerImpl(model_id="x")
+
+        with patch("cv2.VideoCapture", return_value=cap):
+            tracker.track(
+                scene_id="s1",
+                anchor_bbox=BBoxXYWH(x=10, y=20, width=50, height=60),
+                anchor_keyframe=_PIL.new("RGB", (1, 1)),
+                full_video_path="/tmp/proxy.mp4",
+                scene_start_ms=0,
+                scene_end_ms=1000,
+                sample_fps=5,
+            )
+
+        processor.process_new_points_or_boxes_for_video_frame.assert_called_once()
+        kwargs = processor.process_new_points_or_boxes_for_video_frame.call_args.kwargs
+        # Box is xyxy (NOT xywh) per the SAM2 contract:
+        # x1 = 10, y1 = 20, x2 = 60, y2 = 80.
+        assert kwargs["input_boxes"] == [[[10.0, 20.0, 60.0, 80.0]]]
+        assert kwargs["frame_idx"] == 0  # anchor on first sampled frame
+        assert kwargs["obj_ids"] == [1]
+        # original_size is (H, W).
+        assert kwargs["original_size"] == (240, 320)
+
+    def test_propagate_in_video_iterator_called_with_session(self):
+        """Pin: model propagation uses the v5
+        ``propagate_in_video_iterator(inference_session=...)``.
+        ``init_state`` / ``propagate_in_video`` (v4) do not exist
+        on Sam2VideoModel in v5."""
+        from PIL import Image as _PIL
+
+        frames = [_green_frame() for _ in range(30)]
+        cap = _FakeVideoCapture(frames=frames, fps=30.0)
+        model, processor, fake_session = _make_v5_sam2_pair(sample_count=0)
+        set_singleton_for_testing(_fake_loaded(model, processor=processor))
+        tracker = Sam2TrackerImpl(model_id="x")
+
+        with patch("cv2.VideoCapture", return_value=cap):
+            tracker.track(
+                scene_id="s1",
+                anchor_bbox=_bbox_for_320x240(),
+                anchor_keyframe=_PIL.new("RGB", (1, 1)),
+                full_video_path="/tmp/proxy.mp4",
+                scene_start_ms=0,
+                scene_end_ms=1000,
+                sample_fps=5,
+            )
+
+        model.propagate_in_video_iterator.assert_called_once()
+        kwargs = model.propagate_in_video_iterator.call_args.kwargs
+        assert kwargs["inference_session"] is fake_session, (
+            "iterator must be passed the session returned by "
+            "init_video_session, not a freshly-constructed one"
         )
 
 


### PR DESCRIPTION
## Summary

PR F's per-scene diagnostics gave us the AttributeError trace from parent_job_id \`2c3ffac2\`: every scene raised \`AttributeError: 'Sam2VideoModel' object has no attribute 'init_state'\`. Inspection of the v5.5.4 surfaces inside the running container revealed v5 completely reworked the SAM2 video tracking API.

| v4 (what we had) | v5.5.4 (this PR) |
|---|---|
| \`processor(videos=..., return_tensors='pt')\` | \`processor.init_video_session(video=List[PIL])\` |
| \`model.init_state(pixel_values=...)\` | (handled by \`init_video_session\`) |
| \`model.add_new_points_or_box(state, frame_idx, obj_id, box)\` | \`processor.process_new_points_or_boxes_for_video_frame(inference_session, frame_idx, obj_ids=[1], input_boxes=[[[x1,y1,x2,y2]]], original_size=(H,W))\` |
| \`model.propagate_in_video(state)\` → \`(prop_idx, _, masks)\` | \`model.propagate_in_video_iterator(inference_session=...)\` → \`Sam2VideoSegmentationOutput\` (\`pred_masks\` shape \`(batch, num_obj, H, W)\`) |

## Test plan

- [x] 104/104 worker tests pass (102 prior + 2 net new).
- [x] \`TestSam2ProcessorInputShape\` rewritten with 3 tests pinning the v5 call shapes — \`init_video_session(video=List[PIL])\`, \`process_new_points_or_boxes_for_video_frame(input_boxes=[[[x,y,X,Y]]], original_size=(H,W))\`, \`propagate_in_video_iterator(inference_session=fake_session)\`.
- [x] \`test_anchor_bbox_overflowing_frame_is_clamped\` updated to capture the box from \`process_new_points_or_boxes_for_video_frame.call_args.kwargs[input_boxes]\`.
- [x] All existing happy-path + seek/window tests pass against the new mocking surface.

## Verification

After merge → GHCR rebuild → Aircloud restart:
1. Retrigger wizard scan on \`gd_05e7f957502e86cf\`.
2. \`worker_events WHERE job_id = '<new>' AND event_name = 'sam2_track_scene_failed'\` should now be **empty**.
3. Best case: parent transitions \`queued → tracking → assembling → done\`. Render_job_ids populate. Wizard renders shorts.
4. If a NEW exception fires, PR F's diagnostics still surface it per scene — no Aircloud-log round trip.

## Why this is the right fix

Three iteration cycles on the SAM2 wrapper were necessary because we were guessing at v5's API. PR F made each iteration cheap: from "Aircloud log → grep → file ticket" to "SQL query in 5 seconds". This PR is the third correction, and now grounded in empirically-verified \`inspect.signature\` output from the running container.