### PR TITLE
fix(track_stt): clamp scene-crossing chunks to scene bounds

### DIFF
--- a/services/api/app/modules/shorts_auto_product/track_stt/composition_builder.py
+++ b/services/api/app/modules/shorts_auto_product/track_stt/composition_builder.py
@@ -76,24 +76,51 @@ def build_composition_spec(
     timeline_cursor_ms = 0
     clips: list[SceneClipSpec] = []
 
+    # Korean livecommerce scenes are 1-15s; chunks are fixed-width 20s
+    # by default. A chunk routinely spans multiple scenes. The render
+    # service requires each ``SceneClipSpec`` to be within the
+    # underlying source scene's bounds (see
+    # ``ShortsRenderService.create_render_job`` 422 path), so a
+    # scene-crossing chunk must split into N ``SceneClipSpec``s — one
+    # per overlapping scene, each clamped to that scene's bounds.
     for chunk in selected_chunks:
-        scene_id = _attach_scene_id(chunk=chunk, segments=segments)
-        chunk_duration_ms = chunk.end_ms - chunk.start_ms
-        clips.append(
-            SceneClipSpec(
-                scene_id=scene_id,
-                video_id=os_video_id,
-                source_type="gdrive",
-                start_ms=chunk.start_ms,
-                end_ms=chunk.end_ms,
-                timeline_start_ms=timeline_cursor_ms,
-                volume=1.0,
-                # crop / output defaults are fine for v1 — wizard
-                # output is always full-frame 9:16. Output spec is
-                # populated by CompositionSpec's default_factory.
-            )
+        sub_clips = _chunk_to_scene_clipped_subclips(
+            chunk=chunk, segments=segments,
         )
-        timeline_cursor_ms += chunk_duration_ms
+        if not sub_clips:
+            # Defensive: chunks come FROM segments, so every chunk
+            # should have ≥1 overlapping scene. If somehow not,
+            # skip rather than emit an invalid clip.
+            logger.warning(
+                "stt_composition_chunk_no_overlap_skipped",
+                extra={
+                    "chunk_start_ms": chunk.start_ms,
+                    "chunk_end_ms": chunk.end_ms,
+                },
+            )
+            continue
+        for scene_id, src_start_ms, src_end_ms in sub_clips:
+            sub_duration_ms = src_end_ms - src_start_ms
+            if sub_duration_ms <= 0:
+                continue
+            clips.append(
+                SceneClipSpec(
+                    scene_id=scene_id,
+                    video_id=os_video_id,
+                    source_type="gdrive",
+                    start_ms=src_start_ms,
+                    end_ms=src_end_ms,
+                    timeline_start_ms=timeline_cursor_ms,
+                    volume=1.0,
+                )
+            )
+            timeline_cursor_ms += sub_duration_ms
+
+    if not clips:
+        raise ValueError(
+            "build_composition_spec produced 0 clips from "
+            f"{len(selected_chunks)} chunks (no scene overlap?)"
+        )
 
     spec = CompositionSpec(scene_clips=clips, title=title)
     logger.info(
@@ -109,6 +136,49 @@ def build_composition_spec(
 
 
 # ---------- internals ----------
+
+
+def _chunk_to_scene_clipped_subclips(
+    *,
+    chunk: ScoredChunk,
+    segments: list[MentionSegment],
+) -> list[tuple[str, int, int]]:
+    """Split a chunk into 1+ scene-clamped sub-clips.
+
+    Each returned tuple is ``(scene_id, clamped_start_ms, clamped_end_ms)``
+    where the start/end are guaranteed to be within the corresponding
+    scene's actual bounds. Sub-clips are emitted in chronological
+    order (ascending ``clamped_start_ms``).
+
+    Pure function. No I/O. Trivially testable.
+
+    Why this exists: the render service rejects ``SceneClipSpec``s
+    whose start/end fall outside the underlying scene's time range
+    (``ShortsRenderService.create_render_job`` 422). My chunks are
+    fixed-width 20s windows that frequently span 2+ Korean
+    livecommerce scenes (1-15s each). Without this split, every
+    chunk that crosses a scene boundary 422s the whole render.
+    """
+    chunk_start_ms = chunk.start_ms
+    chunk_end_ms = chunk.end_ms
+    sub_clips: list[tuple[str, int, int]] = []
+
+    for segment in segments:
+        for scene in segment.scenes:
+            overlap_start = max(chunk_start_ms, scene.start_ms)
+            overlap_end = min(chunk_end_ms, scene.end_ms)
+            if overlap_end <= overlap_start:
+                continue
+            sub_clips.append(
+                (scene.scene_id, overlap_start, overlap_end),
+            )
+
+    # Multiple scenes can carry the same scene_id if the assembler
+    # ever merges duplicates (currently it doesn't, but be defensive).
+    # Sort by start time so the timeline cursor in the caller
+    # advances monotonically per chunk.
+    sub_clips.sort(key=lambda t: t[1])
+    return sub_clips
 
 
 def _attach_scene_id(

--- a/services/api/tests/test_shorts_auto_product_track_stt_pure.py
+++ b/services/api/tests/test_shorts_auto_product_track_stt_pure.py
@@ -230,11 +230,14 @@ class TestCompositionBuilder:
         assert spec.scene_clips[0].timeline_start_ms == 0
         assert spec.scene_clips[1].timeline_start_ms == 20_000
 
-    def test_chunk_attributed_to_max_overlap_scene(self):
-        # Chunk 5-25s; scene_a (0-15) overlaps 10s, scene_b (15-30)
-        # overlaps 10s — tie. The first match wins per implementation.
-        # We test the more discriminating case: chunk 5-25, scene_a 0-10
-        # (5s overlap), scene_b 10-30 (15s overlap) → scene_b wins.
+    def test_scene_crossing_chunk_splits_into_clamped_subclips(self):
+        """A 20s chunk that spans two scenes must produce 2
+        ``SceneClipSpec``s, each clamped to the underlying scene's
+        bounds. Without this split, the render service 422s
+        ``end_ms out of scene bounds`` because chunks (20s) routinely
+        span Korean livecommerce scenes (1-15s each).
+        """
+        # Chunk 5-25s; scene_a 0-10 (overlap 5-10), scene_b 10-30 (overlap 10-25)
         scene_a = _scene(0, 10_000, sid="A")
         scene_b = _scene(10_000, 30_000, sid="B")
         seg = MentionSegment(start_ms=0, end_ms=30_000, scenes=[scene_a, scene_b])
@@ -243,7 +246,50 @@ class TestCompositionBuilder:
             segments=[seg],
             os_video_id="gd_x",
         )
-        assert spec.scene_clips[0].scene_id == "B"
+        assert len(spec.scene_clips) == 2
+        # Sub-clip 1: scene A, clamped to overlap.
+        assert spec.scene_clips[0].scene_id == "A"
+        assert spec.scene_clips[0].start_ms == 5_000
+        assert spec.scene_clips[0].end_ms == 10_000
+        # Sub-clip 2: scene B, clamped to overlap. Timeline cursor
+        # advanced by sub-clip-1's duration (5s).
+        assert spec.scene_clips[1].scene_id == "B"
+        assert spec.scene_clips[1].start_ms == 10_000
+        assert spec.scene_clips[1].end_ms == 25_000
+        assert spec.scene_clips[1].timeline_start_ms == 5_000
+
+    def test_chunk_within_single_scene_produces_one_clip(self):
+        """When a chunk stays within a single scene's bounds, only
+        one sub-clip is emitted (no split)."""
+        scene = _scene(0, 30_000, sid="solo")
+        seg = MentionSegment(start_ms=0, end_ms=30_000, scenes=[scene])
+        spec = build_composition_spec(
+            selected_chunks=[_chunk(5_000, 25_000)],
+            segments=[seg],
+            os_video_id="gd_x",
+        )
+        assert len(spec.scene_clips) == 1
+        assert spec.scene_clips[0].scene_id == "solo"
+        assert spec.scene_clips[0].start_ms == 5_000
+        assert spec.scene_clips[0].end_ms == 25_000
+
+    def test_chunk_extending_past_scene_end_clamps_to_scene(self):
+        """Real failure mode from staging:
+        clip 1350000-1370000 vs scene 1350000-1365000.
+        Chunk extends past scene's end_ms — the sub-clip must be
+        clamped to the scene's actual end_ms."""
+        scene = _scene(1_350_000, 1_365_000, sid="short")
+        seg = MentionSegment(
+            start_ms=1_350_000, end_ms=1_400_000, scenes=[scene],
+        )
+        spec = build_composition_spec(
+            selected_chunks=[_chunk(1_350_000, 1_370_000)],
+            segments=[seg],
+            os_video_id="gd_x",
+        )
+        assert len(spec.scene_clips) == 1
+        # End clamped to scene's actual end (1_365_000), NOT chunk end.
+        assert spec.scene_clips[0].end_ms == 1_365_000
 
 
 # ---------- mention_extractor query construction ----------


### PR DESCRIPTION
Hot-fix. Render service rejects clips whose end_ms exceeds the source scene's end_ms. My 20s chunks span Korean livecommerce scenes (1-15s each), causing 422s on every clip. Fix splits chunks into per-scene sub-clips clamped to scene bounds.