### PR TITLE
feat(shorts-auto-product): wire track_stt into child runner (PR 2.5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
             tests/test_shorts_auto_product_alias_generator.py \
             tests/test_shorts_auto_product_track_stt_pure.py \
             tests/test_shorts_auto_product_track_stt_async.py \
+            tests/test_shorts_auto_product_stt_runner_branch.py \
             --tb=short
 
           # NOTE: shorts_auto tests are deliberately NOT in the CI

--- a/services/api/app/modules/shorts_auto_product/children/runner.py
+++ b/services/api/app/modules/shorts_auto_product/children/runner.py
@@ -421,6 +421,24 @@ class ChildRunner:
         chosen_catalog_id = catalog_pick.catalog_entry_id
         catalog_label = catalog_label_lookup.get(chosen_catalog_id)
 
+        # ── 3.5. Track-mode branch ────────────────────────────────
+        # When ``auto_shorts_product_v2_track_mode='stt'`` the rest of
+        # this method is replaced by the in-process STT pipeline
+        # (``track_stt.service.assemble_stt_clip``). Default ``"sam2"``
+        # preserves the existing path. See
+        # ``.claude/plans/shorts-auto-product-stt-pivot.md`` PR 2.5.
+        if (
+            getattr(self.settings, "auto_shorts_product_v2_track_mode", "sam2")
+            == "stt"
+        ):
+            await self._process_child_stt(
+                child=child,
+                parent=parent,
+                chosen_catalog_id=chosen_catalog_id,
+                catalog_label=catalog_label,
+            )
+            return
+
         # ── 4. Score + select windows for the chosen catalog ──────
         appearances = await self._load_appearances_for_catalog(
             org_id=parent.org_id, catalog_entry_id=chosen_catalog_id,
@@ -519,6 +537,260 @@ class ChildRunner:
                 "shorts_index": child.shorts_index,
                 "windows": len(plan.windows),
             },
+        )
+
+    # ── STT track (PR 2.5) ───────────────────────────────────────────
+
+    async def _process_child_stt(
+        self,
+        *,
+        child: ProductScanJob,
+        parent: ProductScanJob,
+        chosen_catalog_id: UUID,
+        catalog_label: str | None,
+    ) -> None:
+        """STT-track replacement for steps 4-6 of ``_process_child_payload``.
+
+        Branched into when ``auto_shorts_product_v2_track_mode='stt'``.
+        Loads the full catalog entry (we already have its label, but
+        not ``llm_label`` + ``spoken_aliases``), resolves the
+        ``os_video_id`` from ``drive_files``, constructs an
+        AsyncOpenSearch + AsyncOpenAI per-call (simpler v1; revisit
+        if profiling flags this — see plan §"Open question for PR 2.5"),
+        and runs the STT pipeline.
+
+        Error mapping:
+
+        * :class:`NoMentionsFoundError` and
+          :class:`TranscriptUnavailableError` → ``_complete_no_render``
+          (terminal stage=done with ``render_job_id=None``). The wizard
+          UI already surfaces "no render produced" friendly-error-style
+          for the SAM2 ``no_appearances_for_catalog`` path; STT reuses
+          that same DB shape so the frontend doesn't need a new branch.
+        * :class:`SttPipelineError` (base / OS unreachable / render
+          enqueue failed) → ``_mark_child_failed`` with descriptive
+          message. Distinct from no-render because the user CAN retry.
+
+        Imports the STT module lazily so the SAM2 path doesn't pay
+        the import cost when track_mode='sam2'.
+        """
+        from openai import AsyncOpenAI
+
+        from app.modules.shorts_auto_product.track_stt import service as stt_service
+        from app.modules.shorts_auto_product.track_stt.errors import (
+            NoMentionsFoundError,
+            SttPipelineError,
+            TranscriptUnavailableError,
+        )
+
+        # ── 1. Load full catalog entry + os_video_id resolution ────
+        os_video_id, llm_label, spoken_aliases = await self._load_stt_inputs(
+            org_id=parent.org_id,
+            catalog_entry_id=chosen_catalog_id,
+            drive_file_id=parent.video_id,
+        )
+        if os_video_id is None or llm_label is None:
+            # Catalog entry vanished between picker and load (rare),
+            # or the drive_files row is missing. Either way, no
+            # render to produce.
+            await self._complete_no_render(
+                child_id=child.id,
+                reason="stt_inputs_missing",
+            )
+            return
+
+        length_seconds = (
+            parent.length_seconds
+            or parent.duration_preset_sec
+            or 60
+        )
+        target_duration_ms = int(length_seconds) * 1000
+
+        # ── 2. Construct per-call clients ──────────────────────────
+        os_client = self._build_os_client()
+        openai_client = AsyncOpenAI(
+            api_key=getattr(self.settings, "openai_api_key", "") or "",
+            timeout=15.0,
+        )
+
+        # ── 3. Build the enqueue_render closure ────────────────────
+        # Captures parent + os_video_id by closure so track_stt itself
+        # never sees DB-row internals. Mirrors the existing
+        # ``_create_render_job`` call in the SAM2 path.
+        async def _enqueue_render(spec) -> UUID:
+            return await self._create_render_job(
+                org_id=parent.org_id,
+                user_id=parent.requested_by_user_id,
+                os_video_id=os_video_id,  # type: ignore[arg-type]
+                title=catalog_label,
+                composition_spec=spec,
+            )
+
+        # ── 4. Run the pipeline ────────────────────────────────────
+        try:
+            try:
+                result = await stt_service.assemble_stt_clip(
+                    org_id=parent.org_id,
+                    catalog_entry_id=chosen_catalog_id,
+                    llm_label=llm_label,
+                    spoken_aliases=list(spoken_aliases or []),
+                    os_video_id=os_video_id,
+                    target_duration_ms=target_duration_ms,
+                    title=catalog_label,
+                    os_client=os_client,
+                    openai_client=openai_client,
+                    enqueue_render=_enqueue_render,
+                )
+            except NoMentionsFoundError as e:
+                logger.info(
+                    "stt_runner_no_mentions",
+                    extra={
+                        "child_id": str(child.id),
+                        "catalog_entry_id": str(chosen_catalog_id),
+                        "video_id": os_video_id,
+                        "reason": str(e)[:200],
+                    },
+                )
+                await self._complete_no_render(
+                    child_id=child.id,
+                    reason="stt_no_mentions",
+                )
+                return
+            except TranscriptUnavailableError as e:
+                logger.info(
+                    "stt_runner_transcript_unavailable",
+                    extra={
+                        "child_id": str(child.id),
+                        "video_id": os_video_id,
+                        "reason": str(e)[:200],
+                    },
+                )
+                await self._complete_no_render(
+                    child_id=child.id,
+                    reason="stt_transcript_unavailable",
+                )
+                return
+            except SttPipelineError as e:
+                logger.warning(
+                    "stt_runner_pipeline_error",
+                    extra={
+                        "child_id": str(child.id),
+                        "video_id": os_video_id,
+                        "error": str(e)[:300],
+                    },
+                )
+                await self._mark_child_failed(
+                    child_id=child.id,
+                    error_message=f"stt pipeline failed: {e}"[:1900],
+                )
+                return
+        finally:
+            # AsyncOpenSearch / AsyncOpenAI both expose ``.close``;
+            # swallow exceptions so a teardown error doesn't mask a
+            # successful run.
+            for client in (os_client, openai_client):
+                close = getattr(client, "close", None)
+                if close is None:
+                    continue
+                try:
+                    maybe_awaitable = close()
+                    if hasattr(maybe_awaitable, "__await__"):
+                        await maybe_awaitable
+                except Exception:  # noqa: BLE001 — teardown best-effort
+                    pass
+
+        # ── 5. Mark terminal with the produced render_job_id ───────
+        async with self.session_factory() as session:
+            repo = ProductScanJobRepository(session)
+            completed = await repo.complete_tracking(
+                job_id=child.id,
+                claimed_by=self.claimed_by,
+                cost_delta_usd=Decimal("0"),
+                render_job_id=result.render_job_id,
+            )
+            if completed is None:
+                logger.warning(
+                    "stt_runner_complete_lease_lost",
+                    extra={
+                        "child_id": str(child.id),
+                        "instance_id": self.instance_id,
+                        "render_job_id": str(result.render_job_id),
+                    },
+                )
+                return
+            await session.commit()
+        logger.info(
+            "stt_runner_processed_child",
+            extra={
+                "child_id": str(child.id),
+                "render_job_id": str(result.render_job_id),
+                "catalog_entry_id": str(chosen_catalog_id),
+                "shorts_index": child.shorts_index,
+                "mentioned_scene_count": result.mentioned_scene_count,
+                "matched_alias_count": len(result.matched_aliases),
+            },
+        )
+
+    async def _load_stt_inputs(
+        self,
+        *,
+        org_id: UUID,
+        catalog_entry_id: UUID,
+        drive_file_id: UUID,
+    ) -> tuple[str | None, str | None, list[str]]:
+        """Load (os_video_id, llm_label, spoken_aliases) for the STT
+        pipeline. Read-only, single session.
+
+        Returns ``(None, None, [])`` if either the catalog entry or
+        the drive_file row is missing — caller routes to
+        ``_complete_no_render`` rather than failing the child.
+        """
+        from sqlalchemy import select as _select
+
+        # Lazy local import to keep DriveFile out of the runner's
+        # module-level import graph until the STT path is taken.
+        from app.modules.drive.models import DriveFile
+
+        async with self.session_factory() as session:
+            catalog_repo = ProductCatalogRepository(session)
+            entry = await catalog_repo.get(
+                org_id=org_id, entry_id=catalog_entry_id,
+            )
+            if entry is None:
+                return None, None, []
+            drive_row = await session.execute(
+                _select(DriveFile).where(DriveFile.id == drive_file_id),
+            )
+            drive_file = drive_row.scalar_one_or_none()
+            if drive_file is None:
+                return None, None, []
+            return (
+                drive_file.video_id,
+                entry.llm_label,
+                list(entry.spoken_aliases or []),
+            )
+
+    def _build_os_client(self):
+        """Construct an AsyncOpenSearch client for one STT pipeline call.
+
+        Mirrors ``app/modules/search/client.py::get_opensearch_client``
+        (we don't import it because the loose-coupling rule forbids
+        cross-module imports; the duplication is ~14 lines of
+        configuration).
+        """
+        from opensearchpy import AsyncOpenSearch
+
+        url = getattr(self.settings, "opensearch_url", "http://localhost:9200")
+        is_https = url.startswith("https://")
+        return AsyncOpenSearch(
+            hosts=[url],
+            use_ssl=is_https,
+            verify_certs=is_https,
+            ssl_show_warn=False,
+            timeout=60,
+            max_retries=3,
+            retry_on_timeout=True,
+            pool_maxsize=20,
         )
 
     # ── helpers (private; tests patch via process_child_fn) ──────────

--- a/services/api/tests/test_shorts_auto_product_stt_runner_branch.py
+++ b/services/api/tests/test_shorts_auto_product_stt_runner_branch.py
@@ -1,0 +1,407 @@
+"""PR 2.5 — child runner STT-branch tests.
+
+Verifies the runner's track_mode='stt' branch:
+  * routes to ``_process_child_stt`` only when the flag is set
+  * passes the catalog entry's llm_label + spoken_aliases through
+  * maps each STT error class to the right terminal action
+  * builds the OS + OpenAI clients per-call and tears them down
+  * persists ``render_job_id`` on success
+
+Strategy mirrors ``test_shorts_auto_product_child_runner.py``: no
+real Postgres, no real OpenSearch, no real OpenAI. Repos are
+MagicMock'd; `assemble_stt_clip` is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.modules.shorts_auto_product.children.runner import ChildRunner
+from app.modules.shorts_auto_product.track_stt.errors import (
+    NoMentionsFoundError,
+    SttPipelineError,
+    TranscriptUnavailableError,
+)
+from app.modules.shorts_auto_product.track_stt.models import SttClipResult
+
+
+# ---------- helpers ----------
+
+
+def _settings_stub(*, track_mode: str = "stt"):
+    s = MagicMock()
+    s.auto_shorts_product_v2_child_runner_max_concurrency = 4
+    s.auto_shorts_product_v2_child_runner_poll_seconds = 0.05
+    s.auto_shorts_product_v2_child_lease_seconds = 300
+    s.auto_shorts_product_v2_child_runner_enabled = True
+    s.auto_shorts_product_v2_track_mode = track_mode
+    s.openai_api_key = "sk-test"
+    s.opensearch_url = "http://localhost:9200"
+    s.opensearch_index_prefix = "heimdex"
+    return s
+
+
+def _mock_session_factory():
+    @asynccontextmanager
+    async def factory():
+        session = MagicMock()
+        session.commit = AsyncMock()
+        yield session
+
+    return factory
+
+
+def _build_runner(*, settings=None):
+    return ChildRunner(
+        settings=settings or _settings_stub(),
+        session_factory=_mock_session_factory(),
+        scene_search_client=MagicMock(),
+        instance_id="test-replica",
+    )
+
+
+# ---------- routing tests ----------
+
+
+@pytest.mark.asyncio
+async def test_stt_branch_invoked_when_flag_set(monkeypatch):
+    """track_mode='stt' must route to _process_child_stt and bypass
+    the SAM2 path's _load_appearances_for_catalog call.
+    """
+    runner = _build_runner(settings=_settings_stub(track_mode="stt"))
+
+    # Spy on both branches.
+    stt_called = AsyncMock()
+    monkeypatch.setattr(runner, "_process_child_stt", stt_called)
+
+    # Make sure the SAM2 step would crash if it ran — it shouldn't.
+    sam2_loader = AsyncMock(side_effect=AssertionError("SAM2 path must not run"))
+    monkeypatch.setattr(runner, "_load_appearances_for_catalog", sam2_loader)
+
+    # Wire enough of the upstream to reach the branch.
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(),
+        video_id=uuid4(),
+        product_distribution=None,
+        length_seconds=60,
+        duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    catalog_id = uuid4()
+    catalog_label_lookup = {catalog_id: "Test product"}
+    monkeypatch.setattr(
+        runner, "_load_child_context",
+        AsyncMock(return_value=(child, parent, catalog_label_lookup)),
+    )
+
+    # Patch the repo class to return a fake that grants the claim.
+    import app.modules.shorts_auto_product.children.runner as runner_module
+    fake_repo = MagicMock()
+    fake_repo.claim = AsyncMock(return_value=MagicMock())
+    fake_repo.complete_tracking = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        runner_module, "ProductScanJobRepository",
+        MagicMock(return_value=fake_repo),
+    )
+    # Picker has to return a deterministic catalog id.
+    fake_picker = MagicMock()
+    fake_picker.pick_catalog = MagicMock(return_value=MagicMock(catalog_entry_id=catalog_id))
+    monkeypatch.setattr(
+        runner_module, "SingleProductSubsetPicker",
+        MagicMock(return_value=fake_picker),
+    )
+
+    await runner._process_child_payload(child.id)
+    stt_called.assert_awaited_once()
+    sam2_loader.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sam2_branch_unchanged_when_flag_default(monkeypatch):
+    """track_mode='sam2' (default) must NOT route to _process_child_stt.
+    Verifies PR 2.5 is purely additive when the flag is left alone.
+    """
+    runner = _build_runner(settings=_settings_stub(track_mode="sam2"))
+
+    stt_called = AsyncMock()
+    monkeypatch.setattr(runner, "_process_child_stt", stt_called)
+
+    # Stop the SAM2 path quickly — _load_appearances returns []
+    # which routes to _complete_no_render. We just need to confirm
+    # _process_child_stt is NOT called.
+    monkeypatch.setattr(
+        runner, "_load_appearances_for_catalog",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        runner, "_complete_no_render", AsyncMock(),
+    )
+
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(), video_id=uuid4(),
+        product_distribution=None, length_seconds=60,
+        duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    catalog_id = uuid4()
+    monkeypatch.setattr(
+        runner, "_load_child_context",
+        AsyncMock(return_value=(child, parent, {catalog_id: "X"})),
+    )
+
+    import app.modules.shorts_auto_product.children.runner as runner_module
+    fake_repo = MagicMock()
+    fake_repo.claim = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        runner_module, "ProductScanJobRepository",
+        MagicMock(return_value=fake_repo),
+    )
+    fake_picker = MagicMock()
+    fake_picker.pick_catalog = MagicMock(return_value=MagicMock(catalog_entry_id=catalog_id))
+    monkeypatch.setattr(
+        runner_module, "SingleProductSubsetPicker",
+        MagicMock(return_value=fake_picker),
+    )
+
+    await runner._process_child_payload(child.id)
+    stt_called.assert_not_awaited()
+
+
+# ---------- _process_child_stt happy path + error mapping ----------
+
+
+def _stub_load_stt_inputs(monkeypatch, runner, *, video_id="gd_x", llm_label="달심", aliases=("이 주스",)):
+    monkeypatch.setattr(
+        runner, "_load_stt_inputs",
+        AsyncMock(return_value=(video_id, llm_label, list(aliases))),
+    )
+
+
+def _stub_clients(monkeypatch, runner):
+    """Replace the per-call client constructors with no-op fakes so
+    we don't actually open network sockets in tests.
+    """
+    fake_os = AsyncMock()
+    fake_os.close = AsyncMock()
+    monkeypatch.setattr(runner, "_build_os_client", lambda: fake_os)
+
+    # AsyncOpenAI is constructed inline inside _process_child_stt via
+    # ``from openai import AsyncOpenAI``. Patch the class in the
+    # openai module's namespace.
+    import openai
+    fake_openai = MagicMock()
+    fake_openai.close = AsyncMock()
+    monkeypatch.setattr(openai, "AsyncOpenAI", MagicMock(return_value=fake_openai))
+
+
+@pytest.mark.asyncio
+async def test_stt_happy_path_persists_render_job_id(monkeypatch):
+    runner = _build_runner()
+
+    _stub_load_stt_inputs(monkeypatch, runner)
+    _stub_clients(monkeypatch, runner)
+
+    expected_render_id = uuid4()
+
+    async def _fake_assemble(**kwargs):
+        # Caller passes the closure — call it to verify the wiring.
+        assert kwargs["llm_label"] == "달심"
+        assert kwargs["spoken_aliases"] == ["이 주스"]
+        assert kwargs["os_video_id"] == "gd_x"
+        assert kwargs["target_duration_ms"] == 60_000
+        return SttClipResult(
+            render_job_id=expected_render_id,
+            selected_chunks=[],
+            mentioned_scene_count=5,
+            matched_aliases=["달심"],
+        )
+
+    import app.modules.shorts_auto_product.track_stt.service as stt_service
+    monkeypatch.setattr(stt_service, "assemble_stt_clip", _fake_assemble)
+
+    # Repo for the final complete_tracking call.
+    import app.modules.shorts_auto_product.children.runner as runner_module
+    fake_repo = MagicMock()
+    fake_repo.complete_tracking = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        runner_module, "ProductScanJobRepository",
+        MagicMock(return_value=fake_repo),
+    )
+
+    # _create_render_job is the closure target. Stub to return the
+    # expected id so the assemble_stt_clip mock can claim it.
+    monkeypatch.setattr(
+        runner, "_create_render_job",
+        AsyncMock(return_value=expected_render_id),
+    )
+
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(), video_id=uuid4(),
+        length_seconds=60, duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    catalog_id = uuid4()
+
+    await runner._process_child_stt(
+        child=child, parent=parent,
+        chosen_catalog_id=catalog_id,
+        catalog_label="my product",
+    )
+
+    # complete_tracking called with the render id from the pipeline.
+    fake_repo.complete_tracking.assert_awaited_once()
+    kwargs = fake_repo.complete_tracking.await_args.kwargs
+    assert kwargs["render_job_id"] == expected_render_id
+    assert kwargs["job_id"] == child.id
+
+
+@pytest.mark.asyncio
+async def test_stt_no_mentions_routes_to_complete_no_render(monkeypatch):
+    runner = _build_runner()
+    _stub_load_stt_inputs(monkeypatch, runner)
+    _stub_clients(monkeypatch, runner)
+
+    async def _raise_no_mentions(**kwargs):
+        raise NoMentionsFoundError("nothing matched")
+
+    import app.modules.shorts_auto_product.track_stt.service as stt_service
+    monkeypatch.setattr(stt_service, "assemble_stt_clip", _raise_no_mentions)
+
+    no_render_called = AsyncMock()
+    monkeypatch.setattr(runner, "_complete_no_render", no_render_called)
+    fail_called = AsyncMock()
+    monkeypatch.setattr(runner, "_mark_child_failed", fail_called)
+
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(), video_id=uuid4(),
+        length_seconds=60, duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    await runner._process_child_stt(
+        child=child, parent=parent,
+        chosen_catalog_id=uuid4(),
+        catalog_label="x",
+    )
+    no_render_called.assert_awaited_once()
+    assert no_render_called.await_args.kwargs["reason"] == "stt_no_mentions"
+    fail_called.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stt_transcript_unavailable_routes_to_complete_no_render(monkeypatch):
+    runner = _build_runner()
+    _stub_load_stt_inputs(monkeypatch, runner)
+    _stub_clients(monkeypatch, runner)
+
+    async def _raise(**kwargs):
+        raise TranscriptUnavailableError("no transcripts on this video")
+
+    import app.modules.shorts_auto_product.track_stt.service as stt_service
+    monkeypatch.setattr(stt_service, "assemble_stt_clip", _raise)
+
+    no_render_called = AsyncMock()
+    monkeypatch.setattr(runner, "_complete_no_render", no_render_called)
+
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(), video_id=uuid4(),
+        length_seconds=60, duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    await runner._process_child_stt(
+        child=child, parent=parent,
+        chosen_catalog_id=uuid4(),
+        catalog_label="x",
+    )
+    no_render_called.assert_awaited_once()
+    assert no_render_called.await_args.kwargs["reason"] == "stt_transcript_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_stt_pipeline_error_marks_child_failed(monkeypatch):
+    runner = _build_runner()
+    _stub_load_stt_inputs(monkeypatch, runner)
+    _stub_clients(monkeypatch, runner)
+
+    async def _raise(**kwargs):
+        raise SttPipelineError("os unreachable")
+
+    import app.modules.shorts_auto_product.track_stt.service as stt_service
+    monkeypatch.setattr(stt_service, "assemble_stt_clip", _raise)
+
+    no_render_called = AsyncMock()
+    monkeypatch.setattr(runner, "_complete_no_render", no_render_called)
+    fail_called = AsyncMock()
+    monkeypatch.setattr(runner, "_mark_child_failed", fail_called)
+
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(), video_id=uuid4(),
+        length_seconds=60, duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    await runner._process_child_stt(
+        child=child, parent=parent,
+        chosen_catalog_id=uuid4(),
+        catalog_label="x",
+    )
+    fail_called.assert_awaited_once()
+    no_render_called.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stt_inputs_missing_routes_to_complete_no_render(monkeypatch):
+    """If the catalog entry vanished between picker and load, OR the
+    drive_files row is missing, _process_child_stt must route to
+    _complete_no_render with reason='stt_inputs_missing' rather than
+    crashing or trying to call assemble_stt_clip.
+    """
+    runner = _build_runner()
+    monkeypatch.setattr(
+        runner, "_load_stt_inputs",
+        AsyncMock(return_value=(None, None, [])),
+    )
+    no_render_called = AsyncMock()
+    monkeypatch.setattr(runner, "_complete_no_render", no_render_called)
+
+    # If assemble_stt_clip is called with bad inputs the test fails.
+    import app.modules.shorts_auto_product.track_stt.service as stt_service
+    monkeypatch.setattr(
+        stt_service, "assemble_stt_clip",
+        AsyncMock(side_effect=AssertionError("must not be called when inputs missing")),
+    )
+
+    child = MagicMock(id=uuid4(), shorts_index=1)
+    parent = MagicMock(
+        org_id=uuid4(), video_id=uuid4(),
+        length_seconds=60, duration_preset_sec=None,
+        requested_by_user_id=uuid4(),
+    )
+    await runner._process_child_stt(
+        child=child, parent=parent,
+        chosen_catalog_id=uuid4(),
+        catalog_label="x",
+    )
+    no_render_called.assert_awaited_once()
+    assert no_render_called.await_args.kwargs["reason"] == "stt_inputs_missing"
+
+
+# ---------- _build_os_client smoke ----------
+
+
+def test_build_os_client_returns_async_opensearch(monkeypatch):
+    runner = _build_runner()
+    client = runner._build_os_client()
+    # Construction succeeded — the client object exists with the
+    # expected duck-typed interface.
+    assert hasattr(client, "search")


### PR DESCRIPTION
## Summary

PR 2.5 of the auto-shorts product mode v2 STT-pivot. Wires the `track_stt` pipeline (PR 2) into `children/runner.py` behind the `auto_shorts_product_v2_track_mode` flag. Default `"sam2"` — **zero behavior change in production** until staging validation manually flips the flag.

## What's wired

The runner branches right after step 3 (catalog pick): when `track_mode='stt'` it routes to `_process_child_stt` and returns; otherwise the existing SAM2 path runs unchanged.

Three new private methods on `ChildRunner`:

- `_process_child_stt` — replacement for SAM2 steps 4-6
- `_load_stt_inputs` — read-only fetch of `(os_video_id, llm_label, spoken_aliases)`
- `_build_os_client` — inline `AsyncOpenSearch` construction (loose-coupling)

Lazy imports for `track_stt.service`, `track_stt.errors`, `DriveFile`, and `openai.AsyncOpenAI` mean the SAM2 default path pays zero import cost.

## Error mapping

| STT error | Runner action | DB shape |
|---|---|---|
| `NoMentionsFoundError` | `_complete_no_render(reason='stt_no_mentions')` | `stage=done`, `render_job_id=None` |
| `TranscriptUnavailableError` | `_complete_no_render(reason='stt_transcript_unavailable')` | same |
| `SttPipelineError` | `_mark_child_failed` | `stage=failed` |
| Missing inputs (catalog vanished, drive_files row gone) | `_complete_no_render(reason='stt_inputs_missing')` | `stage=done`, `render_job_id=None` |

All "no render" paths reuse the existing SAM2 `no_appearances_for_catalog` DB shape. Wizard UI already surfaces this; PR 4 can refine messaging if needed.

## Loose-coupling audit

- `track_stt` lazy-imported inside `_process_child_stt` (not module-level)
- `DriveFile` lazy-imported inside `_load_stt_inputs`
- `AsyncOpenSearch` constructed inline (`_build_os_client`) — no cross-module import
- `ShortsRenderService` reused via the existing `_create_render_job` method (no new cross-module surface)

## Test plan

- [x] 8 new unit tests for the runner branch (routing both ways, happy path, all 4 error mappings, OS client smoke)
- [x] 11 existing runner tests still pass (no SAM2 regression)
- [x] Full CI allowlist green: 492/492 pass
- [x] CI allowlist updated to include the new test file
- [ ] Manual staging validation post-merge:
  - SSH staging, set `AUTO_SHORTS_PRODUCT_V2_TRACK_MODE=stt`, restart api
  - Run wizard end-to-end on `gd_05e7f957502e86cf` (9 catalog entries with aliases backfilled in PR 1b)
  - Hand-rate clips on the 3 calibration scenarios (high-recall, alias-required, expected-fallback)

## Plan reference

`.claude/plans/shorts-auto-product-stt-pivot.md` — see "PR 2.5 (runner wiring) shipped locally" for full details.

## Sequel

After PR 2.5 merges + manual staging validation:
- **PR 3**: calibration goldens + eval harness (formalizes the manual validation, lets prod rollout flip be data-driven)
- **PR 4**: frontend wizard refinements (friendly error messages keyed on the new `reason` codes, debug=1 alias-trace overlay)