### PR TITLE
fix(product-track-worker): pass start_frame_idx to SAM2 v5 propagation iterator

### DIFF
--- a/services/product-track-worker/src/sam2_tracker.py
+++ b/services/product-track-worker/src/sam2_tracker.py
@@ -282,10 +282,21 @@ class Sam2TrackerImpl:
             # ``Sam2VideoSegmentationOutput`` per frame in
             # ascending frame order; ``output.pred_masks`` has
             # shape ``(batch_size, num_objects, H, W)``.
+            #
+            # ``start_frame_idx=anchor_idx`` is REQUIRED. Without
+            # it the iterator raises ``ValueError: Cannot determine
+            # the starting frame index; please specify it manually,
+            # or run inference on a frame with inputs first.`` —
+            # observed on every scene of staging incident 2026-05-04
+            # parent_job_id af195a4a. The auto-detect path expects
+            # the session to be primed via ``model.forward(...)``
+            # first, but we use the explicit-start path because
+            # we know the anchor placement.
             samples: list[TrackedSample] = []
             for prop_idx, output in enumerate(
                 loaded.model.propagate_in_video_iterator(
                     inference_session=inference_session,
+                    start_frame_idx=anchor_idx,
                 )
             ):
                 if prop_idx >= len(sampled_frames):

--- a/services/product-track-worker/tests/test_sam2.py
+++ b/services/product-track-worker/tests/test_sam2.py
@@ -675,6 +675,15 @@ class TestSam2ProcessorInputShape:
             "iterator must be passed the session returned by "
             "init_video_session, not a freshly-constructed one"
         )
+        # ``start_frame_idx`` MUST be explicit. Default ``None``
+        # raises ``ValueError: Cannot determine the starting
+        # frame index`` because the session was primed via
+        # ``process_new_points_or_boxes_for_video_frame``, not
+        # ``model.forward(...)``, so the auto-detect path fails.
+        assert kwargs["start_frame_idx"] == 0, (
+            f"expected start_frame_idx=0 (anchor frame); got "
+            f"{kwargs.get('start_frame_idx')!r}"
+        )
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

PR F's per-scene diagnostics showed PR H got us through both \`init_video_session\` and \`process_new_points_or_boxes_for_video_frame\`. Next failure on every scene of parent_job_id \`af195a4a\`:

\`\`\`
ValueError: Cannot determine the starting frame index;
please specify it manually, or run inference on a frame with inputs first.
\`\`\`

The error names the fix. \`propagate_in_video_iterator(start_frame_idx=None, ...)\` defaults to auto-detect: the iterator looks for a "primed" frame in the session (one set via \`model.forward(...)\`) to pick the start. Our session is primed via \`processor.process_new_points_or_boxes_for_video_frame\` (bbox prompt) without a forward call, so auto-detect fails.

Fix: pass \`start_frame_idx=anchor_idx\` (= 0; Phase 3c-B v1 convention) explicitly. The iterator forward-propagates from the anchor frame.

## Test plan

- [x] 104/104 worker tests pass.
- [x] \`test_propagate_in_video_iterator_called_with_session\` extended to assert \`start_frame_idx=0\`. Regression caught in CI if the kwarg is ever dropped.

## Verification

After GHCR rebuild + Aircloud restart:
1. Retrigger wizard scan on \`gd_05e7f957502e86cf\`.
2. \`worker_events WHERE job_id = '<new>' AND event_name = 'sam2_track_scene_failed'\` should now be empty.
3. Best case: SAM2 actually completes propagation per scene, parent transitions \`tracking → assembling → done\`.