### PR TITLE
fix(product-track-worker): SAM2 v5 pred_masks are logits — sigmoid for confidence, threshold for bbox

### DIFF
--- a/services/product-track-worker/src/sam2_tracker.py
+++ b/services/product-track-worker/src/sam2_tracker.py
@@ -306,21 +306,30 @@ class Sam2TrackerImpl:
                 # We added exactly one object (obj_id=1), so the
                 # first dim of ``pred_masks`` is "this video" and
                 # the second is "this object".
-                mask_t = output.pred_masks[0, 0]
-                # Confidence: prefer iou_scores when SAM2 emits
-                # them on the output object; otherwise fall back
-                # to mean-of-mask. Conservative default; calibration
-                # can tighten later.
-                iou_attr = getattr(output, "iou_scores", None)
-                if iou_attr is not None:
-                    try:
-                        mask_conf = float(iou_attr.flatten()[0].item())
-                    except Exception:  # noqa: BLE001
-                        mask_conf = float(mask_t.float().mean().item())
-                else:
-                    mask_conf = float(mask_t.float().mean().item())
-                mask_np = mask_t.detach().cpu().numpy()
-                bbox = _mask_to_bbox(mask_np)
+                #
+                # ``pred_masks`` are LOGITS in v5 (verified by the
+                # 2026-05-04 422 from /complete: every appearance's
+                # ``avg_confidence`` was negative because we were
+                # taking ``mean(logits)`` instead of
+                # ``mean(sigmoid(logits))``). Convert to
+                # probabilities for the confidence aggregate, and
+                # threshold at logit>0 (== prob>0.5) for the
+                # foreground mask handed to ``_mask_to_bbox``
+                # (which interprets any nonzero pixel as
+                # foreground; raw logits would treat every negative
+                # background pixel as foreground too, swelling the
+                # bbox to the whole frame).
+                mask_logits = output.pred_masks[0, 0]
+                mask_conf_raw = float(
+                    torch.sigmoid(mask_logits).mean().item()
+                )
+                # Defensive clamp — sigmoid mean is mathematically
+                # in (0, 1) but float jitter at the edges shouldn't
+                # be allowed to slip past the API's ``ge=0`` /
+                # ``le=1`` schema validators on ``avg_confidence``.
+                mask_conf = max(0.0, min(1.0, mask_conf_raw))
+                binary_mask = (mask_logits > 0).detach().cpu().numpy()
+                bbox = _mask_to_bbox(binary_mask)
                 if bbox is None:
                     # Empty mask — SAM2 lost the object. Emit a
                     # low-confidence sample with the anchor bbox

--- a/services/product-track-worker/tests/test_sam2.py
+++ b/services/product-track-worker/tests/test_sam2.py
@@ -420,7 +420,13 @@ class TestSam2TrackerImplHappyPath:
         # Frame dimensions propagated through.
         assert all(s.frame_width == 320 and s.frame_height == 240 for s in samples)
         # Confidence taken from masks.score per-frame.
-        assert all(0.9 < s.mask_confidence <= 1.0 for s in samples)
+        # ``mask_confidence`` is mean-sigmoid of the predicted mask
+        # logits in v5; with our test mask (3600 of 76800 pixels
+        # set to 1, rest to 0) the mean lands around 0.51. The
+        # important contract is the API-schema range [0, 1] —
+        # negative confidences would 422 at /complete (incident
+        # 2026-05-04 parent_job_id 1b6a4def).
+        assert all(0.0 <= s.mask_confidence <= 1.0 for s in samples)
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

PRs B-I successfully got the SAM2 wrapper through every layer of the v5 API. parent_job_id \`1b6a4def\` made it through SAM2 propagation in 49 seconds (vs. ~10s of fast-fails) and ALL THE WAY to \`api.complete_track(...)\` — only to fail with a 422 at \`/internal/products/{job_id}/complete\`:

\`\`\`
11 validation errors:
  loc: ('body', 'appearances', N, 'avg_confidence')
  type: greater_than_equal
  msg: 'Input should be greater than or equal to 0'
  input: -957.027 / -756.94 / -618.26 / -606.23 / -525.55 / ...
\`\`\`

Negative confidences in the hundreds. Root cause: v5 \`Sam2VideoSegmentationOutput.pred_masks\` are **logits**, not binary masks. Two compounding bugs:

1. **Confidence**: \`mean(logits)\` was dominated by negative background pixels. API rejects via \`Field(ge=0.0)\`.
2. **Bbox**: \`_mask_to_bbox(mask_np.astype(bool))\` treats any nonzero pixel as foreground. Raw logits have BOTH negative and positive nonzero values, so background pixels falsely counted as foreground → bbox spans the whole frame.

Fix: \`mean(sigmoid(logits))\` for confidence (defensively clamped to \`[0, 1]\`), and threshold at \`logit > 0\` (== prob > 0.5) for the binary foreground mask handed to \`_mask_to_bbox\`.

## Test plan

- [x] 104/104 worker tests pass.
- [x] Existing happy-path assertion relaxed from \`0.9 < mask_confidence <= 1.0\` to schema range \`0.0 <= mask_confidence <= 1.0\` — explained inline that calibration lives in staging soak.

## Verification path

After GHCR rebuild + Aircloud restart, retrigger the wizard scan. Expected:
1. SAM2 propagation completes (already does — verified by 1b6a4def reaching /complete)
2. Appearances payload now passes the \`avg_confidence >= 0\` validator
3. \`/complete\` returns 200, \`render_job_id\` populated, parent stage \`done\`
4. Wizard renders shorts. **Feature ships.**

## Out of scope

- Picking a "better" confidence aggregate (e.g., max-prob, foreground-only mean) than sigmoid-mean — calibration concern; current value is at minimum schema-valid.
- Surfacing model-side iou_scores / quality_scores — not exposed on \`Sam2VideoSegmentationOutput\` per the v5 inspect dump we did earlier.