### PR TITLE
fix(scan-order): lazy parent → committed transition on poll

### DIFF
--- a/services/api/app/modules/shorts_auto_product/repositories/job.py
+++ b/services/api/app/modules/shorts_auto_product/repositories/job.py
@@ -344,6 +344,55 @@ class ProductScanJobRepository:
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
 
+    async def transition_parent_to_committed_unclaimed(
+        self,
+        *,
+        job_id: UUID,
+    ) -> ProductScanJob | None:
+        """Transition a wizard scan_order parent from ``fanned_out`` →
+        ``committed`` (PR 2.6 sibling).
+
+        ``committed`` is the parent's terminal state once all children
+        have terminated (Phase 4 plan). This method is the
+        atomically-guarded transition. Caller MUST verify "all children
+        terminal" before invoking — this method does NOT re-check
+        because the children query happens outside the WHERE-clause
+        atomic guard anyway.
+
+        Guarded on ``stage = fanned_out`` AND
+        ``mode = SCAN_MODE_SCAN_ORDER`` so concurrent calls are
+        idempotent: only the first race-winner transitions; subsequent
+        calls return ``None`` and the caller treats that as
+        "already-committed, re-fetch".
+
+        ``completed_at`` is set on this transition since ``committed``
+        IS the workflow's terminal point — wizard polling sees a
+        non-null ``completed_at`` and stops polling.
+        """
+        from app.modules.shorts_auto_product.models import (
+            SCAN_MODE_SCAN_ORDER,
+            SCAN_STAGE_COMMITTED,
+            SCAN_STAGE_FANNED_OUT,
+        )
+
+        now = datetime.now(timezone.utc)
+        stmt = (
+            update(ProductScanJob)
+            .where(
+                ProductScanJob.id == job_id,
+                ProductScanJob.stage == SCAN_STAGE_FANNED_OUT,
+                ProductScanJob.mode == SCAN_MODE_SCAN_ORDER,
+            )
+            .values(
+                stage=SCAN_STAGE_COMMITTED,
+                progress_pct=100,
+                completed_at=now,
+                last_heartbeat_at=now,
+            )
+            .returning(ProductScanJob)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
     async def transition_parent_to_fanned_out_unclaimed(
         self,
         *,

--- a/services/api/app/modules/shorts_auto_product/service.py
+++ b/services/api/app/modules/shorts_auto_product/service.py
@@ -41,9 +41,11 @@ from app.modules.shorts_auto_product.models import (
     SCAN_STAGE_ENUMERATING,
     SCAN_STAGE_ENUMERATION_DONE,
     SCAN_STAGE_FAILED,
+    SCAN_STAGE_FANNED_OUT,
     SCAN_STAGE_QUEUED,
     SCAN_STAGE_RENDERING,
     SCAN_STAGE_TRACKING,
+    TERMINAL_SCAN_STAGES,
     ProductCatalogEntry,
     ProductScanJob,
 )
@@ -813,6 +815,38 @@ class ProductScanService:
                 detail="scan order not found",
             )
         parent, children = result
+
+        # Lazy parent → committed transition.
+        #
+        # In the SAM2 SQS flow the worker's terminal callback could
+        # carry the parent transition along; the STT inline path
+        # (PR 2.6) has no such callback — children terminate via the
+        # api-process runner and there is no follow-up that promotes
+        # the parent to ``committed``. Without this lazy check the
+        # parent stays at ``fanned_out`` forever and the wizard's
+        # polling subscription never sees a terminal state.
+        #
+        # Trigger conditions:
+        #   - parent.stage == fanned_out
+        #   - children list non-empty (defensive — should always be
+        #     so for fanned_out parents)
+        #   - every child stage is in TERMINAL_SCAN_STAGES
+        # Atomically guarded inside the repo method (only the first
+        # racing caller wins). On race-loss the caller falls through
+        # and the next poll sees the already-transitioned parent.
+        if (
+            parent.stage == SCAN_STAGE_FANNED_OUT
+            and children
+            and all(
+                c.stage in TERMINAL_SCAN_STAGES for c in children
+            )
+        ):
+            transitioned = await self.job_repo.transition_parent_to_committed_unclaimed(
+                job_id=parent.id,
+            )
+            if transitioned is not None:
+                parent = transitioned
+
         children_responses = [_job_to_status_response(c) for c in children]
         complete_count = sum(
             1 for c in children_responses if c.completed_at is not None


### PR DESCRIPTION
Wizard infinite-loop fix. Parent stays at `fanned_out` forever after all STT-mode children complete because no callback transitions it to `committed`. Fix: lazy on-poll transition in `get_scan_order_status` when all children are terminal.