### PR TITLE
fix(cli): load all ORM models in backfill_spoken_aliases for mapper config

### DIFF
--- a/services/api/app/cli/backfill_spoken_aliases.py
+++ b/services/api/app/cli/backfill_spoken_aliases.py
@@ -153,6 +153,12 @@ async def _run(args: argparse.Namespace) -> int:
 
     from app.config import get_settings
     from app.db.base import get_async_engine
+    # Trigger registration of every ORM model so SQLAlchemy can
+    # resolve cross-table relationships (e.g., Org.users → User) at
+    # mapper configuration time. Without this, querying Org raises
+    # ``InvalidRequestError: expression 'User' failed to locate a
+    # name``. Mirrors the pattern in app/cli/backfill.py.
+    import app.db.models  # noqa: F401
     from app.storage.s3 import S3Client
 
     settings = get_settings()


### PR DESCRIPTION
## Summary

One-line fast-follow on PR #148. Without ``import app.db.models`` (a no-op import that triggers registration of every ORM module), the lazy resolver in ``_resolve_org_id`` hits ``InvalidRequestError: expression 'User' failed to locate a name`` when SQLAlchemy configures the ``Org`` mapper.

Pattern established in ``app/cli/backfill.py:344``.

## How it was caught

Ran the backfill on staging right after #148 merged:

```
docker compose exec -T api python -m app.cli.backfill_spoken_aliases --org devorg --dry-run
```

Failed mid-mapper-config. Adding the no-op import unblocks staging.

## Test plan

- [x] CI allowlist (no path regression — tests bypass DB)
- [ ] Re-run staging dry-run after merge
- [ ] Real backfill against `gd_05e7f957502e86cf` (validates "온리츄얼" appears for "온리틀" entries)