### PR TITLE
feat(shorts-auto-product): track_stt pipeline (PR 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
             tests/test_v2_router_video_id_resolution.py \
             tests/test_videos_internal_scenes_with_keyframes.py \
             tests/test_shorts_auto_product_alias_generator.py \
+            tests/test_shorts_auto_product_track_stt_pure.py \
+            tests/test_shorts_auto_product_track_stt_async.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -377,6 +377,23 @@ class Settings(BaseSettings):
     auto_shorts_product_v2_enumeration_version: str = "v1.0"
     auto_shorts_product_v2_tracker_version: str = "v1.0"
 
+    # ---------- v0.15.0 STT-pivot track mode ----------
+    #
+    # ``"sam2"`` (default) preserves existing behavior — the
+    # ``shorts_auto_product`` orchestrator fans out to
+    # ``product-track-worker`` via SQS for per-scene SAM2 mask
+    # propagation. ``"stt"`` swaps in the in-process STT pipeline at
+    # ``shorts_auto_product/track_stt``: BM25 mention extraction over
+    # OpenSearch, gpt-4o-mini chunk scoring, no GPU. Flip to ``"stt"``
+    # only after the catalog backfill of ``spoken_aliases`` is complete
+    # for the org (PR 1b).
+    #
+    # See ``.claude/plans/shorts-auto-product-stt-pivot.md`` for the
+    # full migration plan, including the prod rollback path which
+    # requires keeping the SAM2 worker deployable for at least 30 days
+    # post-flip.
+    auto_shorts_product_v2_track_mode: str = "sam2"
+
     # Idempotency window for the scan endpoint — same (video_id,
     # user_id) within this window returns the existing job_id.
     auto_shorts_product_v2_scan_idempotency_seconds: int = 60

--- a/services/api/app/modules/shorts_auto_product/track_stt/__init__.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/__init__.py
@@ -1,0 +1,55 @@
+"""STT-based mention extraction track for shorts-auto product mode v2.
+
+Replaces the SAM2 visual tracking path with mention extraction over
+OpenSearch ``transcript_raw`` / ``scene_caption``. The user picks a
+catalog entry; this module finds the scenes that mention the product
+(via BM25 over the catalog entry's ``llm_label`` + ``spoken_aliases``),
+assembles them into segments, scores chunks, picks top clips, builds
+a CompositionSpec, and enqueues the render.
+
+Pipeline (orchestrated by ``service.assemble_stt_clip``):
+
+    1. ``mention_extractor.find_mentioned_scenes(...)`` → MentionedScene[]
+    2. ``segment_assembler.group_into_segments(...)`` → MentionSegment[]
+    3. ``chunk_scorer.score_segment_chunks(...)``    → ScoredChunk[]
+    4. ``clip_selector.select_top_chunks(...)``      → list[ScoredChunk]
+    5. ``composition_builder.build_composition_spec(...)`` → CompositionSpec
+    6. (caller) → ``ShortsRenderService.create_render_job(...)``
+
+Loose-coupling: this module imports only from
+``heimdex_media_contracts``, ``heimdex_media_pipelines.product_enum``
+(no — pipelines are forbidden, never use), own module,
+``app.lib.product_track`` (already-vendored pure math),
+``app.dependencies`` (top-level DI), ``app.config``, ``app.storage.s3``,
+``opensearchpy``, ``openai``. NEVER imports from ``app.modules.search.*``,
+``app.modules.shorts_auto.*``, ``app.modules.shorts_render.*``, or
+``app.modules.shorts.*``.
+
+Plan: ``.claude/plans/shorts-auto-product-stt-pivot.md`` PR 2.
+"""
+
+from app.modules.shorts_auto_product.track_stt.errors import (
+    MentionExtractionError,
+    NoMentionsFoundError,
+    SttPipelineError,
+    TranscriptUnavailableError,
+)
+from app.modules.shorts_auto_product.track_stt.models import (
+    ChunkScore,
+    MentionedScene,
+    MentionSegment,
+    ScoredChunk,
+    SttClipResult,
+)
+
+__all__ = [
+    "ChunkScore",
+    "MentionedScene",
+    "MentionExtractionError",
+    "MentionSegment",
+    "NoMentionsFoundError",
+    "ScoredChunk",
+    "SttClipResult",
+    "SttPipelineError",
+    "TranscriptUnavailableError",
+]

--- a/services/api/app/modules/shorts_auto_product/track_stt/chunk_scorer.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/chunk_scorer.py
@@ -1,0 +1,381 @@
+"""Chunk scoring — port of standalone product-auto-shorts'
+``scoring.py::GPTChunkScorer`` + ``score_segment``.
+
+Splits each :class:`MentionSegment` into 10-30s chunks (text from the
+underlying ``MentionedScene[]``), asks gpt-4o-mini for hook/CTA/
+importance scores, returns :class:`ScoredChunk[]`. Service-level
+fallback to a heuristic scorer on any LLM defect (timeout, JSON
+parse, schema validation, budget exhausted) — the heuristic gives a
+deterministic 0.5 baseline so the pipeline always produces output.
+
+Distinct from ``app.modules.shorts_auto.scorers.llm.OpenAILLMScorer``
+in two ways:
+
+1. **Different operation.** That scorer is a *scene picker* (gpt-4o
+   asked "which whole scenes belong in the shorts clip"); this one is
+   a *chunk scorer* (asked "score this 10-30s window for hook/CTA/
+   importance"). Different prompts, different response schemas.
+2. **Loose-coupling.** ``shorts_auto_product`` cannot import from
+   ``app.modules.shorts_auto.*`` per CLAUDE.md. This module is
+   self-contained and reuses only ``heimdex_media_contracts`` (zero)
+   + ``openai`` + own-module errors/models.
+
+Cost model (gpt-4o-mini):
+
+* Input: ~600 system tokens + ~1k chunk-text-and-context per call,
+  batched up to 20 chunks per request → ~$0.0003 per chunk
+* Output: ~50 tokens per chunk → trivial
+* **Total: ~$0.005 for a 60s clip selection** (15 chunks). The
+  per-scan budget bucket
+  ``auto_shorts_product_v2_daily_budget_usd=50.0`` swallows this
+  comfortably.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+from app.modules.shorts_auto_product.track_stt.models import (
+    ChunkScore,
+    MentionSegment,
+    ScoredChunk,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Chunk size bounds — match the standalone repo. The cap is
+# ``min(30s, max(10s, requested))`` so the scorer never gets handed
+# a chunk shorter than 10s (too little speech to score) or longer
+# than 30s (LLM context bloat + quality drop).
+_CHUNK_MIN_MS = 10_000
+_CHUNK_MAX_MS = 30_000
+
+# Maximum chunks per single LLM call. Standalone uses 20; we mirror.
+# Beyond ~20 the model's accuracy on per-chunk scoring degrades.
+_MAX_CHUNKS_PER_REQUEST = 20
+
+# Heuristic baseline for the fallback scorer. 0.5 / False / 0.5 is
+# deliberate: the clip selector treats it as "neutral, no signal"
+# — chunks survive selection only if no LLM-scored chunks exist.
+_HEURISTIC_HOOK = 0.5
+_HEURISTIC_HAS_CTA = False
+_HEURISTIC_IMPORTANCE = 0.5
+
+
+# ---------- LLM contract ----------
+#
+# The system prompt is mirrored verbatim from
+# ``product-auto-shorts/app/services/scoring.py::SYSTEM_PROMPT`` —
+# we don't have a calibration story to deviate yet, and the
+# standalone repo's prompt has been tuned on real Korean livecommerce
+# transcripts. Worth a contracts-side prompt class once we run the
+# eval harness in PR 3.
+_SYSTEM_PROMPT = (
+    "You score live commerce transcript chunks for short-form clip "
+    "selection.\n"
+    "\n"
+    "For each chunk, detect:\n"
+    "- excitement level\n"
+    "- urgency\n"
+    "- sales language\n"
+    "- emotional impact\n"
+    "\n"
+    "Return strict JSON through the provided tool with exactly one "
+    "score object per input chunk, in the same order.\n"
+    "\n"
+    "Schema for each score:\n"
+    "{\n"
+    "  \"hook_score\": float between 0 and 1,\n"
+    "  \"has_cta\": boolean,\n"
+    "  \"importance_score\": float between 0 and 1\n"
+    "}\n"
+    "\n"
+    "Scoring guidance:\n"
+    "- hook_score: opening strength, attention value, emotional "
+    "  pull, surprise, or curiosity.\n"
+    "- has_cta: true only when the transcript asks viewers to buy, "
+    "  order, click, act now, or implies urgent conversion.\n"
+    "- importance_score: overall clip-worthiness for a natural "
+    "  product-introduction short. Prefer speech that clearly "
+    "  introduces the product/category, explains benefits, "
+    "  demonstrates usage, compares value, includes a natural "
+    "  transition, or gives purchase motivation.\n"
+    "\n"
+    "Be deterministic. Do not infer facts not present in the "
+    "transcript."
+)
+
+
+_RESPONSE_JSON_SCHEMA: dict[str, Any] = {
+    "name": "chunk_score_batch",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["scores"],
+        "properties": {
+            "scores": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["hook_score", "has_cta", "importance_score"],
+                    "properties": {
+                        "hook_score": {
+                            "type": "number",
+                            "minimum": 0.0,
+                            "maximum": 1.0,
+                        },
+                        "has_cta": {"type": "boolean"},
+                        "importance_score": {
+                            "type": "number",
+                            "minimum": 0.0,
+                            "maximum": 1.0,
+                        },
+                    },
+                },
+            }
+        },
+    },
+}
+
+
+class _ChunkScoreItem(BaseModel):
+    hook_score: float = Field(ge=0.0, le=1.0)
+    has_cta: bool
+    importance_score: float = Field(ge=0.0, le=1.0)
+
+
+class _ChunkScoreBatch(BaseModel):
+    scores: list[_ChunkScoreItem]
+
+
+@dataclass(frozen=True)
+class _ChunkInput:
+    """Pre-LLM chunk shape. Internal only."""
+
+    start_ms: int
+    end_ms: int
+    transcript: str
+
+
+# ---------- public entrypoint ----------
+
+
+async def score_segment_chunks(
+    *,
+    segment: MentionSegment,
+    openai_client: Any,
+    model: str = "gpt-4o-mini",
+    timeout_s: float = 15.0,
+    chunk_size_ms: int = 20_000,
+) -> list[ScoredChunk]:
+    """Slice a segment into chunks, score each via gpt-4o-mini.
+
+    On any LLM defect (timeout, hallucinated count mismatch, JSON
+    parse, schema validation, budget exceeded) every chunk in the
+    segment falls back to the heuristic baseline. We DO NOT raise —
+    a heuristic-scored segment is better than no clip.
+    """
+    chunk_inputs = _build_chunk_inputs(segment, chunk_size_ms)
+    if not chunk_inputs:
+        logger.info(
+            "stt_chunk_scoring_empty_segment",
+            extra={
+                "segment_start_ms": segment.start_ms,
+                "segment_end_ms": segment.end_ms,
+            },
+        )
+        return []
+
+    scores: list[ChunkScore] = []
+    for batch in _batched(chunk_inputs, _MAX_CHUNKS_PER_REQUEST):
+        scores.extend(
+            await _score_one_batch(
+                chunks=batch,
+                openai_client=openai_client,
+                model=model,
+                timeout_s=timeout_s,
+            )
+        )
+
+    assert len(scores) == len(chunk_inputs)  # invariant of _score_one_batch
+    return [
+        ScoredChunk(
+            start_ms=chunk.start_ms,
+            end_ms=chunk.end_ms,
+            text=chunk.transcript,
+            score=score,
+        )
+        for chunk, score in zip(chunk_inputs, scores, strict=True)
+    ]
+
+
+# ---------- internals ----------
+
+
+def _build_chunk_inputs(
+    segment: MentionSegment, chunk_size_ms: int,
+) -> list[_ChunkInput]:
+    """Slice a segment into fixed-width chunks, attaching the
+    transcript_text from any underlying scenes that overlap each
+    chunk. Pure function.
+    """
+    chunk_size = min(_CHUNK_MAX_MS, max(_CHUNK_MIN_MS, chunk_size_ms))
+    chunks: list[_ChunkInput] = []
+    cursor = segment.start_ms
+
+    while cursor < segment.end_ms:
+        chunk_end = min(segment.end_ms, cursor + chunk_size)
+        # Concatenate transcript text from scenes that overlap this
+        # chunk window. Scene granularity is coarser than chunk
+        # granularity; one scene's transcript may span multiple
+        # chunks, in which case the same text appears in each. The
+        # LLM gets the right textual context regardless.
+        overlapping_text_parts: list[str] = []
+        for scene in segment.scenes:
+            if scene.start_ms < chunk_end and scene.end_ms > cursor:
+                # Prefer transcript_raw; fall back to scene_caption
+                # so caption-only videos (gd_bb9c22c2c00d180c-style)
+                # still get scored.
+                text = scene.transcript_text or scene.caption_text
+                if text:
+                    overlapping_text_parts.append(text)
+        transcript = " ".join(overlapping_text_parts).strip()
+        chunks.append(
+            _ChunkInput(
+                start_ms=cursor,
+                end_ms=chunk_end,
+                transcript=transcript,
+            )
+        )
+        cursor = chunk_end
+
+    return chunks
+
+
+async def _score_one_batch(
+    *,
+    chunks: list[_ChunkInput],
+    openai_client: Any,
+    model: str,
+    timeout_s: float,
+) -> list[ChunkScore]:
+    """One LLM call. Returns one ChunkScore per input chunk. On any
+    defect, returns heuristic scores so the caller can keep going.
+    """
+    if not chunks:
+        return []
+
+    payload_chunks = [
+        {
+            "start_ms": c.start_ms,
+            "end_ms": c.end_ms,
+            "transcript": c.transcript,
+        }
+        for c in chunks
+    ]
+
+    try:
+        response = await openai_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": json.dumps(payload_chunks, ensure_ascii=False),
+                },
+            ],
+            response_format={
+                "type": "json_schema",
+                "json_schema": _RESPONSE_JSON_SCHEMA,
+            },
+            temperature=0.0,
+            seed=42,
+            max_tokens=700,
+            timeout=timeout_s,
+        )
+    except Exception as e:  # noqa: BLE001 — fall back, never raise
+        logger.warning(
+            "stt_chunk_scoring_llm_failed_fallback_heuristic",
+            extra={
+                "chunk_count": len(chunks),
+                "error_type": type(e).__name__,
+                "error": str(e)[:300],
+            },
+        )
+        return _heuristic_batch(len(chunks))
+
+    raw = response.choices[0].message.content or ""
+    parsed = _parse_or_fallback(raw, expected_count=len(chunks))
+    return parsed
+
+
+def _parse_or_fallback(
+    raw_text: str, *, expected_count: int,
+) -> list[ChunkScore]:
+    """Parse LLM JSON → ChunkScore[]. Any defect → heuristic batch."""
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError:
+        logger.warning(
+            "stt_chunk_scoring_json_parse_failed_fallback",
+            extra={"raw_head": raw_text[:200]},
+        )
+        return _heuristic_batch(expected_count)
+
+    try:
+        batch = _ChunkScoreBatch.model_validate(data)
+    except ValidationError as e:
+        logger.warning(
+            "stt_chunk_scoring_schema_validation_failed_fallback",
+            extra={"error": str(e)[:200]},
+        )
+        return _heuristic_batch(expected_count)
+
+    if len(batch.scores) != expected_count:
+        logger.warning(
+            "stt_chunk_scoring_count_mismatch_fallback",
+            extra={
+                "expected": expected_count,
+                "got": len(batch.scores),
+            },
+        )
+        return _heuristic_batch(expected_count)
+
+    return [
+        ChunkScore(
+            hook_score=item.hook_score,
+            has_cta=item.has_cta,
+            importance_score=item.importance_score,
+        )
+        for item in batch.scores
+    ]
+
+
+def _heuristic_batch(count: int) -> list[ChunkScore]:
+    """Deterministic baseline. Lets the pipeline produce output even
+    when the LLM is unavailable. Plain 0.5 / False / 0.5 because we
+    have no per-chunk signal without the LLM — the clip selector
+    will then fall back to chronological-first selection.
+    """
+    return [
+        ChunkScore(
+            hook_score=_HEURISTIC_HOOK,
+            has_cta=_HEURISTIC_HAS_CTA,
+            importance_score=_HEURISTIC_IMPORTANCE,
+        )
+        for _ in range(count)
+    ]
+
+
+def _batched(
+    items: list[_ChunkInput], size: int,
+) -> list[list[_ChunkInput]]:
+    return [items[i : i + size] for i in range(0, len(items), size)]

--- a/services/api/app/modules/shorts_auto_product/track_stt/clip_selector.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/clip_selector.py
@@ -1,0 +1,185 @@
+"""Clip selection — port of standalone product-auto-shorts'
+``main.py::_select_clip_groups``.
+
+Takes ``ScoredChunk[]`` (across all segments) and picks the
+contiguous, chronologically-ordered subset whose total duration is
+closest to ``target_duration_ms`` while maximizing composite score.
+
+Pure function — no LLM, no I/O. Deterministic.
+
+Strategy:
+
+1. Sort by ``composite`` score descending → find the best seed.
+2. From that seed forward in time, accumulate adjacent chunks until
+   the target duration is filled.
+3. If accumulation falls short, expand backward from the seed.
+4. Cap at ``MAX_TARGET_OVERSHOOT_MS`` so a sparse segment can't
+   produce a clip 2× the requested duration.
+
+Selection is single-clip in v1 — the wizard requests
+``length_seconds`` ∈ {30, 60, 90} and the user gets one short. The
+standalone repo's ``clip_count`` parameter is intentionally NOT
+ported because the existing wizard already handles
+``requested_count`` at the parent/child level (multiple shorts =
+multiple parent rows, each running this pipeline once).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.modules.shorts_auto_product.track_stt.models import ScoredChunk
+
+logger = logging.getLogger(__name__)
+
+
+# Allowable overshoot above target. Korean livecommerce chunks are
+# typically 20s; the realistic options are landing exactly on target
+# or +1 chunk (≈+20s). Anything more dilutes the clip.
+MAX_TARGET_OVERSHOOT_MS = 20_000
+
+# Minimum acceptable clip duration relative to target. Below this
+# floor the clip is too short to feel intentional — better to fail
+# the pipeline and let the user pick a different product than ship a
+# 12s "60-second" clip.
+_MIN_DURATION_FRACTION = 0.5
+
+
+def select_top_chunks(
+    *,
+    chunks: list[ScoredChunk],
+    target_duration_ms: int,
+) -> list[ScoredChunk]:
+    """Pick the chunks that go into the final clip.
+
+    Args:
+        chunks: All scored chunks across all segments. Order doesn't
+            matter — sorted internally.
+        target_duration_ms: e.g., 30_000 / 60_000 / 90_000 from the
+            wizard's ``length_seconds`` × 1000.
+
+    Returns:
+        Chronologically-ordered chunks. Returns empty when no
+        contiguous run reaches ``_MIN_DURATION_FRACTION * target``;
+        caller surfaces that as the friendly Korean
+        ``no_mentions_found`` message.
+    """
+    if not chunks or target_duration_ms <= 0:
+        return []
+
+    # Sort once for deterministic seed ordering.
+    chronological = sorted(chunks, key=lambda c: c.start_ms)
+    by_score = sorted(chronological, key=lambda c: -c.composite)
+
+    cap_ms = target_duration_ms + MAX_TARGET_OVERSHOOT_MS
+
+    # Try each seed in score order. First seed that produces a
+    # window passing the floor wins. This biases the clip toward
+    # the highest-importance chunk while still respecting
+    # chronological ordering for the assembled output.
+    for seed in by_score:
+        try:
+            seed_idx = chronological.index(seed)
+        except ValueError:  # pragma: no cover - chronological is a sort of chunks
+            continue
+
+        forward = _accumulate_forward(
+            chronological=chronological,
+            seed_idx=seed_idx,
+            target_ms=target_duration_ms,
+            cap_ms=cap_ms,
+        )
+        backward_extended = _expand_backward(
+            chronological=chronological,
+            window=forward,
+            seed_idx=seed_idx,
+            target_ms=target_duration_ms,
+            cap_ms=cap_ms,
+        )
+
+        duration = _window_duration_ms(backward_extended)
+        floor = int(target_duration_ms * _MIN_DURATION_FRACTION)
+        if duration >= floor:
+            logger.info(
+                "stt_clip_selection_completed",
+                extra={
+                    "seed_start_ms": seed.start_ms,
+                    "seed_composite": seed.composite,
+                    "selected_chunk_count": len(backward_extended),
+                    "duration_ms": duration,
+                    "target_ms": target_duration_ms,
+                },
+            )
+            return backward_extended
+
+    # No seed produced a long-enough window. Caller treats this as
+    # "no clip possible" — usually means BM25 found <2 segments
+    # totaling <30s, which is too sparse to render.
+    logger.info(
+        "stt_clip_selection_no_window_meets_floor",
+        extra={
+            "chunk_count": len(chunks),
+            "target_ms": target_duration_ms,
+        },
+    )
+    return []
+
+
+# ---------- internals ----------
+
+
+def _accumulate_forward(
+    *,
+    chronological: list[ScoredChunk],
+    seed_idx: int,
+    target_ms: int,
+    cap_ms: int,
+) -> list[ScoredChunk]:
+    """Walk forward from seed_idx until total duration ≥ target_ms,
+    bounded by cap_ms. Stops short if the next chunk would push
+    past the cap.
+    """
+    window = [chronological[seed_idx]]
+    duration = chronological[seed_idx].end_ms - chronological[seed_idx].start_ms
+    for i in range(seed_idx + 1, len(chronological)):
+        next_chunk = chronological[i]
+        next_dur = next_chunk.end_ms - next_chunk.start_ms
+        projected = duration + next_dur
+        if projected > cap_ms:
+            break
+        window.append(next_chunk)
+        duration = projected
+        if duration >= target_ms:
+            break
+    return window
+
+
+def _expand_backward(
+    *,
+    chronological: list[ScoredChunk],
+    window: list[ScoredChunk],
+    seed_idx: int,
+    target_ms: int,
+    cap_ms: int,
+) -> list[ScoredChunk]:
+    """If the forward window is short of target, extend backward."""
+    duration = _window_duration_ms(window)
+    if duration >= target_ms:
+        return window
+
+    extended = list(window)
+    for i in range(seed_idx - 1, -1, -1):
+        prev_chunk = chronological[i]
+        prev_dur = prev_chunk.end_ms - prev_chunk.start_ms
+        projected = duration + prev_dur
+        if projected > cap_ms:
+            break
+        extended.insert(0, prev_chunk)
+        duration = projected
+        if duration >= target_ms:
+            break
+    return extended
+
+
+def _window_duration_ms(window: list[ScoredChunk]) -> int:
+    return sum(c.end_ms - c.start_ms for c in window)

--- a/services/api/app/modules/shorts_auto_product/track_stt/composition_builder.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/composition_builder.py
@@ -1,0 +1,142 @@
+"""ScoredChunk[] → CompositionSpec adapter.
+
+Mirrors ``children/composition.py::build_composition_spec_from_stitch_plan``
+but takes our STT pipeline's ``ScoredChunk[]`` instead of SAM2's
+``StitchPlan``. The output shape is identical — the renderer doesn't
+care which path produced the spec.
+
+Pure function. No I/O.
+
+Caveats inherited from the existing wizard adapter:
+
+* ``scene_id`` per-clip is approximate — track_stt scoring works on
+  fixed-width chunks, not scene boundaries, so we attach the
+  ``scene_id`` of the underlying ``MentionedScene`` whose interval
+  most overlaps the chunk window. The renderer doesn't actually
+  branch on ``scene_id`` (it cuts on ``start_ms``/``end_ms``); the
+  field is preserved for downstream search-result attribution.
+* ``video_id`` is the OS string id (``gd_…``), not the
+  ``drive_files.id`` UUID. ``SceneClipSpec.video_id`` accepts the
+  same shape ``RenderJobCreate`` already takes.
+* All clips share one ``video_id`` since v1 product mode is single-video.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from heimdex_media_contracts.composition.schemas import (
+    CompositionSpec,
+    SceneClipSpec,
+)
+
+from app.modules.shorts_auto_product.track_stt.models import (
+    MentionSegment,
+    ScoredChunk,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_composition_spec(
+    *,
+    selected_chunks: list[ScoredChunk],
+    segments: list[MentionSegment],
+    os_video_id: str,
+    title: str | None = None,
+) -> CompositionSpec:
+    """Build the render-ready CompositionSpec.
+
+    Args:
+        selected_chunks: Output of :func:`clip_selector.select_top_chunks`,
+            already chronologically ordered.
+        segments: All segments produced by the assembler — used to
+            map each chunk back to its containing scene_id.
+        os_video_id: The drive ``video_id`` string (e.g.
+            ``"gd_05e7f957502e86cf"``).
+        title: Optional title for the saved short. v1 wizard doesn't
+            collect a title at scan time; the post-render rename
+            endpoint handles user-supplied titles.
+
+    Returns:
+        ``CompositionSpec`` ready to hand to ``ShortsRenderService.create_render_job``.
+
+    Raises:
+        ValueError: ``selected_chunks`` is empty. Caller must surface
+            ``NoMentionsFoundError`` upstream rather than build an
+            invalid spec — :class:`CompositionSpec.scene_clips` has
+            ``min_length=1``.
+    """
+    if not selected_chunks:
+        raise ValueError(
+            "build_composition_spec requires at least one selected "
+            "chunk; caller must surface no-mentions earlier"
+        )
+
+    timeline_cursor_ms = 0
+    clips: list[SceneClipSpec] = []
+
+    for chunk in selected_chunks:
+        scene_id = _attach_scene_id(chunk=chunk, segments=segments)
+        chunk_duration_ms = chunk.end_ms - chunk.start_ms
+        clips.append(
+            SceneClipSpec(
+                scene_id=scene_id,
+                video_id=os_video_id,
+                source_type="gdrive",
+                start_ms=chunk.start_ms,
+                end_ms=chunk.end_ms,
+                timeline_start_ms=timeline_cursor_ms,
+                volume=1.0,
+                # crop / output defaults are fine for v1 — wizard
+                # output is always full-frame 9:16. Output spec is
+                # populated by CompositionSpec's default_factory.
+            )
+        )
+        timeline_cursor_ms += chunk_duration_ms
+
+    spec = CompositionSpec(scene_clips=clips, title=title)
+    logger.info(
+        "stt_composition_built",
+        extra={
+            "video_id": os_video_id,
+            "clip_count": len(clips),
+            "duration_ms": spec.total_duration_ms,
+            "title": title,
+        },
+    )
+    return spec
+
+
+# ---------- internals ----------
+
+
+def _attach_scene_id(
+    *,
+    chunk: ScoredChunk,
+    segments: list[MentionSegment],
+) -> str:
+    """Find the scene_id whose [start_ms, end_ms] interval overlaps
+    the chunk most. Falls back to the first segment's first scene
+    if no overlap is found (defensive — shouldn't happen because
+    chunks are built FROM segments).
+    """
+    best_scene_id = ""
+    best_overlap = -1
+
+    for segment in segments:
+        for scene in segment.scenes:
+            overlap_start = max(chunk.start_ms, scene.start_ms)
+            overlap_end = min(chunk.end_ms, scene.end_ms)
+            overlap = overlap_end - overlap_start
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_scene_id = scene.scene_id
+
+    if not best_scene_id and segments and segments[0].scenes:
+        # Defensive fallback — should never trip given chunks come
+        # FROM segments, but keep CompositionSpec valid even if a
+        # future change inverts that invariant.
+        best_scene_id = segments[0].scenes[0].scene_id
+
+    return best_scene_id

--- a/services/api/app/modules/shorts_auto_product/track_stt/errors.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/errors.py
@@ -1,0 +1,52 @@
+"""Typed errors for the STT pipeline.
+
+Three failure shapes the orchestrator branches on:
+
+* :class:`NoMentionsFoundError` — BM25 + (optional fallbacks) returned
+  zero scenes. The wizard should surface a friendly Korean message
+  ("선택하신 상품에 대한 발화나 시각적 단서가 영상에서 충분히
+  발견되지 않았습니다") rather than render an irrelevant clip.
+* :class:`TranscriptUnavailableError` — the video has zero scenes
+  with non-empty ``transcript_raw`` AND zero with non-empty
+  ``scene_caption``. Different from "no mentions" — there's nothing
+  to search at all (e.g., STT pipeline failed and VLM caption pass
+  also empty). UI message suggests "wait for enrichment".
+* :class:`SttPipelineError` (base) — anything else (OS unreachable,
+  budget exhausted mid-batch, unexpected exception). Caller writes
+  ``error_code='internal_error'`` and lets the wizard's
+  ``friendlyParentError`` mapper turn it into the generic
+  retry-please message.
+
+:class:`MentionExtractionError` is the OS-side specialization — used
+internally by ``mention_extractor`` to distinguish "OS query failed"
+from "OS query returned zero hits" so the orchestrator can decide
+between a retry-able failure and a clean ``NoMentionsFoundError``.
+"""
+
+from __future__ import annotations
+
+
+class SttPipelineError(Exception):
+    """Base for STT-pipeline failures the orchestrator handles."""
+
+
+class NoMentionsFoundError(SttPipelineError):
+    """BM25 (and any fallbacks) returned zero qualifying scenes for
+    this catalog entry. NOT an internal error — the wizard surfaces
+    a friendly Korean message and the user picks a different product.
+    """
+
+
+class TranscriptUnavailableError(SttPipelineError):
+    """The video itself has no searchable text — neither
+    ``transcript_raw`` nor ``scene_caption`` are populated on any
+    scene. The user should wait for STT/VLM enrichment to complete
+    before re-trying.
+    """
+
+
+class MentionExtractionError(SttPipelineError):
+    """OS query failed (transport error, malformed query, etc.). The
+    orchestrator treats this as retryable; ``NoMentionsFoundError``
+    is the explicit zero-hits signal.
+    """

--- a/services/api/app/modules/shorts_auto_product/track_stt/mention_extractor.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/mention_extractor.py
@@ -1,0 +1,275 @@
+"""BM25 mention extraction over OpenSearch.
+
+For a given video + catalog entry, finds scenes whose
+``transcript_raw`` or ``scene_caption`` substring-match the
+``llm_label`` or any ``spoken_aliases`` (PR 1b output).
+
+Korean morphology: ``transcript_raw`` and ``scene_caption`` are
+analyzed with the ``nori`` tokenizer in ``heimdex_scenes_v5``. The
+``match`` query splits the search string on the same analyzer, so
+``달심`` matches ``달심에``, ``달심과``, etc. without us hand-rolling
+stems.
+
+Loose-coupling: this module imports ONLY ``opensearchpy`` (external),
+``app.config`` (top-level), and own-module symbols. It does NOT
+import from ``app.modules.search.*`` — we construct an
+``AsyncOpenSearch`` client inline rather than reuse
+``app.modules.search.client.get_opensearch_client`` to keep
+``shorts_auto_product`` from cross-module imports per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from app.modules.shorts_auto_product.track_stt.errors import (
+    MentionExtractionError,
+)
+from app.modules.shorts_auto_product.track_stt.models import MentionedScene
+
+logger = logging.getLogger(__name__)
+
+
+# Per-query result cap. With BM25 + 3-5 aliases, getting >150 hits on
+# a single video means the search is over-matching (e.g., a generic
+# alias like ``"이 패키지"`` is too broad). The assembler downstream
+# will compress this set anyway via the gap-merge.
+_DEFAULT_RESULT_CAP = 200
+
+# Field-level boosts. Transcript_raw is the strongest signal —
+# audio mentions are direct evidence the host is talking about the
+# product. scene_caption is supplementary — VLM descriptions may
+# mention the product even when the host talks about something
+# else (e.g., a wide shot establishing the scene).
+_TRANSCRIPT_BOOST = 3.0
+_CAPTION_BOOST = 1.5
+# Per-alias boost decays so that the canonical llm_label outranks
+# auto-generated aliases. The strongest alias is the brand
+# transliteration (e.g., "달심"); generic aliases ("이 주스") get a
+# floor to keep them from dominating the score.
+_LABEL_BOOST = 2.0
+_ALIAS_HEAD_BOOST = 1.0
+_ALIAS_TAIL_BOOST = 0.4
+
+
+async def find_mentioned_scenes(
+    *,
+    os_client: Any,
+    index_alias: str,
+    org_id: UUID,
+    video_id: str,
+    llm_label: str,
+    spoken_aliases: list[str],
+    result_cap: int = _DEFAULT_RESULT_CAP,
+) -> list[MentionedScene]:
+    """Run a single BM25 query and return matched scenes.
+
+    Args:
+        os_client: An ``AsyncOpenSearch`` (or compatible mock).
+        index_alias: e.g., ``"heimdex_scenes"``.
+        org_id: Tenant guard — the doc id format is
+            ``f"{org_id}:{scene_id}"`` and the ``org_id`` field is a
+            ``keyword`` on every scene row. We filter on the field to
+            keep cross-org leakage impossible at the query layer.
+        video_id: The drive ``video_id`` string (e.g.
+            ``"gd_05e7f957502e86cf"``), NOT the ``drive_files.id`` UUID.
+        llm_label: From the catalog entry — the canonical search term.
+        spoken_aliases: From ``catalog_entries.spoken_aliases``. May be
+            empty (PR 1b backfill not yet run for this entry); the
+            query falls back to ``llm_label`` only in that case.
+        result_cap: Defensive cap on returned hits.
+
+    Returns:
+        ``MentionedScene[]`` ordered by OS ``_score`` descending. May
+        be empty (caller checks and surfaces ``NoMentionsFoundError``).
+
+    Raises:
+        :class:`MentionExtractionError`: OS query failed.
+    """
+
+    query = _build_bm25_query(
+        org_id=org_id,
+        video_id=video_id,
+        llm_label=llm_label,
+        spoken_aliases=spoken_aliases,
+    )
+
+    try:
+        response = await os_client.search(
+            index=index_alias,
+            body={
+                "size": result_cap,
+                "query": query,
+                "_source": [
+                    "scene_id",
+                    "start_ms",
+                    "end_ms",
+                    "transcript_raw",
+                    "scene_caption",
+                ],
+                "sort": [{"_score": "desc"}],
+            },
+        )
+    except Exception as e:  # noqa: BLE001 — wrap-and-rethrow
+        logger.warning(
+            "stt_mention_extraction_os_failed",
+            extra={
+                "video_id": video_id,
+                "org_id": str(org_id),
+                "error": str(e)[:300],
+            },
+        )
+        raise MentionExtractionError(f"OS search failed: {e}") from e
+
+    hits = response.get("hits", {}).get("hits", [])
+    scenes = [_hit_to_scene(h, llm_label, spoken_aliases) for h in hits]
+    # OS returned them ranked by score; keep the order. Caller
+    # may re-sort by start_ms in the assembler.
+    logger.info(
+        "stt_mention_extraction_completed",
+        extra={
+            "video_id": video_id,
+            "org_id": str(org_id),
+            "alias_count": len(spoken_aliases),
+            "scene_count": len(scenes),
+            "max_score": scenes[0].score if scenes else 0.0,
+        },
+    )
+    return scenes
+
+
+# ---------- internals ----------
+
+
+def _build_bm25_query(
+    *,
+    org_id: UUID,
+    video_id: str,
+    llm_label: str,
+    spoken_aliases: list[str],
+) -> dict[str, Any]:
+    """Build the OS query body. Pure function — easy to test."""
+    should_clauses: list[dict[str, Any]] = []
+
+    # ---- canonical label, both fields ----
+    label_clean = (llm_label or "").strip()
+    if label_clean:
+        should_clauses.append({
+            "match": {
+                "transcript_raw": {
+                    "query": label_clean,
+                    "boost": _TRANSCRIPT_BOOST * _LABEL_BOOST,
+                }
+            }
+        })
+        should_clauses.append({
+            "match": {
+                "scene_caption": {
+                    "query": label_clean,
+                    "boost": _CAPTION_BOOST * _LABEL_BOOST,
+                }
+            }
+        })
+
+    # ---- aliases, decaying boost ----
+    seen: set[str] = {label_clean.casefold()} if label_clean else set()
+    for idx, raw_alias in enumerate(spoken_aliases or []):
+        alias = (raw_alias or "").strip()
+        if not alias:
+            continue
+        key = alias.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        # First alias keeps the head boost; remainder share the tail.
+        per_alias_boost = _ALIAS_HEAD_BOOST if idx == 0 else _ALIAS_TAIL_BOOST
+        should_clauses.append({
+            "match": {
+                "transcript_raw": {
+                    "query": alias,
+                    "boost": _TRANSCRIPT_BOOST * per_alias_boost,
+                }
+            }
+        })
+        should_clauses.append({
+            "match": {
+                "scene_caption": {
+                    "query": alias,
+                    "boost": _CAPTION_BOOST * per_alias_boost,
+                }
+            }
+        })
+
+    return {
+        "bool": {
+            "must": [
+                {"term": {"org_id": str(org_id)}},
+                {"term": {"video_id": video_id}},
+            ],
+            "should": should_clauses,
+            "minimum_should_match": 1 if should_clauses else 0,
+        }
+    }
+
+
+def _hit_to_scene(
+    hit: dict[str, Any],
+    llm_label: str,
+    spoken_aliases: list[str],
+) -> MentionedScene:
+    """Map one OS hit → MentionedScene. Pure function.
+
+    ``matched_field`` is determined by which fields had non-empty text
+    that contained any of the search tokens. We don't get
+    per-clause-match data from OS without explain mode, so we re-run
+    a substring check locally — cheap, deterministic, and good enough
+    for the debug surface.
+    """
+    src = hit.get("_source", {}) or {}
+    scene_id = str(src.get("scene_id", ""))
+    start_ms = int(src.get("start_ms", 0) or 0)
+    end_ms = int(src.get("end_ms", 0) or 0)
+    score = float(hit.get("_score", 0.0) or 0.0)
+
+    transcript = (src.get("transcript_raw") or "").strip()
+    caption = (src.get("scene_caption") or "").strip()
+
+    # Build the alias-set for substring re-check.
+    tokens = [t for t in [llm_label, *spoken_aliases] if t]
+    transcript_match = any(_contains_ci(transcript, t) for t in tokens)
+    caption_match = any(_contains_ci(caption, t) for t in tokens)
+
+    if transcript_match and caption_match:
+        matched_field: str = "both"
+    elif transcript_match:
+        matched_field = "transcript_raw"
+    elif caption_match:
+        matched_field = "scene_caption"
+    else:
+        # OS scored it >0 (probably via nori stemming on a partial
+        # token); we can't pin it to a specific field. Bias to
+        # caption since transcript false-stems are rarer in practice.
+        matched_field = "scene_caption"
+
+    matched_aliases = [t for t in tokens if _contains_ci(transcript + " " + caption, t)]
+
+    return MentionedScene(
+        scene_id=scene_id,
+        start_ms=start_ms,
+        end_ms=end_ms,
+        score=score,
+        matched_field=matched_field,  # type: ignore[arg-type]
+        matched_aliases=matched_aliases,
+        transcript_text=transcript,
+        caption_text=caption,
+    )
+
+
+def _contains_ci(haystack: str, needle: str) -> bool:
+    """Case-insensitive substring check. Korean is case-invariant
+    so ``casefold`` is a no-op there; matters for Latin aliases like
+    ``"Dalsim"`` / ``"dalsim"`` / ``"DALSIM"``.
+    """
+    return needle.casefold() in haystack.casefold()

--- a/services/api/app/modules/shorts_auto_product/track_stt/models.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/models.py
@@ -1,0 +1,129 @@
+"""Internal dataclasses for the STT pipeline.
+
+Plain frozen dataclasses (NOT pydantic) because these never cross a
+network boundary — they live entirely inside the api process. The
+contracts library still owns the worker→API and API→worker schemas;
+these are the in-process tube between modules.
+
+Naming convention mirrors the standalone product-auto-shorts repo
+(``MentionedScene``, ``MentionSegment``, ``ScoredChunk``) so anyone
+who has read that repo's pipeline can read ours without re-mapping.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+from uuid import UUID
+
+
+# ---------- mention_extractor output ----------
+
+
+@dataclass(frozen=True)
+class MentionedScene:
+    """One OS scene that BM25-matched the catalog entry's vocabulary.
+
+    ``score`` is the OS ``_score`` value, NOT normalized — different
+    queries can produce different score scales. Within a single
+    pipeline run the relative ordering is what matters.
+    """
+
+    scene_id: str
+    start_ms: int
+    end_ms: int
+    score: float
+
+    # Which field carried the matching tokens. ``"both"`` means the
+    # scene matched in transcript_raw AND scene_caption — strongest
+    # signal. Used by debug telemetry, not by the assembler.
+    matched_field: Literal["transcript_raw", "scene_caption", "both"]
+
+    # Aliases that hit on this scene. Empty list when only the
+    # ``llm_label`` itself matched. Surfaced to the wizard via
+    # ``?debug=1`` query param (PR 4).
+    matched_aliases: list[str] = field(default_factory=list)
+
+    # Carried through for the scorer. Empty string is allowed (means
+    # this scene matched via scene_caption but has no transcript).
+    transcript_text: str = ""
+    caption_text: str = ""
+
+
+# ---------- segment_assembler output ----------
+
+
+@dataclass(frozen=True)
+class MentionSegment:
+    """A run of consecutive mentioned scenes within ``MAX_GAP_SECONDS``
+    of each other. Equivalent to standalone ``ProductSegment`` but
+    without the ``product_id`` discriminator (we only handle one
+    product per pipeline call — the wizard pick).
+    """
+
+    start_ms: int
+    end_ms: int
+    scenes: list[MentionedScene]
+
+    @property
+    def duration_ms(self) -> int:
+        return self.end_ms - self.start_ms
+
+
+# ---------- chunk_scorer output ----------
+
+
+@dataclass(frozen=True)
+class ChunkScore:
+    """Per-chunk scoring output, mirrors standalone ``ChunkScore``
+    pydantic model field-for-field.
+
+    All three numbers in [0.0, 1.0]. The chunk scorer's LLM contract
+    enforces the bounds; the heuristic fallback also clamps.
+    """
+
+    hook_score: float
+    has_cta: bool
+    importance_score: float
+
+
+@dataclass(frozen=True)
+class ScoredChunk:
+    """One ~10-30s window inside a MentionSegment with its score."""
+
+    start_ms: int
+    end_ms: int
+    text: str
+    score: ChunkScore
+
+    @property
+    def composite(self) -> float:
+        """Single-number composite for ranking. CTA gets a small
+        boost; hook gets a small boost; importance is the bulk.
+        """
+        boost = 0.05 if self.score.has_cta else 0.0
+        return min(
+            1.0,
+            0.7 * self.score.importance_score
+            + 0.25 * self.score.hook_score
+            + boost,
+        )
+
+
+# ---------- service output ----------
+
+
+@dataclass(frozen=True)
+class SttClipResult:
+    """Public return shape of ``track_stt.service.assemble_stt_clip``.
+
+    The orchestrator persists ``render_job_id`` on the
+    ``ProductScanJob`` row and surfaces it through the wizard's
+    result page polling.
+    """
+
+    render_job_id: UUID
+    selected_chunks: list[ScoredChunk]
+    mentioned_scene_count: int
+    matched_aliases: list[str]
+    fallback_used: Literal["none", "coreference", "visual"] = "none"

--- a/services/api/app/modules/shorts_auto_product/track_stt/segment_assembler.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/segment_assembler.py
@@ -1,0 +1,114 @@
+"""Segment assembly — port of standalone product-auto-shorts'
+``segmentation.py::group_product_segments``.
+
+Takes ``MentionedScene[]`` (from ``mention_extractor``) and folds
+runs of consecutive scenes within ``MAX_GAP_MS`` of each other into
+``MentionSegment[]``. Drops segments shorter than ``MIN_SEGMENT_MS``
+because clips below that floor produce poor clip pacing.
+
+Pure function — no I/O, no async, no external deps. Trivially
+testable.
+
+Constants are kept in milliseconds (the rest of this codebase uses
+ms uniformly) but mirror the standalone repo's seconds:
+
+    standalone MAX_GAP_SECONDS = 5.0  → MAX_GAP_MS = 5_000
+    standalone MIN_SEGMENT_SECONDS = 20.0 → MIN_SEGMENT_MS = 20_000
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.modules.shorts_auto_product.track_stt.models import (
+    MentionedScene,
+    MentionSegment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Maximum allowed gap between consecutive mentioned scenes within
+# the same segment. Picked to absorb a single non-product scene
+# (typical Korean livecommerce scenes are 1-15s) without breaking
+# the segment, while preventing two distant clusters of mentions
+# from collapsing into one too-long segment.
+MAX_GAP_MS = 5_000
+
+# Minimum total segment duration. Below this floor the clip would
+# be too short to carry a hook + selling moment. Standalone repo
+# uses 20s; we keep that.
+MIN_SEGMENT_MS = 20_000
+
+
+def group_into_segments(
+    scenes: list[MentionedScene],
+) -> list[MentionSegment]:
+    """Group consecutive mentioned scenes into segments.
+
+    Args:
+        scenes: Mentioned scenes in any order. Sorted internally by
+            ``start_ms`` ascending so callers don't have to.
+
+    Returns:
+        ``MentionSegment[]`` ordered chronologically by ``start_ms``.
+        Empty when input is empty or when no run of scenes meets the
+        ``MIN_SEGMENT_MS`` floor.
+    """
+
+    if not scenes:
+        return []
+
+    chronological = sorted(scenes, key=lambda s: s.start_ms)
+
+    segments: list[MentionSegment] = []
+    current_scenes: list[MentionedScene] = [chronological[0]]
+    current_start = chronological[0].start_ms
+    current_end = chronological[0].end_ms
+
+    for scene in chronological[1:]:
+        gap = scene.start_ms - current_end
+        if gap <= MAX_GAP_MS:
+            # Extend current segment.
+            current_scenes.append(scene)
+            current_end = max(current_end, scene.end_ms)
+        else:
+            # Close current, open a new one.
+            _emit_if_long_enough(
+                segments, current_scenes, current_start, current_end,
+            )
+            current_scenes = [scene]
+            current_start = scene.start_ms
+            current_end = scene.end_ms
+
+    _emit_if_long_enough(
+        segments, current_scenes, current_start, current_end,
+    )
+
+    logger.info(
+        "stt_segment_assembly_completed",
+        extra={
+            "input_scene_count": len(scenes),
+            "output_segment_count": len(segments),
+            "kept_scene_count": sum(len(s.scenes) for s in segments),
+            "max_gap_ms": MAX_GAP_MS,
+            "min_segment_ms": MIN_SEGMENT_MS,
+        },
+    )
+    return segments
+
+
+def _emit_if_long_enough(
+    segments: list[MentionSegment],
+    scenes: list[MentionedScene],
+    start_ms: int,
+    end_ms: int,
+) -> None:
+    if (end_ms - start_ms) >= MIN_SEGMENT_MS:
+        segments.append(
+            MentionSegment(
+                start_ms=start_ms,
+                end_ms=end_ms,
+                scenes=list(scenes),
+            )
+        )

--- a/services/api/app/modules/shorts_auto_product/track_stt/service.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/service.py
@@ -1,0 +1,249 @@
+"""Public entrypoint for the STT track. One async call from
+catalog entry → render_job_id.
+
+Loose-coupling: this orchestrator takes:
+  - ``os_client`` (AsyncOpenSearch-shaped) injected by caller
+  - ``openai_client`` (AsyncOpenAI-shaped) injected by caller
+  - ``enqueue_render`` callable injected by caller
+
+so the module never imports from ``app.modules.shorts_render.*`` or
+``app.modules.search.*``. The orchestrator that wires this up
+(``shorts_auto_product/service.py::_handle_scan_order_parent`` once
+the track_mode flag is wired) does the cross-module imports — same
+pattern that ``children/runner.py`` already uses for the SAM2 path.
+
+Pipeline order (mirrors the package docstring):
+
+    1. mention_extractor.find_mentioned_scenes
+    2. segment_assembler.group_into_segments
+    3. chunk_scorer.score_segment_chunks (per segment, then merged)
+    4. clip_selector.select_top_chunks
+    5. composition_builder.build_composition_spec
+    6. enqueue_render(spec) → render_job_id
+
+Each step emits a ``worker_events`` log line via the existing
+``logging`` infra so a per-scan failure can be SQL-queried without
+ssh-ing into anything (mirrors PR F's pattern from the SAM2 v5 chain).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+from uuid import UUID
+
+from heimdex_media_contracts.composition.schemas import CompositionSpec
+
+from app.modules.shorts_auto_product.track_stt import (
+    chunk_scorer,
+    clip_selector,
+    composition_builder,
+    mention_extractor,
+    segment_assembler,
+)
+from app.modules.shorts_auto_product.track_stt.errors import (
+    NoMentionsFoundError,
+    SttPipelineError,
+    TranscriptUnavailableError,
+)
+from app.modules.shorts_auto_product.track_stt.models import (
+    ScoredChunk,
+    SttClipResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Type alias for the injected render-enqueue callable. Returns the
+# render_job_id. The orchestrator constructs this — typically by
+# lazy-importing ShortsRenderService and constructing a closure.
+RenderEnqueuer = Callable[[CompositionSpec], Awaitable[UUID]]
+
+
+async def assemble_stt_clip(
+    *,
+    org_id: UUID,
+    catalog_entry_id: UUID,
+    llm_label: str,
+    spoken_aliases: list[str],
+    os_video_id: str,
+    target_duration_ms: int,
+    title: str | None,
+    os_client: Any,
+    openai_client: Any,
+    enqueue_render: RenderEnqueuer,
+    index_alias: str = "heimdex_scenes",
+    chunker_model: str = "gpt-4o-mini",
+) -> SttClipResult:
+    """End-to-end STT pipeline. Returns the render_job_id wrapped in
+    :class:`SttClipResult`.
+
+    Args:
+        org_id: Tenant ID for the OS query filter.
+        catalog_entry_id: For telemetry. The catalog row itself was
+            already loaded by the caller.
+        llm_label: Catalog entry's primary search term.
+        spoken_aliases: Catalog entry's PR-1b-generated aliases.
+        os_video_id: Drive ``video_id`` string (``"gd_..."``).
+        target_duration_ms: e.g., 60_000 from the wizard.
+        title: Optional title for the saved short.
+        os_client: AsyncOpenSearch (real or mock).
+        openai_client: AsyncOpenAI (real or mock).
+        enqueue_render: Callable that accepts a ``CompositionSpec``
+            and returns the produced render_job_id. The orchestrator
+            wires this — usually via lazy import of
+            ``ShortsRenderService.create_render_job``.
+        index_alias: OpenSearch index alias. Default
+            ``"heimdex_scenes"`` (the production alias).
+        chunker_model: gpt-4o-mini model id. Override only for tests.
+
+    Raises:
+        :class:`NoMentionsFoundError`: BM25 found no qualifying
+            scenes, OR segment assembly produced nothing above the
+            ``MIN_SEGMENT_MS`` floor, OR clip selection couldn't
+            assemble a window above ``_MIN_DURATION_FRACTION``.
+        :class:`TranscriptUnavailableError`: BM25 hit some scenes
+            but every one of them had empty ``transcript_raw`` AND
+            empty ``scene_caption`` — there was nothing to score.
+        :class:`SttPipelineError`: Any other failure (OS unreachable,
+            etc.). Raised by sub-modules.
+    """
+
+    # ---- 1. Mention extraction ----
+    mentioned = await mention_extractor.find_mentioned_scenes(
+        os_client=os_client,
+        index_alias=index_alias,
+        org_id=org_id,
+        video_id=os_video_id,
+        llm_label=llm_label,
+        spoken_aliases=spoken_aliases,
+    )
+    if not mentioned:
+        logger.info(
+            "stt_pipeline_no_mentions",
+            extra={
+                "org_id": str(org_id),
+                "catalog_entry_id": str(catalog_entry_id),
+                "video_id": os_video_id,
+            },
+        )
+        raise NoMentionsFoundError(
+            f"no scenes match catalog entry {catalog_entry_id} "
+            f"on video {os_video_id}"
+        )
+
+    # Detect transcript_unavailable: all hits have empty transcript_raw
+    # AND empty scene_caption. This shouldn't normally happen given
+    # the BM25 boost ratios (we only match against those two fields),
+    # but is a safety belt for malformed OS docs.
+    has_any_text = any(
+        (m.transcript_text or m.caption_text) for m in mentioned
+    )
+    if not has_any_text:
+        raise TranscriptUnavailableError(
+            f"video {os_video_id} has no transcript or caption text "
+            f"on any matching scene"
+        )
+
+    # ---- 2. Segment assembly ----
+    segments = segment_assembler.group_into_segments(mentioned)
+    if not segments:
+        # Mentions existed but didn't cluster into a >=20s window.
+        # Indistinguishable to the user from "no mentions" — same
+        # error class.
+        logger.info(
+            "stt_pipeline_no_qualifying_segments",
+            extra={
+                "video_id": os_video_id,
+                "mention_count": len(mentioned),
+            },
+        )
+        raise NoMentionsFoundError(
+            f"mentions found but none clustered into a {segment_assembler.MIN_SEGMENT_MS}ms+ "
+            f"segment for catalog entry {catalog_entry_id}"
+        )
+
+    # ---- 3. Chunk scoring (across all segments) ----
+    all_chunks: list[ScoredChunk] = []
+    for segment in segments:
+        scored = await chunk_scorer.score_segment_chunks(
+            segment=segment,
+            openai_client=openai_client,
+            model=chunker_model,
+        )
+        all_chunks.extend(scored)
+
+    if not all_chunks:
+        # Should be impossible given non-empty segments → at least
+        # one chunk per segment. Defensive: surface as no-mentions.
+        raise NoMentionsFoundError(
+            f"chunk scoring produced 0 chunks despite {len(segments)} segments"
+        )
+
+    # ---- 4. Clip selection ----
+    selected = clip_selector.select_top_chunks(
+        chunks=all_chunks, target_duration_ms=target_duration_ms,
+    )
+    if not selected:
+        raise NoMentionsFoundError(
+            f"no contiguous chunk window meets the duration floor for "
+            f"catalog entry {catalog_entry_id} (target={target_duration_ms}ms)"
+        )
+
+    # ---- 5. Composition ----
+    spec = composition_builder.build_composition_spec(
+        selected_chunks=selected,
+        segments=segments,
+        os_video_id=os_video_id,
+        title=title,
+    )
+
+    # ---- 6. Render enqueue (caller-supplied) ----
+    try:
+        render_job_id = await enqueue_render(spec)
+    except Exception as e:
+        # Wrap as pipeline error so the orchestrator can map to
+        # ``error_code='render_enqueue_failed'``. Callers that want
+        # finer-grained handling can re-import ShortsRenderService's
+        # error types directly.
+        logger.exception(
+            "stt_pipeline_render_enqueue_failed",
+            extra={
+                "video_id": os_video_id,
+                "catalog_entry_id": str(catalog_entry_id),
+            },
+        )
+        raise SttPipelineError(f"render enqueue failed: {e}") from e
+
+    # Aggregate matched aliases for the result. Distinct via casefold.
+    seen: set[str] = set()
+    matched_aliases: list[str] = []
+    for scene in mentioned:
+        for alias in scene.matched_aliases:
+            key = alias.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            matched_aliases.append(alias)
+
+    logger.info(
+        "stt_pipeline_completed",
+        extra={
+            "org_id": str(org_id),
+            "catalog_entry_id": str(catalog_entry_id),
+            "video_id": os_video_id,
+            "mentioned_scene_count": len(mentioned),
+            "segment_count": len(segments),
+            "selected_chunk_count": len(selected),
+            "render_job_id": str(render_job_id),
+            "matched_alias_count": len(matched_aliases),
+        },
+    )
+
+    return SttClipResult(
+        render_job_id=render_job_id,
+        selected_chunks=selected,
+        mentioned_scene_count=len(mentioned),
+        matched_aliases=matched_aliases,
+        fallback_used="none",
+    )

--- a/services/api/tests/test_shorts_auto_product_track_stt_async.py
+++ b/services/api/tests/test_shorts_auto_product_track_stt_async.py
@@ -1,0 +1,479 @@
+"""Async tests for the track_stt pipeline with mocked clients.
+
+Covers the I/O-bound portions: BM25 OS query, gpt-4o-mini chunk
+scoring, and the end-to-end service orchestration.
+
+Strategy: every external dep (AsyncOpenSearch, AsyncOpenAI,
+render-enqueue callable) is a fake constructed in this file. No
+network. No DB. Tests run in <100ms total.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.modules.shorts_auto_product.track_stt import (
+    chunk_scorer,
+    mention_extractor,
+    service,
+)
+from app.modules.shorts_auto_product.track_stt.errors import (
+    MentionExtractionError,
+    NoMentionsFoundError,
+    SttPipelineError,
+    TranscriptUnavailableError,
+)
+from app.modules.shorts_auto_product.track_stt.models import (
+    ChunkScore,
+    MentionedScene,
+    MentionSegment,
+    ScoredChunk,
+)
+
+
+# ---------- fake OpenSearch ----------
+
+
+class _FakeOSClient:
+    def __init__(self, *, hits: list[dict[str, Any]] | None = None, raises: Exception | None = None):
+        self._hits = hits or []
+        self._raises = raises
+        self.calls: list[dict[str, Any]] = []
+
+    async def search(self, *, index: str, body: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append({"index": index, "body": body})
+        if self._raises is not None:
+            raise self._raises
+        return {"hits": {"total": {"value": len(self._hits)}, "hits": self._hits}}
+
+
+def _hit(scene_id: str, start_ms: int, end_ms: int, transcript: str = "", caption: str = "", score: float = 1.0):
+    return {
+        "_score": score,
+        "_source": {
+            "scene_id": scene_id,
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "transcript_raw": transcript,
+            "scene_caption": caption,
+        },
+    }
+
+
+# ---------- fake AsyncOpenAI ----------
+
+
+@dataclass
+class _Usage:
+    prompt_tokens: int = 700
+    completion_tokens: int = 50
+
+
+@dataclass
+class _Message:
+    content: str
+
+
+@dataclass
+class _Choice:
+    message: _Message
+
+
+@dataclass
+class _Response:
+    choices: list[_Choice]
+    usage: _Usage = field(default_factory=_Usage)
+
+
+class _FakeChatCompletions:
+    def __init__(self, *, raw_text: str | None = None, raises: Exception | None = None):
+        self._raw = raw_text
+        self._raises = raises
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> _Response:
+        self.calls.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+        text = self._raw if self._raw is not None else json.dumps({"scores": [{"hook_score": 0.7, "has_cta": False, "importance_score": 0.8}]})
+        return _Response(choices=[_Choice(message=_Message(content=text))])
+
+
+class _FakeOpenAI:
+    def __init__(self, *, raw_text: str | None = None, raises: Exception | None = None):
+        self.completions = _FakeChatCompletions(raw_text=raw_text, raises=raises)
+        self.chat = _ChatNs(self.completions)
+
+
+class _ChatNs:
+    def __init__(self, completions: _FakeChatCompletions):
+        self.completions = completions
+
+
+# ============================================================
+# mention_extractor.find_mentioned_scenes
+# ============================================================
+
+
+class TestMentionExtractor:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_hits(self):
+        os_client = _FakeOSClient(hits=[])
+        result = await mention_extractor.find_mentioned_scenes(
+            os_client=os_client,
+            index_alias="heimdex_scenes",
+            org_id=uuid4(),
+            video_id="gd_x",
+            llm_label="달심",
+            spoken_aliases=[],
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_scenes_with_correct_shape(self):
+        org = uuid4()
+        os_client = _FakeOSClient(
+            hits=[
+                _hit("gd_x_scene_001", 0, 5_000, transcript="달심 제품을 보여드리면", score=2.5),
+                _hit("gd_x_scene_002", 5_000, 10_000, transcript="이 주스는 정말 좋습니다", score=1.8),
+            ],
+        )
+        result = await mention_extractor.find_mentioned_scenes(
+            os_client=os_client,
+            index_alias="heimdex_scenes",
+            org_id=org,
+            video_id="gd_x",
+            llm_label="달심",
+            spoken_aliases=["이 주스"],
+        )
+        assert len(result) == 2
+        assert all(isinstance(s, MentionedScene) for s in result)
+        # Org filter present in must clauses (cross-org leakage guard).
+        body = os_client.calls[0]["body"]
+        assert {"term": {"org_id": str(org)}} in body["query"]["bool"]["must"]
+        assert {"term": {"video_id": "gd_x"}} in body["query"]["bool"]["must"]
+
+    @pytest.mark.asyncio
+    async def test_os_failure_wraps_as_extraction_error(self):
+        os_client = _FakeOSClient(raises=RuntimeError("connection refused"))
+        with pytest.raises(MentionExtractionError, match="OS search failed"):
+            await mention_extractor.find_mentioned_scenes(
+                os_client=os_client,
+                index_alias="heimdex_scenes",
+                org_id=uuid4(),
+                video_id="gd_x",
+                llm_label="달심",
+                spoken_aliases=[],
+            )
+
+
+# ============================================================
+# chunk_scorer.score_segment_chunks
+# ============================================================
+
+
+def _make_segment(*, num_scenes: int = 2, scene_duration_ms: int = 15_000, transcript_prefix: str = "speech") -> MentionSegment:
+    scenes = [
+        MentionedScene(
+            scene_id=f"scene_{i:03d}",
+            start_ms=i * scene_duration_ms,
+            end_ms=(i + 1) * scene_duration_ms,
+            score=1.0,
+            matched_field="transcript_raw",
+            matched_aliases=[],
+            transcript_text=f"{transcript_prefix} {i}",
+            caption_text="",
+        )
+        for i in range(num_scenes)
+    ]
+    return MentionSegment(
+        start_ms=0,
+        end_ms=num_scenes * scene_duration_ms,
+        scenes=scenes,
+    )
+
+
+class TestChunkScorer:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_one_score_per_chunk(self):
+        seg = _make_segment(num_scenes=2, scene_duration_ms=15_000)
+        # 30s segment, default chunk size 20s → 2 chunks (0-20, 20-30).
+        openai = _FakeOpenAI(
+            raw_text=json.dumps({
+                "scores": [
+                    {"hook_score": 0.7, "has_cta": False, "importance_score": 0.8},
+                    {"hook_score": 0.3, "has_cta": True, "importance_score": 0.5},
+                ]
+            })
+        )
+        result = await chunk_scorer.score_segment_chunks(
+            segment=seg, openai_client=openai,
+        )
+        assert len(result) == 2
+        assert result[0].score.hook_score == 0.7
+        assert result[1].score.has_cta is True
+
+    @pytest.mark.asyncio
+    async def test_empty_segment_returns_empty(self):
+        seg = MentionSegment(start_ms=0, end_ms=0, scenes=[])
+        openai = _FakeOpenAI()
+        result = await chunk_scorer.score_segment_chunks(
+            segment=seg, openai_client=openai,
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back_to_heuristic(self):
+        """A network failure must NOT surface as an exception. Each
+        chunk gets a 0.5/False/0.5 baseline so the pipeline still
+        produces output. This is the contract that lets the wizard
+        keep working when the LLM API is degraded.
+        """
+        seg = _make_segment(num_scenes=1, scene_duration_ms=25_000)
+        openai = _FakeOpenAI(raises=RuntimeError("openai down"))
+        result = await chunk_scorer.score_segment_chunks(
+            segment=seg, openai_client=openai,
+        )
+        assert len(result) >= 1
+        for chunk in result:
+            assert chunk.score.hook_score == 0.5
+            assert chunk.score.has_cta is False
+            assert chunk.score.importance_score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_count_mismatch_falls_back_to_heuristic(self):
+        """LLM returned wrong number of scores — fallback to heuristic
+        rather than fail. We send N chunks; expect N scores.
+        """
+        seg = _make_segment(num_scenes=2, scene_duration_ms=15_000)
+        # Send 1 score for 2 chunks.
+        openai = _FakeOpenAI(
+            raw_text=json.dumps({"scores": [{"hook_score": 0.9, "has_cta": True, "importance_score": 0.9}]})
+        )
+        result = await chunk_scorer.score_segment_chunks(
+            segment=seg, openai_client=openai,
+        )
+        assert len(result) == 2
+        # All heuristic now.
+        for chunk in result:
+            assert chunk.score.hook_score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_falls_back_to_heuristic(self):
+        seg = _make_segment(num_scenes=1, scene_duration_ms=25_000)
+        openai = _FakeOpenAI(raw_text="this is not json")
+        result = await chunk_scorer.score_segment_chunks(
+            segment=seg, openai_client=openai,
+        )
+        for chunk in result:
+            assert chunk.score.hook_score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_caption_used_when_transcript_empty(self):
+        """gd_bb9c22c2c00d180c-style: transcript_raw is "" but
+        scene_caption is populated. Chunk scorer must still get text
+        (from the caption) so the LLM has something to score.
+        """
+        scene = MentionedScene(
+            scene_id="x",
+            start_ms=0,
+            end_ms=25_000,
+            score=1.0,
+            matched_field="scene_caption",
+            matched_aliases=[],
+            transcript_text="",  # empty — caption-only video
+            caption_text="호스트가 샴푸를 소개하고 있다",
+        )
+        seg = MentionSegment(start_ms=0, end_ms=25_000, scenes=[scene])
+        openai = _FakeOpenAI(
+            raw_text=json.dumps({"scores": [{"hook_score": 0.5, "has_cta": False, "importance_score": 0.6}]})
+        )
+        result = await chunk_scorer.score_segment_chunks(
+            segment=seg, openai_client=openai,
+        )
+        # 25s scene at default 20s chunk size → 2 chunks (the second
+        # is a 5s tail). What matters for this test is that the
+        # caption text propagated to every chunk's ``text`` field.
+        assert len(result) >= 1
+        for chunk in result:
+            assert "샴푸" in chunk.text
+
+
+# ============================================================
+# service.assemble_stt_clip end-to-end
+# ============================================================
+
+
+class TestServiceEndToEnd:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_render_job_id(self):
+        # 3 mentioned scenes spanning 30s → 1 segment → at least 1
+        # chunk → 1 selected chunk → 1 composition → 1 render id.
+        os_client = _FakeOSClient(
+            hits=[
+                _hit("scene_001", 0, 10_000, transcript="달심 ABC 주스", score=3.0),
+                _hit("scene_002", 10_000, 20_000, transcript="이 주스는 정말 좋습니다", score=2.0),
+                _hit("scene_003", 20_000, 30_000, transcript="달심 함께 해주세요", score=2.5),
+            ],
+        )
+        openai = _FakeOpenAI(
+            raw_text=json.dumps({"scores": [{"hook_score": 0.7, "has_cta": False, "importance_score": 0.9}, {"hook_score": 0.5, "has_cta": True, "importance_score": 0.7}]})
+        )
+
+        captured_specs: list[Any] = []
+        expected_render_id = uuid4()
+
+        async def _enqueue(spec):
+            captured_specs.append(spec)
+            return expected_render_id
+
+        result = await service.assemble_stt_clip(
+            org_id=uuid4(),
+            catalog_entry_id=uuid4(),
+            llm_label="달심",
+            spoken_aliases=["이 주스"],
+            os_video_id="gd_x",
+            target_duration_ms=30_000,
+            title="test",
+            os_client=os_client,
+            openai_client=openai,
+            enqueue_render=_enqueue,
+        )
+        assert result.render_job_id == expected_render_id
+        assert result.mentioned_scene_count == 3
+        assert len(captured_specs) == 1
+        assert captured_specs[0].title == "test"
+        assert captured_specs[0].clip_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_mentions_raises_no_mentions_found(self):
+        os_client = _FakeOSClient(hits=[])
+        openai = _FakeOpenAI()
+        async def _enqueue(spec): return uuid4()  # noqa: E306
+
+        with pytest.raises(NoMentionsFoundError):
+            await service.assemble_stt_clip(
+                org_id=uuid4(),
+                catalog_entry_id=uuid4(),
+                llm_label="달심",
+                spoken_aliases=[],
+                os_video_id="gd_x",
+                target_duration_ms=30_000,
+                title=None,
+                os_client=os_client,
+                openai_client=openai,
+                enqueue_render=_enqueue,
+            )
+
+    @pytest.mark.asyncio
+    async def test_mentions_but_no_text_raises_transcript_unavailable(self):
+        # OS hit, but every scene has empty transcript AND empty caption.
+        # This is a pathological state for malformed OS docs.
+        os_client = _FakeOSClient(
+            hits=[_hit("scene_001", 0, 25_000, transcript="", caption="")],
+        )
+        openai = _FakeOpenAI()
+        async def _enqueue(spec): return uuid4()  # noqa: E306
+
+        with pytest.raises(TranscriptUnavailableError):
+            await service.assemble_stt_clip(
+                org_id=uuid4(),
+                catalog_entry_id=uuid4(),
+                llm_label="달심",
+                spoken_aliases=[],
+                os_video_id="gd_x",
+                target_duration_ms=30_000,
+                title=None,
+                os_client=os_client,
+                openai_client=openai,
+                enqueue_render=_enqueue,
+            )
+
+    @pytest.mark.asyncio
+    async def test_too_short_for_segment_raises_no_mentions(self):
+        # Only 5s of mentions (below MIN_SEGMENT_MS=20s).
+        os_client = _FakeOSClient(
+            hits=[_hit("scene_001", 0, 5_000, transcript="달심", score=1.0)],
+        )
+        openai = _FakeOpenAI()
+        async def _enqueue(spec): return uuid4()  # noqa: E306
+
+        with pytest.raises(NoMentionsFoundError, match="segment"):
+            await service.assemble_stt_clip(
+                org_id=uuid4(),
+                catalog_entry_id=uuid4(),
+                llm_label="달심",
+                spoken_aliases=[],
+                os_video_id="gd_x",
+                target_duration_ms=30_000,
+                title=None,
+                os_client=os_client,
+                openai_client=openai,
+                enqueue_render=_enqueue,
+            )
+
+    @pytest.mark.asyncio
+    async def test_render_enqueue_failure_wraps_as_pipeline_error(self):
+        os_client = _FakeOSClient(
+            hits=[
+                _hit("scene_001", 0, 15_000, transcript="달심 ABC 주스"),
+                _hit("scene_002", 15_000, 30_000, transcript="달심"),
+            ],
+        )
+        openai = _FakeOpenAI()
+        async def _enqueue(spec):  # noqa: E306
+            raise RuntimeError("render service down")
+
+        with pytest.raises(SttPipelineError, match="render enqueue failed"):
+            await service.assemble_stt_clip(
+                org_id=uuid4(),
+                catalog_entry_id=uuid4(),
+                llm_label="달심",
+                spoken_aliases=[],
+                os_video_id="gd_x",
+                target_duration_ms=30_000,
+                title=None,
+                os_client=os_client,
+                openai_client=openai,
+                enqueue_render=_enqueue,
+            )
+
+    @pytest.mark.asyncio
+    async def test_caption_only_video_still_produces_clip(self):
+        """gd_bb9c22c2c00d180c-style: every scene has empty
+        transcript_raw but populated scene_caption. Pipeline must
+        still produce a valid clip from caption-only signal.
+        """
+        os_client = _FakeOSClient(
+            hits=[
+                _hit("scene_001", 0, 15_000, transcript="", caption="호스트가 샴푸를 소개하고 있다"),
+                _hit("scene_002", 15_000, 30_000, transcript="", caption="호스트가 샴푸 사용법을 설명한다"),
+            ],
+        )
+        openai = _FakeOpenAI()
+        captured: list[UUID] = []
+
+        async def _enqueue(spec):
+            rid = uuid4()
+            captured.append(rid)
+            return rid
+
+        result = await service.assemble_stt_clip(
+            org_id=uuid4(),
+            catalog_entry_id=uuid4(),
+            llm_label="샴푸",
+            spoken_aliases=[],
+            os_video_id="gd_bb9c",
+            target_duration_ms=30_000,
+            title=None,
+            os_client=os_client,
+            openai_client=openai,
+            enqueue_render=_enqueue,
+        )
+        assert result.render_job_id == captured[0]
+        assert result.fallback_used == "none"

--- a/services/api/tests/test_shorts_auto_product_track_stt_pure.py
+++ b/services/api/tests/test_shorts_auto_product_track_stt_pure.py
@@ -1,0 +1,367 @@
+"""Pure-function tests for the track_stt pipeline.
+
+Covers segment_assembler, clip_selector, composition_builder, and
+the BM25 query-construction half of mention_extractor. The async
+parts (mention_extractor.find_mentioned_scenes, chunk_scorer's LLM
+call, service end-to-end) are exercised in
+``test_shorts_auto_product_track_stt_async.py`` with mocked clients.
+
+Loose-coupling assertion: this file imports ONLY from
+``app.modules.shorts_auto_product.track_stt.*`` and stdlib. If a
+future change introduces a forbidden cross-module import, the test
+collection will fail at import time.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.modules.shorts_auto_product.track_stt.clip_selector import (
+    MAX_TARGET_OVERSHOOT_MS,
+    select_top_chunks,
+)
+from app.modules.shorts_auto_product.track_stt.composition_builder import (
+    build_composition_spec,
+)
+from app.modules.shorts_auto_product.track_stt.mention_extractor import (
+    _build_bm25_query,
+    _hit_to_scene,
+)
+from app.modules.shorts_auto_product.track_stt.models import (
+    ChunkScore,
+    MentionedScene,
+    MentionSegment,
+    ScoredChunk,
+)
+from app.modules.shorts_auto_product.track_stt.segment_assembler import (
+    MAX_GAP_MS,
+    MIN_SEGMENT_MS,
+    group_into_segments,
+)
+
+
+# ---------- helpers ----------
+
+
+def _scene(start_ms: int, end_ms: int, sid: str = "x") -> MentionedScene:
+    return MentionedScene(
+        scene_id=sid,
+        start_ms=start_ms,
+        end_ms=end_ms,
+        score=1.0,
+        matched_field="transcript_raw",
+        matched_aliases=[],
+        transcript_text=f"transcript at {start_ms}",
+        caption_text="",
+    )
+
+
+def _chunk(start_ms: int, end_ms: int, hook=0.5, has_cta=False, importance=0.5) -> ScoredChunk:
+    return ScoredChunk(
+        start_ms=start_ms,
+        end_ms=end_ms,
+        text=f"text at {start_ms}",
+        score=ChunkScore(hook_score=hook, has_cta=has_cta, importance_score=importance),
+    )
+
+
+# ---------- segment_assembler ----------
+
+
+class TestSegmentAssembler:
+    def test_empty_input_returns_empty(self):
+        assert group_into_segments([]) == []
+
+    def test_single_short_scene_below_floor_dropped(self):
+        # 5s < 20s floor — must drop.
+        result = group_into_segments([_scene(0, 5_000)])
+        assert result == []
+
+    def test_single_long_scene_above_floor_kept(self):
+        # 25s > 20s floor.
+        result = group_into_segments([_scene(0, 25_000)])
+        assert len(result) == 1
+        assert result[0].duration_ms == 25_000
+
+    def test_consecutive_within_gap_merge_into_one_segment(self):
+        # Gap of 3s between scenes (< 5s MAX_GAP_MS) → merge.
+        # 4s + 3s gap + 18s = 25s span → above floor.
+        scenes = [_scene(0, 4_000), _scene(7_000, 25_000)]
+        result = group_into_segments(scenes)
+        assert len(result) == 1
+        assert result[0].start_ms == 0
+        assert result[0].end_ms == 25_000
+
+    def test_gap_exceeds_max_splits_into_two_segments(self):
+        # 6s gap > 5s MAX_GAP_MS → split. Each segment must individually
+        # exceed MIN_SEGMENT_MS to be kept.
+        scenes = [_scene(0, 22_000), _scene(28_000, 50_000)]
+        result = group_into_segments(scenes)
+        assert len(result) == 2
+        assert result[0].end_ms == 22_000
+        assert result[1].start_ms == 28_000
+
+    def test_gap_exceeds_max_one_too_short_dropped(self):
+        # First segment 4s (below floor), second 22s (kept).
+        scenes = [_scene(0, 4_000), _scene(15_000, 37_000)]
+        result = group_into_segments(scenes)
+        assert len(result) == 1
+        assert result[0].start_ms == 15_000
+
+    def test_unsorted_input_sorted_internally(self):
+        # Caller hands us scenes out of order — assembler still works.
+        scenes = [_scene(20_000, 25_000), _scene(0, 18_000)]
+        result = group_into_segments(scenes)
+        assert len(result) == 1  # 0..25000, gap=2000 → merge
+        assert result[0].start_ms == 0
+        assert result[0].end_ms == 25_000
+
+    def test_overlapping_scenes_collapse_correctly(self):
+        # Scene B starts before A ends (overlap). Should merge cleanly.
+        scenes = [_scene(0, 15_000), _scene(10_000, 25_000)]
+        result = group_into_segments(scenes)
+        assert len(result) == 1
+        assert result[0].end_ms == 25_000  # max of both
+
+
+# ---------- clip_selector ----------
+
+
+class TestClipSelector:
+    def test_empty_input_returns_empty(self):
+        assert select_top_chunks(chunks=[], target_duration_ms=60_000) == []
+
+    def test_zero_target_duration_returns_empty(self):
+        chunks = [_chunk(0, 30_000)]
+        assert select_top_chunks(chunks=chunks, target_duration_ms=0) == []
+
+    def test_single_chunk_meets_target(self):
+        chunks = [_chunk(0, 60_000, importance=0.9)]
+        result = select_top_chunks(chunks=chunks, target_duration_ms=60_000)
+        assert len(result) == 1
+        assert result[0].start_ms == 0
+
+    def test_picks_highest_score_seed(self):
+        # Lower-importance chunk first, higher-importance second.
+        # Selector should pick the higher-importance seed and walk
+        # forward from there.
+        chunks = [
+            _chunk(0, 20_000, importance=0.3),
+            _chunk(20_000, 40_000, importance=0.9),
+            _chunk(40_000, 60_000, importance=0.4),
+        ]
+        result = select_top_chunks(chunks=chunks, target_duration_ms=40_000)
+        # Chunk at 20-40 is the seed (importance 0.9), then forward
+        # picks 40-60 to fill the duration.
+        starts = [c.start_ms for c in result]
+        assert 20_000 in starts
+
+    def test_short_total_below_floor_returns_empty(self):
+        # 15s total but target is 60s → below 50% floor (30s).
+        chunks = [_chunk(0, 15_000)]
+        result = select_top_chunks(chunks=chunks, target_duration_ms=60_000)
+        assert result == []
+
+    def test_overshoot_capped(self):
+        # 10 chunks of 20s each = 200s; target 60s. With cap of
+        # 60+20=80, selector should not return >80s of clips.
+        chunks = [_chunk(i * 20_000, (i + 1) * 20_000, importance=0.5) for i in range(10)]
+        result = select_top_chunks(chunks=chunks, target_duration_ms=60_000)
+        assert sum(c.end_ms - c.start_ms for c in result) <= 60_000 + MAX_TARGET_OVERSHOOT_MS
+
+    def test_chronological_order_preserved(self):
+        chunks = [_chunk(0, 20_000), _chunk(20_000, 40_000), _chunk(40_000, 60_000)]
+        result = select_top_chunks(chunks=chunks, target_duration_ms=60_000)
+        starts = [c.start_ms for c in result]
+        assert starts == sorted(starts)
+
+    def test_cta_boost_breaks_ties(self):
+        # Two chunks with equal importance; only one has_cta.
+        # The CTA chunk should win as the seed.
+        a = _chunk(0, 20_000, hook=0.5, has_cta=False, importance=0.5)
+        b = _chunk(20_000, 40_000, hook=0.5, has_cta=True, importance=0.5)
+        result = select_top_chunks(chunks=[a, b], target_duration_ms=20_000)
+        assert len(result) == 1
+        assert result[0].start_ms == 20_000
+
+
+# ---------- composition_builder ----------
+
+
+class TestCompositionBuilder:
+    def test_empty_chunks_raises(self):
+        with pytest.raises(ValueError, match="at least one selected chunk"):
+            build_composition_spec(
+                selected_chunks=[],
+                segments=[],
+                os_video_id="gd_x",
+            )
+
+    def test_single_chunk_one_clip(self):
+        scene = _scene(0, 30_000, sid="gd_x_scene_001")
+        seg = MentionSegment(start_ms=0, end_ms=30_000, scenes=[scene])
+        spec = build_composition_spec(
+            selected_chunks=[_chunk(0, 30_000)],
+            segments=[seg],
+            os_video_id="gd_x",
+            title="my clip",
+        )
+        assert len(spec.scene_clips) == 1
+        assert spec.scene_clips[0].video_id == "gd_x"
+        assert spec.scene_clips[0].scene_id == "gd_x_scene_001"
+        assert spec.scene_clips[0].start_ms == 0
+        assert spec.scene_clips[0].end_ms == 30_000
+        assert spec.scene_clips[0].timeline_start_ms == 0
+        assert spec.title == "my clip"
+
+    def test_multi_chunk_timeline_cursor_advances(self):
+        scene_a = _scene(0, 20_000, sid="gd_x_scene_001")
+        scene_b = _scene(20_000, 40_000, sid="gd_x_scene_002")
+        seg = MentionSegment(start_ms=0, end_ms=40_000, scenes=[scene_a, scene_b])
+        spec = build_composition_spec(
+            selected_chunks=[_chunk(0, 20_000), _chunk(20_000, 40_000)],
+            segments=[seg],
+            os_video_id="gd_x",
+        )
+        assert len(spec.scene_clips) == 2
+        # Timeline accumulates: clip 1 ends at 20s, clip 2 starts there.
+        assert spec.scene_clips[0].timeline_start_ms == 0
+        assert spec.scene_clips[1].timeline_start_ms == 20_000
+
+    def test_chunk_attributed_to_max_overlap_scene(self):
+        # Chunk 5-25s; scene_a (0-15) overlaps 10s, scene_b (15-30)
+        # overlaps 10s — tie. The first match wins per implementation.
+        # We test the more discriminating case: chunk 5-25, scene_a 0-10
+        # (5s overlap), scene_b 10-30 (15s overlap) → scene_b wins.
+        scene_a = _scene(0, 10_000, sid="A")
+        scene_b = _scene(10_000, 30_000, sid="B")
+        seg = MentionSegment(start_ms=0, end_ms=30_000, scenes=[scene_a, scene_b])
+        spec = build_composition_spec(
+            selected_chunks=[_chunk(5_000, 25_000)],
+            segments=[seg],
+            os_video_id="gd_x",
+        )
+        assert spec.scene_clips[0].scene_id == "B"
+
+
+# ---------- mention_extractor query construction ----------
+
+
+class TestMentionExtractorQuery:
+    def test_label_only_no_aliases(self):
+        org = uuid4()
+        q = _build_bm25_query(
+            org_id=org,
+            video_id="gd_x",
+            llm_label="달심",
+            spoken_aliases=[],
+        )
+        # 1 must clause for org_id, 1 must for video_id → in must.
+        assert {"term": {"org_id": str(org)}} in q["bool"]["must"]
+        assert {"term": {"video_id": "gd_x"}} in q["bool"]["must"]
+        # 2 should clauses (transcript + caption) for the label.
+        assert len(q["bool"]["should"]) == 2
+
+    def test_label_plus_aliases_produces_field_x_alias_clauses(self):
+        q = _build_bm25_query(
+            org_id=uuid4(),
+            video_id="gd_x",
+            llm_label="달심 ABC 주스",
+            spoken_aliases=["달심", "이 주스", "abc주스"],
+        )
+        # 4 unique terms (label + 3 aliases minus the duplicate
+        # "달심"-prefix which IS "달심"... actually "달심 ABC 주스" and
+        # "달심" are different strings, both included).
+        # Each term × 2 fields = 8 should clauses; one alias dedupes
+        # against another via casefold but the aliases here are all
+        # distinct.
+        n_should = len(q["bool"]["should"])
+        # 4 terms × 2 fields = 8.
+        assert n_should == 8
+
+    def test_dedupe_alias_equal_to_label(self):
+        # If an alias is identical to the label, the dedup set drops
+        # the alias clauses.
+        q = _build_bm25_query(
+            org_id=uuid4(),
+            video_id="gd_x",
+            llm_label="달심",
+            spoken_aliases=["달심", "DALSIM", "이 주스"],
+        )
+        # Expected: 1 label + 2 distinct aliases = 3 terms × 2 fields
+        # = 6 should clauses. ("달심"/"달심" dedupes; "DALSIM" lowercase
+        # is its own; "이 주스" is its own.)
+        # Actual: label + "DALSIM" + "이 주스" → 6.
+        assert len(q["bool"]["should"]) == 6
+
+    def test_empty_label_and_empty_aliases_produces_no_should_clauses(self):
+        # Defensive: should never happen in practice but must not
+        # crash. With minimum_should_match=0 the query becomes a
+        # plain "all from this org+video" — broad but not invalid.
+        q = _build_bm25_query(
+            org_id=uuid4(),
+            video_id="gd_x",
+            llm_label="",
+            spoken_aliases=[],
+        )
+        assert q["bool"]["should"] == []
+        assert q["bool"]["minimum_should_match"] == 0
+
+
+# ---------- mention_extractor _hit_to_scene ----------
+
+
+class TestHitToScene:
+    def _hit(self, *, transcript: str = "", caption: str = "", sid: str = "x", score: float = 1.0):
+        return {
+            "_score": score,
+            "_source": {
+                "scene_id": sid,
+                "start_ms": 0,
+                "end_ms": 1_000,
+                "transcript_raw": transcript,
+                "scene_caption": caption,
+            },
+        }
+
+    def test_match_in_transcript_only(self):
+        hit = self._hit(transcript="달심에 대해 말씀드리면", caption="")
+        scene = _hit_to_scene(hit, "달심", [])
+        assert scene.matched_field == "transcript_raw"
+        assert "달심" in scene.matched_aliases
+
+    def test_match_in_caption_only(self):
+        hit = self._hit(transcript="", caption="호스트가 달심 제품을 들고 있다")
+        scene = _hit_to_scene(hit, "달심", [])
+        assert scene.matched_field == "scene_caption"
+
+    def test_match_in_both_fields_returns_both(self):
+        hit = self._hit(transcript="달심에 대해", caption="달심 제품")
+        scene = _hit_to_scene(hit, "달심", [])
+        assert scene.matched_field == "both"
+
+    def test_case_insensitive_alias_match(self):
+        hit = self._hit(transcript="DALSIM is a brand", caption="")
+        scene = _hit_to_scene(hit, "달심", ["Dalsim"])
+        assert scene.matched_field == "transcript_raw"
+        # Original-cased alias preserved in matched_aliases.
+        assert "Dalsim" in scene.matched_aliases
+
+    def test_no_substring_match_falls_back_to_caption(self):
+        # OS scored >0 via nori stemming on a partial token, but our
+        # local substring check finds nothing. Fall back to caption.
+        hit = self._hit(transcript="completely unrelated text", caption="")
+        scene = _hit_to_scene(hit, "달심", [])
+        assert scene.matched_field == "scene_caption"
+        assert scene.matched_aliases == []
+
+    def test_carries_through_text_to_scene(self):
+        hit = self._hit(
+            transcript="this is the transcript",
+            caption="this is the caption",
+        )
+        scene = _hit_to_scene(hit, "transcript", [])
+        assert scene.transcript_text == "this is the transcript"
+        assert scene.caption_text == "this is the caption"


### PR DESCRIPTION
## Summary

PR 2 of the auto-shorts product mode v2 STT-pivot. Pure addition — no behavior change. The new `auto_shorts_product_v2_track_mode` config flag defaults to `"sam2"`, preserving production behavior.

The pipeline (`track_stt/service.assemble_stt_clip`):

```
1. mention_extractor.find_mentioned_scenes  — BM25 over OS, transcript_raw + scene_caption
2. segment_assembler.group_into_segments    — 5s gap merge, 20s minimum
3. chunk_scorer.score_segment_chunks         — gpt-4o-mini hook/CTA/importance, heuristic fallback
4. clip_selector.select_top_chunks           — score-seeded forward+backward expansion
5. composition_builder.build_composition_spec — ScoredChunk[] → CompositionSpec
6. caller-supplied enqueue_render(spec)      — render_job_id
```

## Loose-coupling audit

`track_stt` imports only:
- `heimdex_media_contracts.composition` + `heimdex_media_contracts.product` (external lib, OK)
- `app.modules.shorts_auto_product.*` (own module, OK)
- `pydantic`, `opensearchpy`, `openai` (external libs, OK)

Does NOT import from `app.modules.search.*`, `app.modules.shorts.*`, `app.modules.shorts_render.*`, `app.modules.shorts_auto.*`, or `heimdex_media_pipelines.*`.

Render-service invocation is pushed to the caller via the `enqueue_render: Callable[[CompositionSpec], Awaitable[UUID]]` dep parameter. The orchestrator (PR 2.5) wires the closure.

## Why PR 2 was split

Original plan put runner wiring in PR 2. `children/runner.py` has 14 methods + intricate lease handling — wiring track_stt through it has higher review surface than the pipeline itself. Splitting:
- **PR 2 (this)**: pipeline + tests + config flag, additive only
- **PR 2.5 (next)**: runner wiring with closure construction, behavior change behind flag

Default flag = `"sam2"` means no production behavior change after this PR lands.

## Test plan

- [x] 30 pure-function tests (segment assembler, clip selector, composition builder, BM25 query construction, hit→scene mapping)
- [x] 15 async tests with fake OS + fake AsyncOpenAI + fake render-enqueue (mention extractor, chunk scorer w/ fallback paths, end-to-end service)
- [x] 484/484 pass on the full CI allowlist (existing 439 + 45 new)
- [x] Module imports clean, no cross-module imports introduced
- [x] CI allowlist updated to run the new tests

## Plan reference

`.claude/plans/shorts-auto-product-stt-pivot.md` — see "PR 2 (track_stt pipeline) shipped locally; runner-wiring split off as PR 2.5" for full details + the 6 plan corrections noted during implementation.

## Sequel

PR 2.5 will:
1. Branch `children/runner.py` on `track_mode='stt'`
2. Construct the `enqueue_render` closure (lazy `from app.modules.shorts_render.service import ShortsRenderService` matching the existing pattern)
3. Add integration tests for the runner branching
4. Default flag stays `"sam2"` until staging validation passes